### PR TITLE
Add uneven load training feature

### DIFF
--- a/python/mxnet/context.py
+++ b/python/mxnet/context.py
@@ -2,6 +2,7 @@
 """Context management API of mxnet."""
 from __future__ import absolute_import
 
+
 class Context(object):
     """Constructing a context.
 
@@ -12,6 +13,12 @@ class Context(object):
 
     device_id : int (default=0)
         The device id of the device, needed for GPU
+
+    work_load : int (default=1)
+        The work_load in a list of devices. For example,
+            if we have a list of device with work_load [1, 2, 1],
+            the first and third device will take 1/4 work load,
+            while the second device will take 1/2 work_load.
 
     Note
     ----
@@ -31,13 +38,16 @@ class Context(object):
     default_ctx = None
     devtype2str = {1: 'cpu', 2: 'gpu', 3: 'cpu_pinned'}
     devstr2type = {'cpu': 1, 'gpu': 2, 'cpu_pinned': 3}
-    def __init__(self, device_type, device_id=0):
+
+    def __init__(self, device_type, device_id=0, work_load=1):
         if isinstance(device_type, Context):
             self.device_typeid = device_type.device_typeid
             self.device_id = device_type.device_id
+            self.work_load = device_type.work_load
         else:
             self.device_typeid = Context.devstr2type[device_type]
             self.device_id = device_id
+            self.work_load = work_load
         self._old_ctx = None
 
     @property
@@ -68,7 +78,7 @@ class Context(object):
 Context.default_ctx = Context('cpu', 0)
 
 
-def cpu(device_id=0):
+def cpu(device_id=0, work_load=1):
     """Return a CPU context.
 
     This function is a short cut for Context('cpu', device_id)
@@ -79,15 +89,18 @@ def cpu(device_id=0):
         The device id of the device. device_id is not needed for CPU.
         This is included to make interface compatible with GPU.
 
+    work_load : int (default=1)
+        The work_load in a list of devices.
+
     Returns
     -------
     context : Context
         The corresponding CPU context.
     """
-    return Context('cpu', device_id)
+    return Context('cpu', device_id, work_load)
 
 
-def gpu(device_id=0):
+def gpu(device_id=0, work_load=1):
     """Return a GPU context.
 
     This function is a short cut for Context('cpu', device_id)
@@ -97,12 +110,15 @@ def gpu(device_id=0):
     device_id : int, optional
         The device id of the device, needed for GPU
 
+    work_load : int (default=1)
+        The work_load in a list of devices.
+
     Returns
     -------
     context : Context
         The corresponding GPU context.
     """
-    return Context('gpu', device_id)
+    return Context('gpu', device_id, work_load)
 
 
 def current_context():

--- a/python/mxnet/context.py
+++ b/python/mxnet/context.py
@@ -2,7 +2,6 @@
 """Context management API of mxnet."""
 from __future__ import absolute_import
 
-
 class Context(object):
     """Constructing a context.
 
@@ -13,12 +12,6 @@ class Context(object):
 
     device_id : int (default=0)
         The device id of the device, needed for GPU
-
-    work_load : int (default=1)
-        The work_load in a list of devices. For example,
-            if we have a list of device with work_load [1, 2, 1],
-            the first and third device will take 1/4 work load,
-            while the second device will take 1/2 work_load.
 
     Note
     ----
@@ -38,16 +31,13 @@ class Context(object):
     default_ctx = None
     devtype2str = {1: 'cpu', 2: 'gpu', 3: 'cpu_pinned'}
     devstr2type = {'cpu': 1, 'gpu': 2, 'cpu_pinned': 3}
-
-    def __init__(self, device_type, device_id=0, work_load=1):
+    def __init__(self, device_type, device_id=0):
         if isinstance(device_type, Context):
             self.device_typeid = device_type.device_typeid
             self.device_id = device_type.device_id
-            self.work_load = device_type.work_load
         else:
             self.device_typeid = Context.devstr2type[device_type]
             self.device_id = device_id
-            self.work_load = work_load
         self._old_ctx = None
 
     @property
@@ -78,7 +68,7 @@ class Context(object):
 Context.default_ctx = Context('cpu', 0)
 
 
