### PR TITLE
refactor kvstore on model.py

### DIFF
--- a/doc/developer-guide/multi_node.md
+++ b/doc/developer-guide/multi_node.md
@@ -18,20 +18,16 @@ MXNet uses a two-level *parameter server* for data synchronization.
 ## KVStore
 
 MXNet implemented the two-level parameter server in class *KVStore*. We
-currently provide the following types:
+currently provide the following three types. Given the batch size *b*:
 
-| kvstore type | multi-devices | multi-workers | #ex per device | #ex per update | max delay |
+| kvstore type | #devices | #workers | #ex per device | #ex per update | max delay |
 | :--- | --- | --- | --- | --- | --- |
-| `none` |  no | no | *b* | *b* | *0* |
-| `local` | yes | no | *b / k* | *b* | *0* |
-| `dist_sync` | yes | yes | *b / k* | *b × n* | *0* |
-| `dist_async` | yes | yes |  *b / k* | *b* | inf |
+| `local` | *k* | 1 | *b / k* | *b* | *0* |
+| `dist_sync` | *k* | *n* | *b / k* | *b × n* | *0* |
+| `dist_async` | *k* | *n* |  *b / k* | *b* | inf |
 
-where
-
-- **n** : the number of workers (often mean machines)
-- **k** : the number of devices used on a worker (could vary for different workers)
-- **b** : the batch size set by users
+where the number of devices *k* used on a worker could vary for different
+workers. And
 
 - **number examples per update** : for each update, the number of examples used to
   calculate the averaged gradients. Often the larger, the slower the convergence.

--- a/doc/developer-guide/multi_node.md
+++ b/doc/developer-guide/multi_node.md
@@ -24,46 +24,58 @@ A device could be a GPU card, CPU, or other computational units.
 | kvstore type | multi-devices | multi-workers | #ex per device | #ex per update | max delay |
 | :--- | --- | --- | --- | --- | --- |
 | `none` |  no | no | *b* | *b* | *0* |
-| `local` / `device` | yes | no | *b / k* | *b* | *0* |
+| `local` | yes | no | *b / k* | *b* | *0* |
 | `dist_sync` | yes | yes | *b / k* | *b × n* | *0* |
 | `dist_async` | yes | yes |  *b / k* | *b* | inf |
 
 
 ## Multiple devices on a single machine
 
-Both `local` and `device` can handle the situation that a single machine with
-multiple devices. They give the some results (model accuracy) as the single
-device case. But comparing to the latter, each device only processes *1 / k*
-examples each time (also consumes *1 / k* device memory), so we often increase
-the batch size *b* for better system performance.
+KV store `local` synchronizes data over multiple devices on a single machine.
+It gives the same results (e.g. model accuracy) as the single device case. But
+comparing to the latter, assume there are *k* devices, then each device only
+processes *1 / k* examples each time (also consumes *1 / k* device memory). We
+often increase the batch size *b* for better system performance.
 
-We can further fine tune the system performance by specifying where to average
-the gradients over all devices, and where to update the weight:
+When using `local`, the system will automatically chooses one of the following
+three types. Their differences are on where to average
+the gradients over all devices, and where to update the weight.
 
-| case | kvstore type | update on kvstore | average gradient | perform update |
-| :--- | :--- | :--- | --- | --- | --- |
-| 1 | 'local' | yes | CPU | CPU |
-| 2 | 'local' | no | CPU | all devices |
-| 3 | 'device | yes | a device | all devices |
 
-- On case 1, gradients are first copied to main memory, next averaged on CPU,
+They produce
+(almost) the same results, but may vary on speed.
+
+share the
+same semantic
+
+They are semantically identical, but their speemay have different
+speeds
+We can further fine tune the system performance by specifying :
+
+| kvstore type | average gradient | perform update |
+| :--- | :--- | --- |
+| `local_update_cpu` | CPU | CPU |
+| `local_allreduce_cpu` | CPU | all devices |
+| `local_allreduce_device` | a device | all devices |
+
+- `local_update_cpu`, gradients are first copied to main memory, next averaged on CPU,
   and then update the weight on CPU. It is suitable when the average size of
   weights are not large and there are a large number of weight. For example the
   google Inception network.
 
-- Case 2 is similar to 1 except that the averaged gradients are copied back to
-  the devices, and then weights are updated on devices. It is faster than 1 when
-  the weight size is large so we can use the device to accelerate the computation
-  (but we increase the workload by *k* times). Examples are AlexNet on
-  imagenet.
+- `local_allreduce_cpu` is similar to `local_update_cpu` except that the
+  averaged gradients are copied back to the devices, and then weights are
+  updated on devices. It is faster than 1 when the weight size is large so we
+  can use the device to accelerate the computation (but we increase the workload
+  by *k* times). Examples are AlexNet on imagenet.
 
-- Case 3 is similar to 1 except that the gradient are averaged on a chosen
-  device. It may take advantage of the possible device-to-device communication, and may
-  accelerate the averaging step. It is faster than 2 when the gradients are
-  huge. But it requires more device memory.
+- `local_allreduce_device` is similar to `local_allreduce_cpu` except that the
+  gradient are averaged on a chosen device. It may take advantage of the
+  possible device-to-device communication, and may accelerate the averaging
+  step. It is faster than 2 when the gradients are huge. But it requires more
+  device memory.
 
 ## Multiple machines
