### PR TITLE
[WIP/RFC] Asynchronous native operators

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -51,7 +51,8 @@ typedef void *RecordIOHandle;
 
 MXNET_EXTERN_C {
 struct NativeOpInfo {
-  void (*forward)(int, float**, int*, unsigned**, int*, void*);
+  // in_size, in_data, out_size, out_data, payload, callback
+  void (*forward)(int, void**, int, void**, void*, const void*);
   void (*backward)(int, float**, int*, unsigned**, int*, void*);
   void (*infer_shape)(int, int*, unsigned**, void*);
   void (*list_outputs)(char***, void*);
@@ -64,6 +65,11 @@ struct NativeOpInfo {
   void* p_list_arguments;
 };
 }
+/*!
+ *
+ */
+MXNET_DLL int MXInvokeOpCallback(void *handle);
+
 /*!
  * \brief return str message of the last error
  *  all function in this file will return 0 when success

--- a/include/mxnet/operator.h
+++ b/include/mxnet/operator.h
@@ -46,6 +46,8 @@ struct OpContext {
   int is_train;
   /*! \brief RunContext related resources */
   RunContext run_ctx;
+  /*! Context the operator is running on.*/
+  Context ctx;
   /*! \brief the callback when operation completes, used by asynchronize ops */
   engine::CallbackOnComplete async_on_complete;
   /*! \brief Resources requested by the operator */

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1080,3 +1080,9 @@ int MXRecordIOReaderReadRecord(RecordIOHandle *handle,
   *size = context->read_buff->size();
   API_END();
 }
+
+int MXInvokeOpCallback(void *handle) {
+  API_BEGIN();
+  (static_cast<OpContext*>(handle))->async_on_complete();
+  API_END();
+}

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -223,6 +223,8 @@ GraphExecutor::GetOpExecEntry(uint32_t nid) {
 
   Operator* op = op_node.op.get();
   OpContext* op_ctx_ptr = &op_node.op_ctx;
+  // Set device context
+  op_ctx_ptr->ctx = op_node.ctx;
   bool is_gpu = op_node.ctx.dev_mask() == gpu::kDevMask;
   bool is_async = op->exec_type() == Operator::kAsync;
   exec.exec_fun = [op, is_gpu, is_async, op_ctx_ptr, in_array, req, out_array, aux_array]


### PR DESCRIPTION
This is by no means done yet, but I would like some early feedback :) I also don't expect this code to work in its current state. For me it is a rough draft of how I think things might work

Currently NativeOps creates a copy of the input/output data and then synchronizes the TBlobs afterwards. That is problematic for asynchronous operation, since in Julia `ctx.async_on_complete` needs to be called from the Julia side of the code and there can't be any operations afterwards.

## Questions:
- Is it allowed to create NDArrays like this [https://github.com/vchuravy/mxnet/blob/65409a1f6753f04239443c5011f4c40907a31d13/src/operator/native_op-inl.h#L57] ? Passing handel to NDArrays to Python and Julia makes things easier.
- Currently `ctx.async_on_complete` is an object with a member function `operator()` getting a function pointer to a member function is quite tricky, any other ideas how we could handle this elegantly?

CC: @piiswrong 
Ref: https://github.com/dmlc/MXNet.jl/pull/16