### PR TITLE
Seems some typos in the figure

### DIFF
--- a/doc/python/symbol_in_pictures.md
+++ b/doc/python/symbol_in_pictures.md
@@ -46,6 +46,7 @@ You can use ```mx.symbol.Group``` to group symbols together then bind them to
 get outputs of both.
 
 ![MultiOut](https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/symbol/executor_multi_out.png)
+The figure seems get two typos.
 
 But always remember, only bind what you need, so system can do more optimizations for you.
 


### PR DESCRIPTION
In the section "Bind Multiple Outputs", the figure seems have three typos.
The code "G = mx.sym.Group([E,D])" should be "G = mx.sym.Group([E,C])", 
"d_out" should be "c_out", 
and
"executor.output[1] = 10 //D" in the lower right corner should be "executor.output[1] = 10 //C".