### PR TITLE
Implementing support for NativeOps in Julia

### DIFF
--- a/example/numpy-ops/numpy_softmax.py
+++ b/example/numpy-ops/numpy_softmax.py
@@ -53,7 +53,7 @@ train, val = mnist_iterator(batch_size=100, input_shape = (784,))
 logging.basicConfig(level=logging.DEBUG)
 
 model = mx.model.FeedForward(
-    ctx = mx.gpu(), symbol = mlp, num_epoch = 20,
+    ctx = mx.cpu(), symbol = mlp, num_epoch = 20,
     learning_rate = 0.1, momentum = 0.9, wd = 0.00001)
 
 model.fit(X=train, eval_data=val)

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -51,11 +51,17 @@ typedef void *RecordIOHandle;
 
 MXNET_EXTERN_C {
 struct NativeOpInfo {
-  void (*forward)(int, float**, int*, unsigned**, int*);
-  void (*backward)(int, float**, int*, unsigned**, int*);
-  void (*infer_shape)(int, int*, unsigned**);
-  void (*list_outputs)(char***);
-  void (*list_arguments)(char***);
+  void (*forward)(int, float**, int*, unsigned**, int*, void*);
+  void (*backward)(int, float**, int*, unsigned**, int*, void*);
+  void (*infer_shape)(int, int*, unsigned**, void*);
+  void (*list_outputs)(char***, void*);
+  void (*list_arguments)(char***, void*);
+  // all functions also pass a payload void* pointer
+  void* p_forward;
+  void* p_backward;
+  void* p_infer_shape;
+  void* p_list_outputs;
+  void* p_list_arguments;
 };
 }
 /*!

--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -45,7 +45,12 @@ class NumpyOp(object):
                 ('backward', fb_functype),
                 ('infer_shape', infer_functype),
                 ('list_outputs', list_functype),
-                ('list_arguments', list_functype)
+                ('list_arguments', list_functype),
+                ('p_forward', c_void_p),
+                ('p_backward', c_void_p),
+                ('p_infer_shape', c_void_p),
+                ('p_list_outputs', c_void_p),
+                ('p_list_arguments', c_void_p),
                 ]
         def forward_entry(num_tensor, tensor_ptrs, tensor_dims,
                           tensor_shapes, tensor_tags):
@@ -103,7 +108,8 @@ class NumpyOp(object):
                                  fb_functype(backward_entry),
                                  infer_functype(infer_shape_entry),
                                  list_functype(list_outputs_entry),
-                                 list_functype(list_arguments_entry))
+                                 list_functype(list_arguments_entry),
+                                 None, None, None, None, None)
         cb_ptr = hex(cast(pointer(self.info_), c_void_p).value)
         # pylint: disable=E1101
         return symbol.Symbol._Native(*args,

--- a/src/operator/native_op-inl.h
+++ b/src/operator/native_op-inl.h
@@ -56,7 +56,8 @@ class NativeOp : public Operator {
     SyncVec(in_data, "in_data", s, 0);
     SyncVec(out_data, "out_data", s, 1);
     s->Wait();
-    param_.pinfo->forward(ptrs.size(), ptrs.data(), ndims.data(), shapes.data(), tags.data());
+    param_.pinfo->forward(ptrs.size(), ptrs.data(), ndims.data(), shapes.data(),
+        tags.data(), param_.pinfo->p_forward);
     for (index_t i = 0; i < out_data.size(); ++i) {
       CHECK_NE(req[i], kAddTo) << "NativeOp doesn't support AddTo for output";
       if (req[i] != kNullOp) {
@@ -89,7 +90,8 @@ class NativeOp : public Operator {
       SyncVec(out_grad, "out_grad", s, 3);
     }
     s->Wait();
-    param_.pinfo->backward(ptrs.size(), ptrs.data(), ndims.data(), shapes.data(), tags.data());
+    param_.pinfo->backward(ptrs.size(), ptrs.data(), ndims.data(), shapes.data(),
+        tags.data(), param_.pinfo->p_backward);
     for (index_t i = 0; i < in_grad.size(); ++i) {
       CHECK_NE(req[i], kAddTo) << "NativeOp doesn't support AddTo for output";
       if (req[i] != kNullOp) {
@@ -155,7 +157,7 @@ class NativeOpProp : public OperatorProperty {
  public:
   std::vector<std::string> ListArguments() const override {
     char ** args = NULL;
-    param_.pinfo->list_arguments(&args);
+    param_.pinfo->list_arguments(&args, param_.pinfo->p_list_arguments);
     std::vector<std::string> ret;
     for (int i = 0; args[i] != NULL; ++i) {
       ret.push_back(args[i]);
@@ -165,7 +167,7 @@ class NativeOpProp : public OperatorProperty {
 
   std::vector<std::string> ListOutputs() const override {
     char ** args = NULL;
-    param_.pinfo->list_outputs(&args);
+    param_.pinfo->list_outputs(&args, param_.pinfo->p_list_outputs);
     std::vector<std::string> ret;
     for (int i = 0; args[i] != NULL; ++i) {
       ret.push_back(args[i]);
@@ -204,7 +206,8 @@ class NativeOpProp : public OperatorProperty {
     }
     shapes.resize(param_.num_inputs_+param_.num_outputs_);
     ndims.resize(param_.num_inputs_+param_.num_outputs_);
-    param_.pinfo->infer_shape(shapes.size(), ndims.data(), shapes.data());
+    param_.pinfo->infer_shape(shapes.size(), ndims.data(), shapes.data(),
+          param_.pinfo->p_infer_shape);
     for (unsigned i = 0; i < in_shape->size(); ++i) {
       (*in_shape)[i] = TShape(shapes[i], shapes[i]+ndims[i]);
     }


### PR DESCRIPTION
I am currently trying to implement NativeOps in Julia. (see https://github.com/dmlc/MXNet.jl/issues/15)

One of the issues is that calling a Julia function directly is not possible. Instead one has to provide a opaque pointer to the julia function one actually wants to call.

See http://julialang.org/blog/2013/05/callback/ and https://github.com/dmlc/MXNet.jl/blob/master/src/kvstore.jl#L115