### PR TITLE
Fix workspace in convolution being bigger than anticipated 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -70,3 +70,4 @@ List of Contributors
 * [Ming Zhang](https://github.com/starimpact)
 * [sxjscience](https://github.com/sxjscience)
 * [Zheng Xu](https://github.com/XericZephyr)
+* [Valentin Churavy](https://github.com/vchuravy)

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ include tests/cpp/unittest.mk
 test: $(TEST)
 
 lint: rcpplint
-	python dmlc-core/scripts/lint.py mxnet ${LINT_LANG} include src scripts python predict/python
+	python2 dmlc-core/scripts/lint.py mxnet ${LINT_LANG} include src scripts python predict/python
 
 doc: doxygen
 
@@ -150,7 +150,7 @@ doxygen:
 
 # R related shortcuts
 rcpplint:
-	python dmlc-core/scripts/lint.py mxnet-rcpp ${LINT_LANG} R-package/src
+	python2 dmlc-core/scripts/lint.py mxnet-rcpp ${LINT_LANG} R-package/src
 
 rcppexport:
 	Rscript -e "require(mxnet); mxnet::mxnet.export(\"R-package\")"

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -240,10 +240,15 @@ class ConvolutionOp : public Operator {
                                      param_.num_filter / param_.num_group,
                                      oshape[2] * oshape[3]);
     const uint64_t workspace_size = param_.workspace;  // In elements of sizeof(real_t)
-    nstep_ = std::max(std::min(static_cast<index_t>(workspace_size / shape_colunit_.Size()),
-                               ishape[0]), 1U);
-    int nop = (ishape[0] + nstep_ - 1) / nstep_;
+    index_t nstep = std::max(std::min(static_cast<index_t>(workspace_size / shape_colunit_.Size()),
+                                      ishape[0]), 1U);
+    index_t nop = (ishape[0] + nstep - 1) / nstep;
     nstep_ = (ishape[0] + nop - 1) / nop;
+
+    if (nstep_ == nstep) {
+      nstep_ = std::max(nstep_ - 1, 1U);
+    }
+
     mshadow::Shape<2> scol = mshadow::Shape2(shape_colunit_[0],
                                              shape_colunit_[1] * nstep_);
     mshadow::Shape<3> sdst = mshadow::Shape3(shape_dstunit_[0],


### PR DESCRIPTION
In certain situations `nstep` and `nstep_` can be of equal size and that leads to problem with calculating the required workspace size in the allowed maximum.

For context see : https://github.com/dmlc/MXNet.jl/issues/14#issuecomment-156332531