-
 
 Both `dist_async` and `dist_sync` can handle the multiple machines
 situation. But they are different on both semantic and performance.

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -21,23 +21,60 @@ A device could be a GPU card, CPU, or other computational units.
   convergence.
 
 
-| kvstore type | multi devices | multi workers | #ex per device | #ex per update | max delay |
-| :--- | :--- | ---:| ---:| ---:| ---:| ---:| ---:|
+| kvstore type | multi-devices | multi-workers | #ex per device | #ex per update | max delay |
+| :--- | --- | --- | --- | --- | --- |
 | `none` |  no | no | *b* | *b* | *0* |
 | `local` / `device` | yes | no | *b / k* | *b* | *0* |
-| `dist_async` | yes | yes | yes |  *b / k* | *b* | *n*
-| `dist_sync` | no | yes | yes | *b / k* | *b × n* | *0*
+| `dist_sync` | yes | yes | *b / k* | *b × n* | *0* |
+| `dist_async` | yes | yes |  *b / k* | *b* | inf |
 
 
+## Multiple devices on a single machine
+
+Both `local` and `device` can handle the situation that a single machine with
+multiple devices. They give the some results (model accuracy) as the single
+device case. But comparing to the latter, each device only processes *1 / k*
+examples each time (also consumes *1 / k* device memory), so we often increase
+the batch size *b* for better system performance.
+
+We can further fine tune the system performance by specifying where to average
+the gradients over all devices, and where to update the weight:
+
+| case | kvstore type | update on kvstore | average gradient | perform update |
+| :--- | :--- | :--- | --- | --- | --- |
+| 1 | 'local' | yes | CPU | CPU |
+| 2 | 'local' | no | CPU | all devices |
+| 3 | 'device | yes | a device | all devices |
+
+- On case 1, gradients are first copied to main memory, next averaged on CPU,
+  and then update the weight on CPU. It is suitable when the average size of
+  weights are not large and there are a large number of weight. For example the
+  google Inception network.
+
+- Case 2 is similar to 1 except that the averaged gradients are copied back to
+  the devices, and then weights are updated on devices. It is faster than 1 when
+  the weight size is large so we can use the device to accelerate the computation
+  (but we increase the workload by *k* times). Examples are AlexNet on
+  imagenet.
+
+- Case 3 is similar to 1 except that the gradient are averaged on a chosen
+  device. It may take advantage of the possible device-to-device communication, and may
+  accelerate the averaging step. It is faster than 2 when the gradients are
+  huge. But it requires more device memory.
+
+## Multiple machines
 
 
-- **2-4** for single machine with multiple devices. They are identical for
-  convergence, but may vary on performance.
-  -
- dev<sub>0</sub> on worker<sub>0</sub> |
+Both `dist_async` and `dist_sync` can handle the multiple machines
+situation. But they are different on both semantic and performance.
 
-  cpu on worker<sub>0</sub> |
-  devs on worker<sub>0</sub> |
-  devs on worker<sub>0</sub> |
- | servers |
-  | cpus on workers |
+- `dist_sync`: the gradients are first averaged on the servers, and then send to
+  back to workers for updating the weight. It is similar to `local` and
+  `update_on_kvstore=false` if we treat a machine as a device.  It guarantees
+  almost identical convergence with the single machine single device situation
+  if reduces the batch size to *b / n*. However, it requires synchronization
+  between all workers, and therefore may harm the system performance.
+
+- `dist_async`: the gradient is sent to the servers, and the weight is updated
+  there. The weights a worker has may be stale.
+  (TODO) make the max delay be settable?

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -6,26 +6,38 @@ A device could be a GPU card, CPU, or other computational units.
 
 <img src=https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/multi-node/ps_arch.png width=400/>
 
-- *b*: the batch size set by users
-- *k*: the number of devices used on a worker (could vary for different workers)
-- *n*: the number of workers (often mean machines)
+- **n** : the number of workers (often mean machines)
+- **k** : the number of devices used on a worker (could vary for different workers)
+- **b** : the batch size set by users
 
-- *number examples per update*: for each update, the number of examples used to
+- **number examples per update** : for each update, the number of examples used to
   calculate the averaged gradients. Often the larger, the slower the convergence.
-- *number examples per device*: the number of examples batched to one device
+- **number examples per device** : the number of examples batched to one device
   each time. Often the larger, the better the performance.
-- *max delay*: The maximal delay of the weight a worker can get. Given a worker,
+- **max delay** : The maximal delay of the weight a worker can get. Given a worker,
   a delay *d* for weight *w* means when this worker uses *w* (to calculate the
   gradient), *w* have been already updated by *d* times on some other places. A
   larger delay often improves the performance, but may slows down the
   convergence.
 
 
-| kvstore type | update on kvstore | multi devices | multi workers | #ex per device | #ex per update | max delay | update place |
+| kvstore type | multi devices | multi workers | #ex per device | #ex per update | max delay |
 | :--- | :--- | ---:| ---:| ---:| ---:| ---:| ---:|
