### PR TITLE
fix deconvolution kernel size check

### DIFF
--- a/src/operator/deconvolution-inl.h
+++ b/src/operator/deconvolution-inl.h
@@ -313,8 +313,6 @@ class DeconvolutionProp : public OperatorProperty {
         << "incorrect kernel size: " << param_.kernel;
     CHECK_GE(param_.stride.Size(), 0) \
         << "incorrect stride size: " << param_.stride;
-    CHECK(ksize_x <= dshape[3] && ksize_y <= dshape[2])
-        << "kernel size exceed input";
     (*out_shape)[deconv::kOut][1] = param_.num_filter;
     (*out_shape)[deconv::kOut][2] = param_.stride[0] * (dshape[2] - 1) +
         ksize_y - 2 * param_.pad[0];


### PR DESCRIPTION
in deconvolution, no restriction on kernel_size (because deconv usually used for upsampling, so the kernel_size can be larger than input feature_map size. )