### PR TITLE
Added pow.

### DIFF
--- a/python/mxnet/symbol.py
+++ b/python/mxnet/symbol.py
@@ -86,6 +86,14 @@ class Symbol(object):
     def __rtruediv__(self, other):
         return self.__rdiv__(other)
 
+    def __pow__(self, other):
+        if isinstance(other, Symbol):
+            return Symbol._Power(self, other)
+        if isinstance(other, Number):
+            return Symbol._PowerScalar(self, scalar=other)
+        else:
+            raise TypeError('type %s not supported' % str(type(other)))
+
     def __del__(self):
         check_call(_LIB.MXSymbolFree(self.handle))
 
@@ -835,3 +843,28 @@ def _init_symbol_module():
 
 # Initialize the atomic symbo in startups
 _init_symbol_module()
+
+# pylint: disable=no-member
+# pylint: disable=redefined-builtin
+def pow(base, exp):
+    """ Raise base to an exp.
+
+    Parameters
+    ---------
+    base: Symbol or Number
+    exp: Symbol or Number
+
+    Returns
+    -------
+    result: Symbol or Number
+    """
+    if isinstance(base, Symbol) and isinstance(exp, Symbol):
+        return Symbol._Power(base, exp)
+    if  isinstance(base, Symbol) and isinstance(exp, Number):
+        return Symbol._PowerScalar(base, scalar=exp)
+    if  isinstance(base, Number) and isinstance(exp, Symbol):
+        return Symbol._PowerScalar(exp, scalar=base, scalar_on_right=True)
+    if  isinstance(base, Number) and isinstance(exp, Number):
+        return base**exp
+    else:
+        raise TypeError('types (%s, %s) not supported' % (str(type(base)), str(type(exp))))

--- a/src/operator/elementwise_binary_op.cc
+++ b/src/operator/elementwise_binary_op.cc
@@ -26,6 +26,8 @@ MXNET_REGISTER_OP_PROPERTY(_Mul, ElementWiseBinaryOpProp<mshadow::op::mul>)
 .describe("Perform an elementwise mul.");
 MXNET_REGISTER_OP_PROPERTY(_Div, ElementWiseBinaryOpProp<mshadow::op::div>)
 .describe("Perform an elementwise div.");
+MXNET_REGISTER_OP_PROPERTY(_Power, ElementWiseBinaryOpProp<mshadow_op::power>)
+.describe("Perform an elementwise power.");
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/elementwise_binary_scalar_op.cc
+++ b/src/operator/elementwise_binary_scalar_op.cc
@@ -38,5 +38,10 @@ MXNET_REGISTER_OP_PROPERTY(_DivScalar, ElementwiseBinaryScalarOpProp<mshadow::op
 .add_argument("array", "Symbol", "Input array operand to the operation.")
 .add_arguments(ScalarOpParam::__FIELDS__());
 
+MXNET_REGISTER_OP_PROPERTY(_PowerScalar, ElementwiseBinaryScalarOpProp<mshadow_op::power>)
+.describe("Perform an elementwise power.")
+.add_argument("array", "Symbol", "Input array operand to the operation.")
+.add_arguments(ScalarOpParam::__FIELDS__());
+
 }  // namespace op
 }  // namespace mxnet


### PR DESCRIPTION
This commit adds 2 operators:` _Power` and `_ScalarPower`.

To use this in python one can either user `a**b` or `mx.sym.pow(a, b)`.

There were some decisions I had to make that I wasn't quite sure from a design perspective were the right thing to do (adding a custom pow method in python that picks which op to use for example). 

First commit, so please let me know what terrible things I am doing.