-| none | no | no | no | *b* | *b* | *0* | dev<sub>0</sub> on worker<sub>0</sub> |
-| local | yes | yes | no | *b / k* | *b* | *0* | cpu on worker<sub>0</sub> |
-| local | no | yes | no  | *b/k* | *b* | *0* | devs on worker<sub>0</sub> |
-| device | no | yes | no | *b/k* |*b* | *0* | devs on worker<sub>0</sub> |
-| dist | yes | yes | no | yes | *b/k* |*b* | *n* | servers |
-| dist | no | yes | no | *b/k* | *b × n* | *0* | cpus on workers |
+| `none` |  no | no | *b* | *b* | *0* |
+| `local` / `device` | yes | no | *b / k* | *b* | *0* |
+| `dist_async` | yes | yes | yes |  *b / k* | *b* | *n*
+| `dist_sync` | no | yes | yes | *b / k* | *b × n* | *0*
+
+
+
+
+- **2-4** for single machine with multiple devices. They are identical for
+  convergence, but may vary on performance.
+  -
+ dev<sub>0</sub> on worker<sub>0</sub> |
+
+  cpu on worker<sub>0</sub> |
+  devs on worker<sub>0</sub> |
+  devs on worker<sub>0</sub> |
+ | servers |
+  | cpus on workers |

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -2,13 +2,13 @@
 
 Architecture
 
-<img src=https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/multi-node/ps_arch.png width=800/>
+<img src=https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/multi-node/ps_arch.png width=400/>
 
 | kvstore type | update on kvstore | multi-devices | multi-workers | #ex per update | max delay | update place |
 | :--- | :--- | ---:| ---:| ---:| ---:| ---:|
-| none | no | no | no | *b* | *0* | worker<sub>0<\sub>'s dev<sub>0<\sub> |
-| local | yes | yes | no | *b* | *0* | worker<sub>0<\sub>'s cpu |
-| local | no | yes | no | *b* | *0* | worker<sub>0<\sub>'s devs |
-| device | no | yes | no | *b* | *0* | worker<sub>0<\sub>'s devs |
+| none | no | no | no | *b* | *0* | worker<sub>0</sub>'s dev<sub>0<\sub> |
+| local | yes | yes | no | *b* | *0* | worker<sub>0</sub>'s cpu |
+| local | no | yes | no | *b* | *0* | worker<sub>0</sub>'s devs |
+| device | no | yes | no | *b* | *0* | worker<sub>0</sub>'s devs |
 | dist | yes | yes | yes | *b* | *n* | servers |
 | dist | no | yes | yes | *b × n* | *0* | workers' cpu |

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -1,12 +1,14 @@
 # Multi-devices and multi-machines
 
-![ps arch](https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/multi-node/ps_arch.png)
+Architecture
 
-| kvstore type | updt on kvstore | multi-devs | multi-workers | #ex per updt | max delay | updt place |
+<img src=https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/multi-node/ps_arch.png width=800/>
+
+| kvstore type | update on kvstore | multi-devices | multi-workers | #ex per update | max delay | update place |
 | :--- | :--- | ---:| ---:| ---:| ---:| ---:|
-| none | no | no | no | *b* | *0* | worker\_0's dev\_0 |
-| local | yes | yes | no | *b* | *0* | worker_0's cpu |
-| local | no | yes | no | *b* | *0* | worker\_0's devs |
-| device | no | yes | no | *b* | *0* | worker\_0's devs |
+| none | no | no | no | *b* | *0* | worker<sub>0<\sub>'s dev<sub>0<\sub> |
+| local | yes | yes | no | *b* | *0* | worker<sub>0<\sub>'s cpu |
+| local | no | yes | no | *b* | *0* | worker<sub>0<\sub>'s devs |
+| device | no | yes | no | *b* | *0* | worker<sub>0<\sub>'s devs |
 | dist | yes | yes | yes | *b* | *n* | servers |
 | dist | no | yes | yes | *b × n* | *0* | workers' cpu |

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -21,11 +21,11 @@ A device could be a GPU card, CPU, or other computational units.
   convergence.
 
 
-| kvstore type | update on kvstore | multiple? | #ex per dev | #ex per update | max delay | update place |
+| kvstore type | update on kvstore | multi devices | multi workers | #ex per device | #ex per update | max delay | update place |
 | :--- | :--- | ---:| ---:| ---:| ---:| ---:|
-| none | no | no | *b* | *b* | *0* | dev<sub>0</sub> on worker<sub>0</sub> |
-| local | yes | devs| *b/k* | *b* | *0* | cpu on worker<sub>0</sub> |
-| local | no | devs  | *b/k* | *b* | *0* | devs on worker<sub>0</sub> |
-| device | no | devs | *b/k* |*b* | *0* | devs on worker<sub>0</sub> |
-| dist | yes | devs + workers | yes | *b/k* |*b* | *n* | servers |
-| dist | no | devs + workers | *b/k* | *b × n* | *0* | cpus on workers |
+| none | no | no | no | *b* | *b* | *0* | dev<sub>0</sub> on worker<sub>0</sub> |
+| local | yes | yes | no | *b / k* | *b* | *0* | cpu on worker<sub>0</sub> |
+| local | no | yes | no  | *b/k* | *b* | *0* | devs on worker<sub>0</sub> |
+| device | no | yes | no | *b/k* |*b* | *0* | devs on worker<sub>0</sub> |
+| dist | yes | yes | no | yes | *b/k* |*b* | *n* | servers |
+| dist | no | yes | no | *b/k* | *b × n* | *0* | cpus on workers |

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -22,7 +22,7 @@ A device could be a GPU card, CPU, or other computational units.
 
 
 | kvstore type | update on kvstore | multi devices | multi workers | #ex per device | #ex per update | max delay | update place |
