### PR TITLE
compile on Mac OSX

### DIFF
--- a/src/storage/cpu_device_storage.h
+++ b/src/storage/cpu_device_storage.h
@@ -38,7 +38,13 @@ class CPUDeviceStorage {
 };  // class CPUDeviceStorage
 
 inline void* CPUDeviceStorage::Alloc(size_t size) {
+#ifdef __APPLE__
+  return CHECK_NOTNULL(malloc(size));
+#elif _MSC_VER
+  return CHECK_NOTNULL(_aligned_malloc(size, alignment_));
+#else
   return CHECK_NOTNULL(memalign(alignment_, size));
+#endif
 }
 
 inline void CPUDeviceStorage::Free(void* ptr) { free(ptr); }


### PR DESCRIPTION
There is no `memalign ` on Mac OSX. 

On OSX all calls to malloc/calloc/etc. are always 16 byte aligned, so just using `malloc` is OK here.

If we really need to use other alignment, like 32, `posix_memalign` should be used.

```
void * buf = NULL;
posix_memalign(&buf, alignment_, size);
return CHECK_NOTNULL(buf);
```