### PR TITLE
Add multi-label usage and fix num_round typo in API doc

### DIFF
--- a/doc/python/io.md
+++ b/doc/python/io.md
@@ -132,6 +132,34 @@ A sample command:
 ```
 More details can be found by running ```./bin/im2rec```.
 
+### Extension: Mutliple Labels for a Single Image
+
+The `im2rec` tool and `mx.io.ImageRecordIter` also has a mutli-label support for a single image.
+Assume you have 4 labels for a single image, you can take the following steps to utilize the RecordIO tools.
+
+1. Write the the image list files as follows:
+```
+integer_image_index \t label_1 \t label_2 \t label_3 \t label_4 \t path_to_image
+```
+
+2. When use `im2rec` tools, add a 'label_width=4' to the command argument, e.g.
+```bash
+./bin/im2rec image.lst image_root_dir output.bin resize=256 label_width=4
+```
+
+3. In your iterator generation code, set `label_width=4` and `path_imglist=<<The PATH TO YOUR image.lst>>`, e.g.
+
+```python
+dataiter = mx.io.ImageRecordIter(
+  path_imgrec="data/cifar/train.rec",
+  data_shape=(3,28,28),
+  path_imglist="data/cifar/image.lst",
+  label_width=4
+)
+```
+
+Then you're all set for a multi-label image iterator.
+
 IO API Reference
 ----------------
 

--- a/doc/python/model.md
+++ b/doc/python/model.md
@@ -28,7 +28,7 @@ softmax = mx.symbol.SoftmaxOutput(fc2, name='sm')
 model = mx.model.FeedForward.create(
      softmax,
      X=data_set,
-     num_round=num_round,
+     num_epoch=num_epoch,
      learning_rate=0.01)
 ```
 You can also use scikit-learn style construct and fit function to create a model.
@@ -36,7 +36,7 @@ You can also use scikit-learn style construct and fit function to create a model
 # create a model using sklearn-style two step way
 model = mx.model.FeedForward.create(
      softmax,
-     num_round=num_round,
+     num_epoch=num_epoch,
      learning_rate=0.01)
 
 mode.fit(X=data_set)


### PR DESCRIPTION
As required, doc the multi-label usage. 


Also I fixed some `num_round` typos in `model.md`.