-| :--- | :--- | ---:| ---:| ---:| ---:| ---:|
+| :--- | :--- | ---:| ---:| ---:| ---:| ---:| ---:|
 | none | no | no | no | *b* | *b* | *0* | dev<sub>0</sub> on worker<sub>0</sub> |
 | local | yes | yes | no | *b / k* | *b* | *0* | cpu on worker<sub>0</sub> |
 | local | no | yes | no  | *b/k* | *b* | *0* | devs on worker<sub>0</sub> |

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -1,0 +1,12 @@
+# Multi-devices and multi-machines
+
+![ps arch](https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/multi-node/ps_arch.png)
+
+| kvstore type | updt on kvstore | multi-devs | multi-workers | #ex per updt | max delay | updt place |
+| :--- | :--- | ---:| ---:| ---:| ---:| ---:|
+| none | no | no | no | *b* | *0* | worker\_0's dev\_0 |
+| local | yes | yes | no | *b* | *0* | worker_0's cpu |
+| local | no | yes | no | *b* | *0* | worker\_0's devs |
+| device | no | yes | no | *b* | *0* | worker\_0's devs |
+| dist | yes | yes | yes | *b* | *n* | servers |
+| dist | no | yes | yes | *b × n* | *0* | workers' cpu |

--- a/doc/multi_node.md
+++ b/doc/multi_node.md
@@ -1,14 +1,31 @@
 # Multi-devices and multi-machines
 
-Architecture
+## Architecture
+
+A device could be a GPU card, CPU, or other computational units.
 
 <img src=https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/multi-node/ps_arch.png width=400/>
 
-| kvstore type | update on kvstore | multi-devices | multi-workers | #ex per update | max delay | update place |
+- *b*: the batch size set by users
+- *k*: the number of devices used on a worker (could vary for different workers)
+- *n*: the number of workers (often mean machines)
+
+- *number examples per update*: for each update, the number of examples used to
+  calculate the averaged gradients. Often the larger, the slower the convergence.
+- *number examples per device*: the number of examples batched to one device
+  each time. Often the larger, the better the performance.
+- *max delay*: The maximal delay of the weight a worker can get. Given a worker,
+  a delay *d* for weight *w* means when this worker uses *w* (to calculate the
+  gradient), *w* have been already updated by *d* times on some other places. A
+  larger delay often improves the performance, but may slows down the
+  convergence.
+
+
+| kvstore type | update on kvstore | multiple? | #ex per dev | #ex per update | max delay | update place |
 | :--- | :--- | ---:| ---:| ---:| ---:| ---:|
-| none | no | no | no | *b* | *0* | worker<sub>0</sub>'s dev<sub>0<\sub> |
-| local | yes | yes | no | *b* | *0* | worker<sub>0</sub>'s cpu |
-| local | no | yes | no | *b* | *0* | worker<sub>0</sub>'s devs |
-| device | no | yes | no | *b* | *0* | worker<sub>0</sub>'s devs |
-| dist | yes | yes | yes | *b* | *n* | servers |
-| dist | no | yes | yes | *b × n* | *0* | workers' cpu |
+| none | no | no | *b* | *b* | *0* | dev<sub>0</sub> on worker<sub>0</sub> |
+| local | yes | devs| *b/k* | *b* | *0* | cpu on worker<sub>0</sub> |
+| local | no | devs  | *b/k* | *b* | *0* | devs on worker<sub>0</sub> |
+| device | no | devs | *b/k* |*b* | *0* | devs on worker<sub>0</sub> |
+| dist | yes | devs + workers | yes | *b/k* |*b* | *n* | servers |
+| dist | no | devs + workers | *b/k* | *b × n* | *0* | cpus on workers |

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -787,6 +787,14 @@ MXNET_DLL int MXKVStoreSetUpdater(KVStoreHandle handle,
                                   MXKVStoreUpdater updater);
 
 
+/*!
+ * \brief get the type of the kvstore
+ * \param handle handle to the KVStore
+ * \param type a string type
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXKVStoreGetType(KVStoreHandle handle,
+                               const char** type);
 //--------------------------------------------
 // Part 6: advanced KVStore for multi-machines
 //--------------------------------------------

--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -39,7 +39,7 @@ class KVStore {
   /**
    * \brief return the type
    */
-  inline std::string type() { return type_; }
+  inline const std::string& type() { return type_; }
 
   /*!
    * \brief Initialize a list of key-value pair to the store.

--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -25,12 +25,21 @@ class KVStore {
 
   /*!
    * \brief Factory function to create a new KVStore.
-   * \param type The type of the kvstore, can be "local" or "dist"
-   * - local works for multiple devices on a single machine (single process)
-   * - dist works for multi-machines (multiple processes)
+   * \param type The type of the kvstore,
+   *   'local' : multi-devices on a single machine. can be also
+   *      'local_update_cpu', 'local_allreduce_cpu'
+   *   'device' or 'local_allreduce_device' : same to local but use gpus for kv
+   *       allreduce
+   *   'dist_sync' : multi-machines with BSP
+   *   'dist_async' : multi-machines with partical asynchronous
    * \return a new created KVStore.
    */
   static KVStore *Create(const char *type = "local");
