### PR TITLE
fix typo causing unary ndarray function being defined with fallback generic functions

### DIFF
--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -601,7 +601,7 @@ def _make_ndarray_function(handle):
             out = NDArray(_new_empty_handle())
         check_call(_LIB.MXFuncInvoke( \
                 handle, \
-                c_array(NDArrayHandle, (src.handle)), \
+                c_array(NDArrayHandle, (src.handle,)), \
                 c_array(mx_float, ()), \
                 c_array(NDArrayHandle, (out.handle,))))
         return out

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -645,7 +645,7 @@ def _make_ndarray_function(handle):
     # End of function declaration
     if n_mutate_vars == 1 and n_used_vars == 2 and n_scalars == 0:
         ret_function = binary_ndarray_function
-    elif n_mutate_vars == 1 and n_used_vars == 2 and n_scalars == 0:
+    elif n_mutate_vars == 1 and n_used_vars == 1 and n_scalars == 0:
         ret_function = unary_ndarray_function
     else:
         ret_function = generic_ndarray_function


### PR DESCRIPTION
For example, currently `_copyto` is defined using the generic function generator instead of unary function generator.