### PR TITLE
Add a new Policy in ThreadedEngine to do update per device

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - TASK=python CXX=g++
     - TASK=python3 CXX=g++
     - TASK=python_naive CXX=g++
+    - TASK=python_perdev CXX=g++
     - TASK=cpp_unittest CXX=g++
 
 # dependent apt packages

--- a/include/mxnet/engine.h
+++ b/include/mxnet/engine.h
@@ -33,8 +33,10 @@ typedef Opr* OprHandle;
 enum class FnProperty {
   /*! \brief Normal operation */
   kNormal,
-  /*! \brief Copy operation between CPU and GPU */
-  kCopy,
+  /*! \brief Copy operation from GPU to other devices */
+  kCopyFromGPU,
+  /*! \brief Copy operation from CPU to other devices */
+  kCopyToGPU,
   /*! \brief Asynchronous function call */
   kAsync
 };  // enum class FnProperty

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -40,7 +40,7 @@ if [ ${TASK} == "python3" ]; then
     make all || exit -1
     export MXNET_ENGINE_TYPE=ThreadedEngine
     nosetests tests/python/unittest || exit -1
-    nosetests tests/python/train || exit -1   
+    nosetests tests/python/train || exit -1
 fi
 
 if [ ${TASK} == "python_naive" ]; then
@@ -48,7 +48,15 @@ if [ ${TASK} == "python_naive" ]; then
     make all || exit -1
     export MXNET_ENGINE_TYPE=NaiveEngine
     nosetests tests/python/unittest || exit -1
-    nosetests tests/python/train || exit -1   
+    nosetests tests/python/train || exit -1
+fi
+
+if [ ${TASK} == "python_perdev" ]; then
+    echo "USE_CUDA=0" >> config.mk
+    make all || exit -1
+    export MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+    nosetests tests/python/unittest || exit -1
+    nosetests tests/python/train || exit -1
 fi
 
 if [ ${TASK} == "cpp_unittest" ]; then

--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -21,12 +21,12 @@ inline Engine* CreateEngine() {
     ret =  CreateNaiveEngine();
   } else if (stype == "ThreadedEngine") {
     ret = CreateThreadedEnginePooled();
-  } else if (stype == "ThreadedEnginePerDevie") {
+  } else if (stype == "ThreadedEnginePerDevice") {
     ret = CreateThreadedEnginePerDevice();
   }
 
   CHECK_NE(ret, nullptr)
-      << "Cannot find Eine " << type << " in registry";
+      << "Cannot find Engine " << type;
   if (!default_engine) {
     LOG(INFO) << "MXNet start using engine: " << type;
   }

