### PR TITLE
Fixed the trailing L problem of hex(...)

### DIFF
--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -199,7 +199,7 @@ class NumpyOp(PythonOp):
                                  list_functype(list_outputs_entry),
                                  list_functype(list_arguments_entry),
                                  None, None, None, None, None)
-        cb_ptr = hex(cast(pointer(self.info_), c_void_p).value)
+        cb_ptr = format(cast(pointer(self.info_), c_void_p).value, 'x')
         # pylint: disable=E1101
         return symbol.Symbol._Native(*args,
                                      info=cb_ptr,


### PR DESCRIPTION
Using `hex` for 16-bit string conversion will cause the [Trailing L Problem](http://stackoverflow.com/questions/5917203/python-trailing-l-problem) for 64-bit value.  See https://github.com/dmlc/mxnet/issues/545 for more detail.