+
+  /**
+   * \brief return the type
+   */
+  inline std::string type() { return type_; }
 
   /*!
    * \brief Initialize a list of key-value pair to the store.
@@ -269,6 +278,11 @@ class KVStore {
    * \brief the user-defined  updater
    */
   Updater updater_;
+
+  /**
+   * \brief the kvstore type
+   */
+  std::string type_;
 };
 
 }  // namespace mxnet

--- a/python/mxnet/context.py
+++ b/python/mxnet/context.py
@@ -29,8 +29,8 @@ class Context(object):
     """
     # static class variable
     default_ctx = None
-    devtype2str = {1: 'cpu', 2: 'gpu', 3: 'cpu'}
-    devstr2type = {'cpu': 1, 'gpu': 2, 'cpu': 3}
+    devtype2str = {1: 'cpu', 2: 'gpu', 3: 'cpu_pinned'}
+    devstr2type = {'cpu': 1, 'gpu': 2, 'cpu_pinned': 3}
     def __init__(self, device_type, device_id=0):
         if isinstance(device_type, Context):
             self.device_typeid = device_type.device_typeid

--- a/python/mxnet/context.py
+++ b/python/mxnet/context.py
@@ -29,8 +29,8 @@ class Context(object):
     """
     # static class variable
     default_ctx = None
-    devtype2str = {1: 'cpu', 2: 'gpu'}
-    devstr2type = {'cpu': 1, 'gpu': 2}
+    devtype2str = {1: 'cpu', 2: 'gpu', 3: 'cpu'}
+    devstr2type = {'cpu': 1, 'gpu': 2, 'cpu': 3}
     def __init__(self, device_type, device_id=0):
         if isinstance(device_type, Context):
             self.device_typeid = device_type.device_typeid

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -6,7 +6,7 @@ import ctypes
 import pickle
 from .ndarray import NDArray
 from .base import _LIB
-from .base import check_call, c_array, c_str, string_types, mx_uint
+from .base import check_call, c_array, c_str, string_types, mx_uint, py_str
 from .base import NDArrayHandle, KVStoreHandle
 from . import optimizer as opt
 
@@ -63,25 +63,12 @@ class KVStore(object):
     def __del__(self):
         check_call(_LIB.MXKVStoreFree(self.handle))
 
-    def get_type(self):
-        """Get the type of this kvstore
-
-        Returns
-        -------
-        type : str
-            the string type
-        """
-        kv_type = ctypes.c_char_p()
-        check_call(_LIB.MXKVStoreGetType(self.handle, ctypes.byref(kv_type)))
-        return kv_type.value
-
-
     def init(self, key, value):
         """ Initialize a single or a sequence of key-value pairs into the store.
 
         For each key, one must init it before push and pull.
 
-        Only worker 0's (get_rank() == 0) data are used.
+        Only worker 0's (rank == 0) data are used.
 
         This function returns after data have been initialized successfully
 
@@ -108,7 +95,7 @@ class KVStore(object):
         >>> keys = [5, 7, 9]
         >>> kv.init(keys, [mx.nd.ones(shape)]*len(keys))
         """
-        if (self.get_rank() == 0):
+        if (self.rank == 0):
             ckeys, cvals = _ctype_key_value(key, value)
             check_call(_LIB.MXKVStoreInit(
                 self.handle, mx_uint(len(ckeys)), ckeys, cvals))
@@ -279,7 +266,21 @@ class KVStore(object):
         else:
             self._set_updater(opt.get_updater(optimizer))
 
-    def get_rank(self):
+    @property
+    def type(self):
+        """Get the type of this kvstore
+
+        Returns
+        -------
+        type : str
+            the string type
+        """
+        kv_type = ctypes.c_char_p()
+        check_call(_LIB.MXKVStoreGetType(self.handle, ctypes.byref(kv_type)))
+        return py_str(kv_type.value)
+
+    @property
+    def rank(self):
         """Get the rank of this worker node
 
         Returns
@@ -291,7 +292,8 @@ class KVStore(object):
         check_call(_LIB.MXKVStoreGetRank(self.handle, ctypes.byref(rank)))
         return rank.value
 
-    def get_num_workers(self):
+    @property
+    def num_workers(self):
         """Get the number of worker ndoes
 
         Returns
@@ -345,17 +347,17 @@ class KVStore(object):
         pulling, we can place a barrier to guarantee that the initialization is
         finished.
 
-        The following codes run on n machines in parallel
-
-        >>> if kv.get_rank() == 0:
-        ...     kv.init(keys, values);
-        ... kv.barrier()
-        ... kv.pull(keys, out = values);
-
         But note that, this functions only blocks the main thread of workers
         until all of them are reached this point. It doesn't guarantee that all
         operations issued before are actually finished, such as \ref Push and
         \ref Pull. In that case, we need to call \ref Wait or \ref WaitAll
+
+        The following codes implement a BSP model
+
+        >>> kv.push(keys, values)
+        ... kv._wait(keys)
+        ... kv._barrier()
+        ... kv.pull(keys, out = values);
         """
         check_call(_LIB.MXKVStoreBarrier(self.handle))
 

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -261,7 +261,7 @@ class KVStore(object):
                 raise
             self._send_command_to_servers(0, optim_str)
         else:
-            self._set_updater(opt.optimizer_clossure(optimizer))
+            self._set_updater(opt.get_updater(optimizer))
 
     def get_rank(self):
         """Get the rank of this worker node

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -169,6 +169,9 @@ class KVStore(object):
             self.handle, mx_uint(len(ckeys)), ckeys, cvals,
             ctypes.c_int(priority)))
 