--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -15,12 +15,16 @@ inline Engine* CreateEngine() {
   const bool default_engine = (type == nullptr);
   if (type == nullptr) type = "ThreadedEngine";
   std::string stype = type;
+
   Engine *ret = nullptr;
-  if (stype == "ThreadedEngine") {
-    ret = CreateThreadedEngine();
-  } else if (stype == "NaiveEngine") {
+  if (stype == "NaiveEngine") {
     ret =  CreateNaiveEngine();
+  } else if (stype == "ThreadedEngine") {
+    ret = CreateThreadedEnginePooled();
+  } else if (stype == "ThreadedEnginePerDevie") {
+    ret = CreateThreadedEnginePerDevice();
   }
+
   CHECK_NE(ret, nullptr)
       << "Cannot find Eine " << type << " in registry";
   if (!default_engine) {

--- a/src/engine/engine_impl.h
+++ b/src/engine/engine_impl.h
@@ -65,11 +65,16 @@ inline T* Opr::Cast() {
 #endif
 }
 
+/*! \brief Maximum number of GPUs */
+static constexpr std::size_t kMaxNumGPUs = 16;
+
 // predeclare factory function for each type of engine
 /*! \return NaiveEngine instance */
 Engine *CreateNaiveEngine();
-/*! \return ThreadedEngine instance */
-Engine *CreateThreadedEngine();
+/*! \return ThreadedEnginePooled instance */
+Engine *CreateThreadedEnginePooled();
+/*! \return ThreadedEnginePerDevie instance */
+Engine *CreateThreadedEnginePerDevice();
 }  // namespace engine
 }  // namespace mxnet
 #endif  // MXNET_ENGINE_ENGINE_IMPL_H_

--- a/src/engine/stream_manager.h
+++ b/src/engine/stream_manager.h
@@ -13,7 +13,6 @@
 #include "../common/cuda_utils.h"
 
 namespace mxnet {
-
 namespace engine {
 
 /*!
@@ -44,9 +43,9 @@ class StreamManager {
 template <std::size_t kNumGpus, std::size_t kStreams>
 RunContext StreamManager<kNumGpus, kStreams>::GetRunContext(
     Context const& ctx) {
+  RunContext ret;
   switch (ctx.dev_mask) {
-    case cpu::kDevMask:
-      return {nullptr};
+    case cpu::kDevMask: ret.stream = nullptr; break;
     case gpu::kDevMask: {
 #if MXNET_USE_CUDA
       std::size_t use_counter;
@@ -63,21 +62,22 @@ RunContext StreamManager<kNumGpus, kStreams>::GetRunContext(
         use_counter = counter;
         counter = (counter + 1) % kStreams;
       }
-      return {gpu_streams_.at(ctx.dev_id).at(use_counter)};
-#else  // MXNET_USE_CUDA
-      LOG(FATAL) << "Please compile with CUDA enabled";
+      ret.stream = gpu_streams_.at(ctx.dev_id).at(use_counter);
+      break;
+#else
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif  // MXNET_USE_CUDA
     }
   }
-  return {nullptr};
+  return ret;
 }
 
 template <std::size_t kNumGpus, std::size_t kStreams>
 RunContext StreamManager<kNumGpus, kStreams>::GetIORunContext(
     Context const& ctx) {
+  RunContext ret;
   switch (ctx.dev_mask) {
-    case cpu::kDevMask:
-      return {nullptr};
+    case cpu::kDevMask: ret.stream = nullptr; break;
     case gpu::kDevMask: {
 #if MXNET_USE_CUDA
       CUDA_CALL(cudaSetDevice(ctx.dev_id));
@@ -87,13 +87,14 @@ RunContext StreamManager<kNumGpus, kStreams>::GetIORunContext(
           gpu_io_streams_.at(ctx.dev_id) = mshadow::NewStream<gpu>(false, false);
         }
       }
-      return {gpu_io_streams_.at(ctx.dev_id)};
-#else  // MXNET_USE_CUDA
-      LOG(FATAL) << "Please compile with CUDA enabled";
+      ret.stream = gpu_io_streams_.at(ctx.dev_id);
+      break;
+#else
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif  // MXNET_USE_CUDA
     }
   }
-  return {nullptr};
+  return ret;
 }
 
 template <std::size_t kNumGpus, std::size_t kStreams>

--- a/src/engine/thread_pool.h
+++ b/src/engine/thread_pool.h
@@ -17,14 +17,14 @@ namespace engine {
 /*!
  * \brief Thread pool.
  */
-template <std::size_t kSize>
 class ThreadPool {
  public:
   /*!
-   * \brief Constructor takes function to run and its arguments.
+   * \brief Constructor takes function to run.
+   * \param size size of the thread pool.
+   * \param func the function to run on the thread pool.
    */
-  template <typename Function, typename... Args>
-  explicit ThreadPool(Function&& func, Args&&... args);
+  explicit ThreadPool(size_t size, std::function<void()> func);
   /*!
    * \brief Destructor.
    */
@@ -34,7 +34,7 @@ class ThreadPool {
   /*!
    * \brief Worker threads.
    */
-  std::array<std::thread, kSize> worker_threads_;
+  std::vector<std::thread> worker_threads_;
   /*!
    * \brief Disallow default construction.
    */
@@ -45,16 +45,14 @@ class ThreadPool {
   DISALLOW_COPY_AND_ASSIGN(ThreadPool);
 };
 
-template <std::size_t kSize>
-template <typename Function, typename... Args>
-ThreadPool<kSize>::ThreadPool(Function&& func, Args&&... args) {
-  for (auto&& i : worker_threads_) {
-    i = std::thread{std::forward<Function>(func), std::forward<Args>(args)...};
+ThreadPool::ThreadPool(size_t size, std::function<void()> func)
+    : worker_threads_(size) {
+  for (auto& i : worker_threads_) {
+    i = std::thread(func);
   }
 }
 
-template <std::size_t kSize>
-ThreadPool<kSize>::~ThreadPool() noexcept(false) {
+ThreadPool::~ThreadPool() noexcept(false) {
   for (auto&& i : worker_threads_) {
     i.join();
   }
@@ -62,5 +60,4 @@ ThreadPool<kSize>::~ThreadPool() noexcept(false) {
 
 }  // namespace engine
 }  // namespace mxnet
-
 #endif  // MXNET_ENGINE_THREAD_POOL_H_

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -1,0 +1,170 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file threaded_engine_perdevice.cc
+ * \brief ThreadedEngine that uses fix amount of thread for each device.
+ */
+#include <dmlc/base.h>
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <dmlc/concurrency.h>
+#include "./threaded_engine.h"
+#include "./thread_pool.h"
+#include "./stream_manager.h"
+
+namespace mxnet {
+namespace engine {
+/*!
+ * \brief ThreadedEngine uses per device threads.
+ * The policy of this Engine:
+ *  - Execute Async operation immediately if pushed from Pusher.
+ *  - Use fixed amount of threads for each device.
+ *  - Use special threads for copy operations.
+ *  - Each stream is allocated and binded to each of the thread.
+ */
+class ThreadedEnginePerDevice : public ThreadedEngine {
+ public:
+  ThreadedEnginePerDevice() noexcept(false) {
+    cpu_worker_nthreads_ = dmlc::GetEnv("MXNET_CPU_WORKER_NTHREADS", 2);
+    gpu_worker_nthreads_ = dmlc::GetEnv("MXNET_GPU_WORKER_NTHREADS", 2);
+    gpu_copy_nthreads_ = dmlc::GetEnv("MXNET_GPU_COPY_NTHREADS", 1);
+
+    // create CPU task
+    auto *cpu_queue = &(cpu_worker_.task_queue);
+    cpu_worker_.pool.reset(new ThreadPool(
+        cpu_worker_nthreads_, [this, cpu_queue] {
+          this->CPUWorker(cpu_queue);
+        }));
+    // GPU tasks will be created lazily
+  }
+  ~ThreadedEnginePerDevice() noexcept(false) {
+  }
+
+ protected:
+  void PushToExecute(OprBlock *opr_block, bool pusher_thread) override {
+    if (opr_block->opr->prop == FnProperty::kAsync && pusher_thread) {
+      CHECK_EQ(opr_block->ctx.dev_mask, cpu::kDevMask);
+      RunContext run_ctx;
+      run_ctx.stream = nullptr;
+      this->ExecuteOprBlock(run_ctx, opr_block);
+    } else {
+      const Context& ctx = opr_block->ctx;
+      if (ctx.dev_mask == cpu::kDevMask) {
+        cpu_worker_.task_queue.Push(opr_block);
+      } else {
+        CHECK_EQ(ctx.dev_mask, gpu::kDevMask);
+        ThreadWorkerBlock* block = this->GetGPUWorkerBlock(
+            ctx.dev_id, opr_block->opr->prop);
+        block->task_queue.Push(opr_block);
+      }
+    }
+  }
+
+ private:
+  // working unit for each of the task.
+  struct ThreadWorkerBlock {
+    // task queue on this task
+    dmlc::ConcurrentBlockingQueue<OprBlock*>  task_queue;
+    // thread pool that works on this task
+    std::unique_ptr<ThreadPool> pool;
+    // destructor
+    ~ThreadWorkerBlock() noexcept(false) {
+      task_queue.SignalForKill();
+    }
+  };
+  /*! \brief number of concurrent thread cpu worker uses */
+  int cpu_worker_nthreads_;
+  /*! \brief number of concurrent thread each gpu worker uses */
+  int gpu_worker_nthreads_;
+  /*! \brief number of concurrent thread each gpu copy worker uses */
+  int gpu_copy_nthreads_;
+  // mutex used when creating a ThreadWorkerBlock
+  std::mutex create_mutex_;
+  // cpu worker
+  ThreadWorkerBlock cpu_worker_;
+  // workers doing normal works on GPU
+  std::array<std::unique_ptr<ThreadWorkerBlock>, kMaxNumGPUs> gpu_normal_workers_;
+  // workers doing copy works from/to GPU
+  std::array<std::unique_ptr<ThreadWorkerBlock>, kMaxNumGPUs> gpu_copy_workers_;
+  /*!
+   * \brief get GPU Task Worker
+   * \param dev_id the device id
+   * \param prop The property of the function.
+   */
+  inline ThreadWorkerBlock *GetGPUWorkerBlock(size_t dev_id,
+                                              FnProperty prop) {
+    bool is_copy = (prop == FnProperty::kCopy);
+    CHECK_LT(dev_id, kMaxNumGPUs)
+        << "GPU Device index " << dev_id
+        << " exceed bound " << kMaxNumGPUs;
+    std::array<std::unique_ptr<ThreadWorkerBlock>, kMaxNumGPUs> *workers;
+    if (is_copy) {
+      workers = &gpu_copy_workers_;
+    } else {
+      workers = &gpu_normal_workers_;
+    }
+    ThreadWorkerBlock *block = workers->at(dev_id).get();
+    if (block != nullptr) return block;
+    {
+      // only lock when block is not available.
+      std::lock_guard<std::mutex> lock(create_mutex_);
+      // need to double check, because state can change
+      ThreadWorkerBlock *block = workers->at(dev_id).get();
+      if (block != nullptr) return block;
+      int nthread = is_copy ? gpu_copy_nthreads_ : gpu_worker_nthreads_;
+      workers->at(dev_id).reset(new ThreadWorkerBlock());
+      block = workers->at(dev_id).get();
+      block->pool.reset(new ThreadPool(nthread, [this, dev_id, is_copy, block] () {
+            this->GPUWorker(dev_id, is_copy, &(block->task_queue));
+          }));
+      return block;
+    }
+  }
+  /*!
+   * \brief GPU worker that performs operations on a certain device.
+   * \param dev_id The device id of the worker.
+   * \param is_copy_worker whether the worker only do copy job
+   * \param task_queue the device id of the worker.
+   */
+  inline void GPUWorker(int dev_id,
+                        bool is_copy_worker,
+                        dmlc::ConcurrentBlockingQueue<OprBlock*>* task_queue) {
+    #if MXNET_USE_CUDA
+    // allocate stream
+    mshadow::SetDevice(dev_id);
+    RunContext run_ctx;
+    mshadow::Stream<gpu> *stream;
+    if (is_copy_worker) {
+      stream = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0);
+    } else {
+      stream = mshadow::NewStream<gpu>(false, false);
+    }
+    run_ctx.stream = stream;
+    // execute task
+    OprBlock* opr_block;
+    while (task_queue->Pop(&opr_block)) {
+      this->ExecuteOprBlock(run_ctx, opr_block);
+    }
+    mshadow::DeleteStream<gpu>(stream);
+    #endif
+  }
+  /*!
+   * \brief CPU worker that performs operations on CPU.
+   * \param task_queue the device id of the worker.
+   */
+  inline void CPUWorker(dmlc::ConcurrentBlockingQueue<OprBlock*>* task_queue) {
+    RunContext run_ctx;
+    run_ctx.stream = nullptr;
+    // execute task
+    OprBlock* opr_block;
+    while (task_queue->Pop(&opr_block)) {
+      this->ExecuteOprBlock(run_ctx, opr_block);
+    }
+  }
+};
+
+Engine *CreateThreadedEnginePerDevice() {
+  return new ThreadedEnginePerDevice();
+}
+}  // namespace engine
+}  // namespace mxnet
+

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -7,6 +7,7 @@
 #include <dmlc/logging.h>
 #include <dmlc/parameter.h>
 #include <dmlc/concurrency.h>
+#include <array>
 #include "./threaded_engine.h"
 #include "./thread_pool.h"
 #include "./stream_manager.h"
@@ -92,7 +93,8 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
    */
   inline ThreadWorkerBlock *GetGPUWorkerBlock(size_t dev_id,
                                               FnProperty prop) {
-    bool is_copy = (prop == FnProperty::kCopy);
+    bool is_copy = (prop == FnProperty::kCopyFromGPU ||
+                    prop == FnProperty::kCopyToGPU);
     CHECK_LT(dev_id, kMaxNumGPUs)
         << "GPU Device index " << dev_id
         << " exceed bound " << kMaxNumGPUs;
@@ -130,7 +132,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
                         dmlc::ConcurrentBlockingQueue<OprBlock*>* task_queue) {
     #if MXNET_USE_CUDA
     // allocate stream
-    mshadow::SetDevice(dev_id);
+    mshadow::SetDevice<gpu>(dev_id);
     RunContext run_ctx;
     mshadow::Stream<gpu> *stream;
     if (is_copy_worker) {

--- a/src/engine/threaded_engine_pooled.cc
+++ b/src/engine/threaded_engine_pooled.cc
@@ -22,9 +22,9 @@ namespace engine {
  */
 class ThreadedEnginePooled : public ThreadedEngine {
  public:
-  ThreadedEnginePooled()
-      : thread_pool_{[this]() { ThreadWorker(&task_queue_); }},
-    io_thread_pool_{[this]() { ThreadWorker(&io_task_queue_); }} {}
+  ThreadedEnginePooled() :
+      thread_pool_(kNumWorkingThreads, [this]() { ThreadWorker(&task_queue_); }),
+      io_thread_pool_(1, [this]() { ThreadWorker(&io_task_queue_); }) {}
 
   ~ThreadedEnginePooled() noexcept(false) {
     task_queue_.SignalForKill();
@@ -59,8 +59,8 @@ class ThreadedEnginePooled : public ThreadedEngine {
   /*!
    * \brief Thread pools.
    */
-  ThreadPool<kNumWorkingThreads>  thread_pool_;
-  ThreadPool<1> io_thread_pool_;
+  ThreadPool thread_pool_;
+  ThreadPool io_thread_pool_;
   /*!
    * \brief Worker.
    * \param task_queue Queue to work on.
@@ -109,7 +109,7 @@ class ThreadedEnginePooled : public ThreadedEngine {
   }
 };
 
-Engine *CreateThreadedEngine() {
+Engine *CreateThreadedEnginePooled() {
   return new ThreadedEnginePooled();
 }
 }  // namespace engine

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -169,7 +169,7 @@ void CopyFromTo(const NDArray &from, NDArray *to) {
         ret.ptr_->CheckAndAlloc();
         TBlob tmp = ret.data();
         ndarray::Copy<cpu, cpu>(from.data(), &tmp,
-                               from.ctx(), ret.ctx(), ctx);
+                                from.ctx(), ret.ctx(), ctx);
       }, from.ctx(), const_vars, {ret.ptr_->var});
   } else {
 #if MXNET_USE_CUDA
@@ -178,28 +178,28 @@ void CopyFromTo(const NDArray &from, NDArray *to) {
           ret.ptr_->CheckAndAlloc();
           TBlob tmp = ret.data();
           ndarray::Copy<cpu, gpu>(from.data(), &tmp,
-                                 from.ctx(), ret.ctx(), ctx);
+                                  from.ctx(), ret.ctx(), ctx);
           // Wait GPU kernel to complete
           ctx.get_stream<gpu>()->Wait();
-        }, ret.ctx(), const_vars, {ret.ptr_->var});
+        }, ret.ctx(), const_vars, {ret.ptr_->var}, FnProperty::kCopyToGPU);
     } else if (a == gpu::kDevMask && b == cpu::kDevMask) {
       Engine::Get()->PushSync([from, ret](RunContext ctx) {
           ret.ptr_->CheckAndAlloc();
           TBlob tmp = ret.data();
           ndarray::Copy<gpu, cpu>(from.data(), &tmp,
-                                 from.ctx(), ret.ctx(), ctx);
+                                  from.ctx(), ret.ctx(), ctx);
           // Wait GPU kernel to complete
           ctx.get_stream<gpu>()->Wait();
-        }, from.ctx(), const_vars, {ret.ptr_->var});
+        }, from.ctx(), const_vars, {ret.ptr_->var}, FnProperty::kCopyFromGPU);
     } else if (a == gpu::kDevMask && b == gpu::kDevMask) {
       Engine::Get()->PushSync([from, ret](RunContext ctx) {
           ret.ptr_->CheckAndAlloc();
           TBlob tmp = ret.data();
           ndarray::Copy<gpu, gpu>(from.data(), &tmp,
-                                 from.ctx(), ret.ctx(), ctx);
+                                  from.ctx(), ret.ctx(), ctx);
           // Wait GPU kernel to complete
           ctx.get_stream<gpu>()->Wait();
-        }, from.ctx(), const_vars, {ret.ptr_->var});
+        }, from.ctx(), const_vars, {ret.ptr_->var}, FnProperty::kCopyFromGPU);
     } else {
       LOG(FATAL) << "unknown device mask";
     }

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -205,9 +205,6 @@ GraphExecutor::GetOpExecEntry(uint32_t nid) {
     }
   }
 
-  for (const Resource& r : op_node.op_ctx.requested) {
-    exec.mutate_vars.push_back(static_cast<DAGEngine::Variable>(r.var));
-  }
   // start setup exec function.
   for (const Resource& r : op_node.op_ctx.requested) {
     exec.mutate_vars.push_back(static_cast<Engine::VarHandle>(r.var));

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -205,6 +205,9 @@ GraphExecutor::GetOpExecEntry(uint32_t nid) {
     }
   }
 
+  for (const Resource& r : op_node.op_ctx.requested) {
+    exec.mutate_vars.push_back(static_cast<DAGEngine::Variable>(r.var));
+  }
   // start setup exec function.
   for (const Resource& r : op_node.op_ctx.requested) {
     exec.mutate_vars.push_back(static_cast<Engine::VarHandle>(r.var));

--- a/tests/cpp/threaded_engine_unittest.cc
+++ b/tests/cpp/threaded_engine_unittest.cc
@@ -72,7 +72,7 @@ TEST(Engine, basics) {
         Foo(ctx, 42);
         cb();
       },
-      {}, {var}, mxnet::FnProperty::kCopy));
+      {}, {var}, mxnet::FnProperty::kCopyFromGPU));
   engine->Push(oprs.at(0), mxnet::Context{});
   LOG(INFO) << "IO operator pushed, should wait for 2 seconds.";
   engine->WaitForVar(var);


### PR DESCRIPTION
- Add a new policy in ThreadedEngine to do update per device
- Use a weaker threadpool that takes no args, but allows specify number of workers at run-time
- Update FnProperty to include copy cases.