### PR TITLE
OSX Travis Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,8 @@ Debug
 .dir-locals.el
 __pycache__
 *.pkl
-
+*.params
+*.json
 *.d
 build
 dmlc-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # disable sudo to use container based build
 sudo: false
+# Enabling test on Linux and OS X
+os:
+  - linux
 
 # Use Build Matrix to do lint and build seperately
 env:
@@ -48,12 +51,10 @@ before_install:
 
 install:
   - pip install cpplint pylint --user `whoami`
-  - make -f dmlc-core/scripts/packages.mk gtest
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+
 
 script:
   - scripts/travis_script.sh
-
 
 
 before_cache:

--- a/scripts/travis_osx_install.sh
+++ b/scripts/travis_osx_install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+brew update
+brew tap homebrew/science
+brew info opencv
+brew install graphviz
+brew install opencv
+
+if [ ${TASK} == "python-package3" ]; then
+    wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+else
+    wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh
+fi
+
+
+bash conda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+# Useful for debugging any issues with conda
+conda info -a
+
+if [ ${TASK} == "python-package3" ]; then
+    conda create -n myenv python=3.4
+    alias python3=python
+else
+    conda create -n myenv python=2.7
+fi
+source activate myenv
+conda install numpy scipy matplotlib nose
+python -m pip install graphviz

--- a/src/io/iter_image_recordio.cc
+++ b/src/io/iter_image_recordio.cc
@@ -406,7 +406,7 @@ class ImageRecordIter : public IIterator<DataInst> {
       elapsed = (uint64_t)(time(NULL) - start);
       if (imcnt % 1000 == 0 && param_.silent == 0) {
         printf("\r                                                               \r");
-        printf("[%8lu] images processed, %ld sec elapsed", imcnt, elapsed);
+        printf("[%8lu] images processed, %ld sec elapsed", imcnt, (long)elapsed);  // NOLINT(*)
         fflush(stdout);
       }
     }

--- a/src/operator/elementwise_binary_op-inl.h
+++ b/src/operator/elementwise_binary_op-inl.h
@@ -165,7 +165,7 @@ class ElementWiseBinaryOpProp : public OperatorProperty {
         << TypeString() << " do not take any additional keyword arguments besides lhs and rhs";
   }
   std::map<std::string, std::string> GetParams() const override {
-    return {};
+    return std::map<std::string, std::string>();
   }
 
   bool InferShape(std::vector<TShape> *in_shape,

--- a/src/operator/reshape-inl.h
+++ b/src/operator/reshape-inl.h
@@ -152,7 +152,8 @@ class FlattenProp : public ReshapeProp {
   void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {}
 
   std::map<std::string, std::string> GetParams() const override {
-    return {};
+    // need to use this on osx
+    return std::map<std::string, std::string>();
   }
 
   std::string TypeString() const override {

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -39,7 +39,6 @@ def test_symbol_internal():
                               'fc1_weight', 'fc1_bias',
                               'fc2_weight', 'fc2_bias']
     internal =  net1.get_internals()
-    print internal.list_outputs()
     fc1 = internal['fc1_output']
     assert fc1.list_arguments() == oldfc.list_arguments()
 
@@ -56,7 +55,6 @@ def test_symbol_saveload():
     sym = models.mlp2()
     fname = 'tmp_sym.json'
     sym.save(fname)
-    print sym.tojson()
     data2 = mx.symbol.load(fname)
     # save because of order
     assert sym.tojson() == data2.tojson()


### PR DESCRIPTION
- The script is updated to support osx builds.
- The OSX option is not enabled because the python package have platform dependent issues that need to be resolved, likely to be string encoding or ctypes issue. 