+        # self._wait(key)
+        # self._barrier()
+
     def pull(self, key, out=None, priority=0):
         """ Pull a single value or a sequence of values from the store.
 

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -63,6 +63,19 @@ class KVStore(object):
     def __del__(self):
         check_call(_LIB.MXKVStoreFree(self.handle))
 
+    def get_type(self):
+        """Get the type of this kvstore
+
+        Returns
+        -------
+        type : str
+            the string type
+        """
+        kv_type = ctypes.c_char_p()
+        check_call(_LIB.MXKVStoreGetType(self.handle, ctypes.byref(kv_type)))
+        return kv_type.value
+
+
     def init(self, key, value):
         """ Initialize a single or a sequence of key-value pairs into the store.
 

--- a/python/mxnet/kvstore_server.py
+++ b/python/mxnet/kvstore_server.py
@@ -31,7 +31,7 @@ class KVStoreServer(object):
                 self.kvstore.set_optimizer(optimizer)
             else:
                 print ("server %d, unknown command (%d, %s)" % (
-                    self.kvstore.get_rank(), cmd_id, cmd_body))
+                    self.kvstore.rank, cmd_id, cmd_body))
         return server_controller
 
     def run(self):

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -193,10 +193,6 @@ def _train_multi_device(symbol, ctx, input_shape,
     Notes
     -----
     - This function will inplace update the NDArrays in arg_parans and aux_states.
-    - Turning update_on_kvstore on and off can affect speed of multi-gpu training.
-      - It is auto selected by default.
-      - update_on_kvstore=True works well for inception type nets that contains many small weights.
-      - update_on_kvstore=False works better for Alexnet style net with bulk weights.
     """
     if logger is None:
         logger = logging
@@ -224,7 +220,7 @@ def _train_multi_device(symbol, ctx, input_shape,
         texec.copy_params_from(arg_params, aux_params)
 
     # create kvstore
-    if isinstance(kvstore, KVStore):
+    if isinstance(kvstore, kvs.KVStore):
         kv = kvstore
     elif isinstance(kvstore, str):
         # create kvstore using the string type
@@ -755,8 +751,7 @@ class FeedForward(BASE_ESTIMATOR):
     def create(symbol, X, y=None, ctx=None,
                num_round=None, optimizer='sgd', initializer=Uniform(0.01),
                eval_data=None, eval_metric='acc', iter_end_callback=None,
-               update_on_kvstore=None, kvstore_type='local', kvstore=None,
-               logger=None, **kwargs):
+               kvstore='local', logger=None, **kwargs):
         """Functional style to create a model.
 
         This function will be more consistent with functional

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -148,8 +148,7 @@ def create(name, rescale_grad=1, **kwargs):
     else:
         raise ValueError('Cannot find optimizer %s' % name)
 
-
-def optimizer_clossure(optimizer):
+def get_updater(optimizer):
     """Return a clossure of the updater needed for kvstore
 
     Parameters

--- a/src/c_api.cc
+++ b/src/c_api.cc
@@ -1088,3 +1088,10 @@ int MXKVStoreSendCommmandToServers(KVStoreHandle handle,
       cmd_id, std::string(cmd_body));
   API_END();
 }
+
+int MXKVStoreGetType(KVStoreHandle handle,
+                     const char** type) {
+  API_BEGIN();
+  *CHECK_NOTNULL(type) = static_cast<KVStore*>(handle)->type().c_str();
+  API_END();
+}

--- a/src/io/iter_image_recordio.cc
+++ b/src/io/iter_image_recordio.cc
@@ -101,6 +101,11 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
   int preprocess_threads;
   /*! \brief whether to remain silent */
   bool verbose;
+  /*! \brief partition the data into multiple parts */
+  int num_parts;
+  /*! \brief the index of the part will read*/
+  int part_index;
+
   // declare parameters
   DMLC_DECLARE_PARAMETER(ImageRecParserParam) {
     DMLC_DECLARE_FIELD(path_imglist).set_default("")
@@ -116,6 +121,10 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
         .describe("Backend Param: Number of thread to do preprocessing.");
     DMLC_DECLARE_FIELD(verbose).set_default(true)
         .describe("Auxiliary Param: Whether to output parser information.");
+    DMLC_DECLARE_FIELD(num_parts).set_default(1)
+        .describe("partition the data into multiple parts");
+    DMLC_DECLARE_FIELD(part_index).set_default(0)
+        .describe("the index of the part will read");
   }
 };
 
@@ -203,12 +212,9 @@ inline void ImageRecordIOParser::Init(
     LOG(INFO) << "ImageRecordIOParser: " << param_.path_imgrec
               << ", use " << threadget << " threads for decoding..";
   }
-  // TODO(mu, tianjun) add DMLC env variable to detect parition
-  const int part_index = 0;
-  const int num_parts = 1;
   source_ = dmlc::InputSplit::Create(
-      param_.path_imgrec.c_str(), part_index,
-      num_parts, "recordio");
+      param_.path_imgrec.c_str(), param_.part_index,
+      param_.num_parts, "recordio");
   // use 64 MB chunk when possible
   source_->HintChunkSize(8 << 20UL);
 #else

--- a/src/io/iter_mnist.cc
+++ b/src/io/iter_mnist.cc
@@ -31,6 +31,10 @@ struct MNISTParam : public dmlc::Parameter<MNISTParam> {
   bool flat;
   /*! \brief random seed */
   int seed;
+  /*! \brief partition the data into multiple parts */
+  int num_parts;
+  /*! \brief the index of the part will read*/
+  int part_index;
   // declare parameters
   DMLC_DECLARE_PARAMETER(MNISTParam) {
     DMLC_DECLARE_FIELD(image).set_default("./train-images-idx3-ubyte")
@@ -47,6 +51,10 @@ struct MNISTParam : public dmlc::Parameter<MNISTParam> {
         .describe("Augmentation Param: Random Seed.");
     DMLC_DECLARE_FIELD(silent).set_default(false)
         .describe("Auxiliary Param: Whether to print out data info.");
+    DMLC_DECLARE_FIELD(num_parts).set_default(1)
+        .describe("partition the data into multiple parts");
+    DMLC_DECLARE_FIELD(part_index).set_default(0)
+        .describe("the index of the part will read");
   }
 };
 
@@ -113,12 +121,32 @@ class MNISTIter: public IIterator<TBlobBatch> {
   }
 
  private:
+  inline void GetPart(int count, int* start, int *end) {
+    CHECK_GE(param_.part_index, 0);
+    CHECK_GT(param_.num_parts, 0);
+    CHECK_GT(param_.num_parts, param_.part_index);
+
+    *start = static_cast<int>(
+        static_cast<double>(count) / param_.num_parts * param_.part_index);
+    *end = static_cast<int>(
+        static_cast<double>(count) / param_.num_parts * (param_.part_index+1));
+  }
+
   inline void LoadImage(void) {
-    dmlc::Stream *stdimg = dmlc::Stream::Create(param_.image.c_str(), "r");
+    // dmlc::Stream *stdimg = dmlc::Stream::Create(param_.image.c_str(), "r");
+    dmlc::SeekStream* stdimg
+        = dmlc::SeekStream::CreateForRead(param_.image.c_str());
     ReadInt(stdimg);
     int image_count = ReadInt(stdimg);
     int image_rows  = ReadInt(stdimg);
     int image_cols  = ReadInt(stdimg);
+
+    int start, end;
+    GetPart(image_count, &start, &end);
+    image_count = end - start;
+    if (start > 0) {
+      stdimg->Seek(stdimg->Tell() + start * image_rows * image_cols);
+    }
 
     img_.shape_ = mshadow::Shape3(image_count, image_rows, image_cols);
     img_.stride_ = img_.size(2);
@@ -139,9 +167,20 @@ class MNISTIter: public IIterator<TBlobBatch> {
     delete stdimg;
   }
   inline void LoadLabel(void) {
-    dmlc::Stream *stdlabel = dmlc::Stream::Create(param_.label.c_str(), "r");
+    // dmlc::Stream *stdlabel = dmlc::Stream::Create(param_.label.c_str(), "r");
+
+    dmlc::SeekStream* stdlabel
+        = dmlc::SeekStream::CreateForRead(param_.label.c_str());
     ReadInt(stdlabel);
     int labels_count = ReadInt(stdlabel);
+
+    int start, end;
+    GetPart(labels_count, &start, &end);
+    labels_count = end - start;
+    if (start > 0) {
+      stdlabel->Seek(stdlabel->Tell() + start);
+    }
+
     labels_.resize(labels_count);
     for (int i = 0; i < labels_count; ++i) {
       unsigned char ch;

--- a/src/io/iter_mnist.cc
+++ b/src/io/iter_mnist.cc
@@ -133,7 +133,6 @@ class MNISTIter: public IIterator<TBlobBatch> {
   }
 
   inline void LoadImage(void) {
-    // dmlc::Stream *stdimg = dmlc::Stream::Create(param_.image.c_str(), "r");
     dmlc::SeekStream* stdimg
         = dmlc::SeekStream::CreateForRead(param_.image.c_str());
     ReadInt(stdimg);
@@ -167,7 +166,6 @@ class MNISTIter: public IIterator<TBlobBatch> {
     delete stdimg;
   }
   inline void LoadLabel(void) {
-    // dmlc::Stream *stdlabel = dmlc::Stream::Create(param_.label.c_str(), "r");
 
     dmlc::SeekStream* stdlabel
         = dmlc::SeekStream::CreateForRead(param_.label.c_str());

--- a/src/io/iter_mnist.cc
+++ b/src/io/iter_mnist.cc
@@ -166,7 +166,6 @@ class MNISTIter: public IIterator<TBlobBatch> {
     delete stdimg;
   }
   inline void LoadLabel(void) {
-
     dmlc::SeekStream* stdlabel
         = dmlc::SeekStream::CreateForRead(param_.label.c_str());
     ReadInt(stdlabel);

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -10,6 +10,7 @@
 #include "./kvstore_local.h"
 #include "./mxnet_ps_node.h"
 #include "mxnet/engine.h"
+// #include "dmlc/parameter.h"
 #include "ps.h"
 #include "base/range.h"
 
@@ -43,6 +44,7 @@ class KVStoreDist : public KVStoreLocal {
         // stop the executor at servers
         SendCommandToServers(CommandID::kStop, "");
       }
+      Barrier();
       ps::StopSystem();
     }
   }

--- a/tests/python/distributed/test_mlp.py
+++ b/tests/python/distributed/test_mlp.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# pylint: skip-file
+
+import mxnet as mx
+import numpy as np
+import os, sys
+import pickle as pickle
+import logging
+curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+sys.path.append(os.path.join(curr_path, '../common/'))
+import models
+import get_data
+
+# symbol net
+batch_size = 100
+data = mx.symbol.Variable('data')
+fc1 = mx.symbol.FullyConnected(data, name='fc1', num_hidden=128)
+act1 = mx.symbol.Activation(fc1, name='relu1', act_type="relu")
+fc2 = mx.symbol.FullyConnected(act1, name = 'fc2', num_hidden = 64)
+act2 = mx.symbol.Activation(fc2, name='relu2', act_type="relu")
+fc3 = mx.symbol.FullyConnected(act2, name='fc3', num_hidden=10)
+softmax = mx.symbol.Softmax(fc3, name = 'sm')
+
+def accuracy(label, pred):
+    py = np.argmax(pred, axis=1)
+    return np.sum(py == label) / float(label.size)
+
+num_round = 4
+prefix = './mlp'
+
+kv = mx.kvstore.create('dist')
+batch_size /= kv.get_num_workers()
+
+#check data
+get_data.GetMNIST_ubyte()
+
+train_dataiter = mx.io.MNISTIter(
+        image="data/train-images-idx3-ubyte",
+        label="data/train-labels-idx1-ubyte",
+        data_shape=(784,), num_parts=kv.get_num_workers(), part_index=kv.get_rank(),
+        batch_size=batch_size, shuffle=True, flat=True, silent=False, seed=10)
+val_dataiter = mx.io.MNISTIter(
+        image="data/t10k-images-idx3-ubyte",
+        label="data/t10k-labels-idx1-ubyte",
+        data_shape=(784,),
+        batch_size=batch_size, shuffle=True, flat=True, silent=False)
+
+def test_mlp():
+    logging.basicConfig(level=logging.DEBUG)
+
+    model = mx.model.FeedForward.create(
+        softmax,
+        X=train_dataiter,
+        eval_data=val_dataiter,
+        eval_metric=mx.metric.np(accuracy),
+        ctx=[mx.cpu(i) for i in range(1)],
+        num_round=num_round,
+        learning_rate=0.05, wd=0.0004,
+        momentum=0.9,
+        kvstore=kv,
+        )
+    logging.info('Finish traning...')
+    prob = model.predict(val_dataiter)
+    logging.info('Finish predict...')
+    val_dataiter.reset()
+    y = np.concatenate([label.asnumpy() for _, label in val_dataiter]).astype('int')
+    py = np.argmax(prob, axis=1)
+    acc = float(np.sum(py == y)) / len(y)
+    logging.info('final accuracy = %f', acc)
+    assert(acc > 0.93)
+
+if __name__ == "__main__":
+    test_mlp()

--- a/tests/python/train/test_mlp.py
+++ b/tests/python/train/test_mlp.py
@@ -40,9 +40,6 @@ val_dataiter = mx.io.MNISTIter(
 def test_mlp():
     # print logging by default
     logging.basicConfig(level=logging.DEBUG)
-    console = logging.StreamHandler()
-    console.setLevel(logging.DEBUG)
-    logging.getLogger('').addHandler(console)
 
     model = mx.model.FeedForward.create(
         softmax,
@@ -53,8 +50,7 @@ def test_mlp():
         ctx=[mx.cpu(i) for i in range(2)],
         num_round=num_round,
         learning_rate=0.1, wd=0.0004,
-        momentum=0.9,
-        update_on_kvstore=True)
+        momentum=0.9)
 
     logging.info('Finish traning...')
     prob = model.predict(val_dataiter)

--- a/tests/python/unittest/test_kvstore.py
+++ b/tests/python/unittest/test_kvstore.py
@@ -104,8 +104,13 @@ def test_updater(dev = 'cpu'):
         for v in vv:
             check_diff_to_scalar(v, num_devs * num_push)
 
+def test_get_type():
+    kvtype = 'local_allreduce_cpu'
+    kv = mx.kv.create(kvtype)
+    assert kv.get_type() == kvtype
 
 if __name__ == '__main__':
+    test_get_type()
     test_single_kv_pair()
     test_list_kv_pair()
     test_aggregator()

--- a/tests/python/unittest/test_kvstore.py
+++ b/tests/python/unittest/test_kvstore.py
@@ -107,7 +107,7 @@ def test_updater(dev = 'cpu'):
 def test_get_type():
     kvtype = 'local_allreduce_cpu'
     kv = mx.kv.create(kvtype)
-    assert kv.get_type() == kvtype
+    assert kv.type == kvtype
 
 if __name__ == '__main__':
     test_get_type()


### PR DESCRIPTION
replaced `kvstore_type` and `udpate_on_server` by `kvstore` (either a type or a KVStore) on model.py, more doc

https://github.com/mli/mxnet/blob/master/doc/developer-guide/multi_node.md

passed tests on mnist and cifar with multi-gpus