-def cpu(device_id=0, work_load=1):
+def cpu(device_id=0):
     """Return a CPU context.
 
     This function is a short cut for Context('cpu', device_id)
@@ -89,18 +79,15 @@ def cpu(device_id=0, work_load=1):
         The device id of the device. device_id is not needed for CPU.
         This is included to make interface compatible with GPU.
 
-    work_load : int (default=1)
-        The work_load in a list of devices.
-
     Returns
     -------
     context : Context
         The corresponding CPU context.
     """
-    return Context('cpu', device_id, work_load)
+    return Context('cpu', device_id)
 
 
-def gpu(device_id=0, work_load=1):
+def gpu(device_id=0):
     """Return a GPU context.
 
     This function is a short cut for Context('cpu', device_id)
@@ -110,15 +97,12 @@ def gpu(device_id=0, work_load=1):
     device_id : int, optional
         The device id of the device, needed for GPU
 
-    work_load : int (default=1)
-        The work_load in a list of devices.
-
     Returns
     -------
     context : Context
         The corresponding GPU context.
     """
-    return Context('gpu', device_id, work_load)
+    return Context('gpu', device_id)
 
 
 def current_context():

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -93,14 +93,11 @@ def _split_input_slice(batch_size, ctx):
     ------
     ValueError
         If there are two many splits such that some slice can be empty.
-    ------
-    Known bugs:
-        We found that too small batch_size could cause ValueError problems in work_load based split,
-        e.g. batch_size = 6 and work_load_list = [1, 1, 1, 1]
     """
     work_load_list = [float(c.work_load) for c in ctx]
     total_work_load = sum(work_load_list)
-    batch_num_list = [round(work_load * batch_size / total_work_load) for work_load in work_load_list]
+    batch_num_list = [round(work_load * batch_size / total_work_load)
+                      for work_load in work_load_list]
     batch_num_sum = sum(batch_num_list)
     if batch_num_sum < batch_size:
         batch_num_list[-1] += batch_size - batch_num_sum


### PR DESCRIPTION
I've created a uneven load training mechanism for multiple devices in a single machine. 

## Usage 

Here is my test code modified from `example/imagenet/inception.py`
```python
work_load_list = [(0, 5), (1, 1.5), (2, 5)]
gpus = [mx.gpu(i, work_load) for i, work_load in work_load_list]

model = mx.model.FeedForward(ctx=gpus, symbol=softmax, num_epoch=num_epoch,
                             learning_rate=0.05, momentum=0.9, wd=0.00001)

model.fit(X=train, eval_data=val,
          eval_metric="acc",
          batch_end_callback=mx.callback.Speedometer(batch_size),
          epoch_end_callback=mx.callback.do_checkpoint(model_prefix))
```

Here, `work_load_list` is a list of `(device_index, work_load)` tuple. Pass `gpus` to the `ctx` argument for `model.fit` API could automatically unevenly distribute samples to different devices. 

**If you don't want this feature, you're good to use your old code with this new commit.**

## Result

My test machine is a workstation equipped with a Quadro K4000 and two Tesla K40c. Training with the modified `example/imagenet/inception.py`, with ratio `10:10:3` for `K40c:K40c:K4000`, the training speedometer is shown as: 

```
INFO:root:Iter[0] Batch [100]	Speed: 92.63 samples/sec
INFO:root:Iter[0] Batch [150]	Speed: 91.22 samples/sec
INFO:root:Iter[0] Batch [200]	Speed: 92.20 samples/sec
INFO:root:Iter[0] Batch [250]	Speed: 92.53 samples/sec
INFO:root:Iter[0] Batch [300]	Speed: 92.55 samples/sec
```

With only two Tesla GPUs, we observe a speed around 

```
INFO:root:Iter[0] Batch [12700]	Speed: 80.39 samples/sec
INFO:root:Iter[0] Batch [12750]	Speed: 80.27 samples/sec
INFO:root:Iter[0] Batch [12800]	Speed: 80.31 samples/sec
```

So this uneven work load feature is able to squeeze the last GPU on the machine and slightly improve the performance. 