### PR TITLE
Fix num_pad of io.NDArrayIter.

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -156,10 +156,7 @@ class NDArrayIter(DataIter):
             self.batch_data[i, 0:actual_size, ::] = data[loc:loc+actual_size, ::]
             self.batch_label[i, 0:actual_size] = label[loc:loc+actual_size]
             loc += batch_size
-        if data.shape[0] > batch_size:
-            self.num_pad = data.shape[0] % batch_size
-        else:
-            self.num_pad = batch_size - data.shape[0]
+        self.num_pad = batch_size - data.shape[0] % batch_size
         self.out_data = None
         self.out_label = None
         self.current_batch = -1


### PR DESCRIPTION
Correct the number of padding in `io.NDArrayIter` and remove unnecessary `if` conditions.