### PR TITLE
[EXECUTOR] Enable multiple device in one graph, beta of model parallel

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -689,6 +689,42 @@ MXNET_DLL int MXExecutorBind(SymbolHandle symbol_handle,
                              NDArrayHandle *aux_states,
                              ExecutorHandle *out);
 
+/*!
+ * \brief Generate Executor from symbol,
+ *  This is advanced function, allow specify group2ctx map.
+ *  The user can annotate "ctx_group" attribute to name each group.
+ *
+ * \param symbol_handle symbol handle
+ * \param dev_type device type of default context
+ * \param dev_id device id of default context
+ * \param num_map_keys size of group2ctx map
+ * \param map_keys keys of group2ctx map
+ * \param map_dev_types device type of group2ctx map
+ * \param map_dev_ids device id of group2ctx map
+ * \param len length
+ * \param in_args in args array
+ * \param arg_grad_store arg grads handle array
+ * \param grad_req_type grad req array
+ * \param aux_states_len length of auxiliary states
+ * \param aux_states auxiliary states array
+ * \param out output executor handle
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXExecutorBindX(SymbolHandle symbol_handle,
+                              int dev_type,
+                              int dev_id,
+                              mx_uint num_map_keys,
+                              const char** map_keys,
+                              const int* map_dev_types,
+                              const int* map_dev_ids,
+                              mx_uint len,
+                              NDArrayHandle *in_args,
+                              NDArrayHandle *arg_grad_store,
+                              mx_uint *grad_req_type,
+                              mx_uint aux_states_len,
+                              NDArrayHandle *aux_states,
+                              ExecutorHandle *out);
+
 //--------------------------------------------
 // Part 5: IO Interface
 //--------------------------------------------

--- a/include/mxnet/operator.h
+++ b/include/mxnet/operator.h
@@ -83,7 +83,14 @@ class Operator {
      * \brief Forward/Backward are asynchronize,
      *  will call OpContext.async_on_complete when operation finishes.
      */
-    kAsync
+    kAsync,
+    /*!
+     * \brief Cross device copy operation, this is a special operator
+     *  That indicates copy across devices, the input and output can sit on different device.
+     *  In current implementation, copy operator is specially handled by executor.
+     *  This flag is used for special case treatment and future extension of different copy ops.
+     */
+    kCrossDeviceCopy
   };
   /*! \brief destructor */
   virtual ~Operator() {}

--- a/include/mxnet/symbolic.h
+++ b/include/mxnet/symbolic.h
@@ -294,7 +294,8 @@ class Executor {
    * \brief Create an operator by bind symbol with context and arguments.
    *  If user do not want to compute the gradients of i-th argument, grad_req_type[i] can be kNullOp.
    *
-   * \param ctx the context of binding.
+   * \param default_ctx the default context of binding.
+   * \param group2ctx Context mapping group to context.
    * \param symbol the symbol that specifies the output of Forward pass.
    * \param in_args the NDArray that stores the input arguments to the symbol.
    * \param arg_grad_store NDArray that is used to store the gradient output of the input arguments.
@@ -303,7 +304,8 @@ class Executor {
    * \return a new executor.
    */
   static Executor *Bind(Symbol symbol,
-                        Context ctx,
+                        const Context& default_ctx,
+                        const std::map<std::string, Context>& group2ctx,
                         const std::vector<NDArray> &in_args,
                         const std::vector<NDArray> &arg_grad_store,
                         const std::vector<OpReqType> &grad_req_type,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -768,9 +768,35 @@ int MXExecutorBind(SymbolHandle symbol_handle,
                    mx_uint aux_states_len,
                    NDArrayHandle *aux_states,
                    ExecutorHandle *out) {
+  return MXExecutorBindX(symbol_handle,
+                         dev_type, dev_id,
+                         0, nullptr, nullptr, nullptr,
+                         len, in_args, arg_grad_store, grad_req_type,
+                         aux_states_len, aux_states, out);
+}
+
+int MXExecutorBindX(SymbolHandle symbol_handle,
+                    int dev_type,
+                    int dev_id,
+                    mx_uint num_map_keys,
+                    const char** map_keys,
+                    const int* map_dev_types,
+                    const int* map_dev_ids,
+                    mx_uint len,
+                    NDArrayHandle *in_args,
+                    NDArrayHandle *arg_grad_store,
+                    mx_uint *grad_req_type,
+                    mx_uint aux_states_len,
+                    NDArrayHandle *aux_states,
+                    ExecutorHandle *out) {
   API_BEGIN();
   Symbol *symb = static_cast<Symbol*>(symbol_handle);
   Context ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id);
+  std::map<std::string, Context> ctx_map;
+  for (mx_uint i = 0; i < num_map_keys; ++i) {
+    ctx_map[std::string(map_keys[i])] = Context::Create(
+        static_cast<Context::DeviceType>(map_dev_types[i]), map_dev_ids[i]);
+  }
   NDArray **in_args_ptr = reinterpret_cast<NDArray**>(in_args);
   NDArray **arg_grad_ptr = reinterpret_cast<NDArray**>(arg_grad_store);
   NDArray **aux_states_ptr = reinterpret_cast<NDArray**>(aux_states);
@@ -791,7 +817,8 @@ int MXExecutorBind(SymbolHandle symbol_handle,
   for (mx_uint i = 0; i < aux_states_len; ++i) {
     aux_states_vec.push_back(*(aux_states_ptr[i]));
   }
-  *out = Executor::Bind(*symb, ctx, in_args_vec, arg_grad_vec, grad_req_vec, aux_states_vec);
+  *out = Executor::Bind(*symb, ctx, ctx_map, in_args_vec,
+                        arg_grad_vec, grad_req_vec, aux_states_vec);
   API_END();
 }
 

--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -117,9 +117,11 @@ int MXPredCreate(const char* symbol_json_str,
   ret->arg_arrays = arg_arrays;
   // bind
   {
+    std::map<std::string, Context> ctx_map;
     std::vector<NDArray> grad_store(arg_arrays.size());
     std::vector<OpReqType> grad_req(arg_arrays.size(), kNullOp);
-    ret->exec.reset(Executor::Bind(sym, ctx, arg_arrays,
+    ret->exec.reset(Executor::Bind(sym, ctx, ctx_map,
+                                   arg_arrays,
                                    grad_store, grad_req,
                                    aux_arrays));
     ret->out_arrays = ret->exec->outputs();

--- a/src/operator/cross_device_copy.cc
+++ b/src/operator/cross_device_copy.cc
@@ -1,0 +1,67 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file cross_device_copy.cc
+ * \brief Special operator that copys NDArray
+*/
+#include <dmlc/logging.h>
+#include <mxnet/operator.h>
+
+namespace mxnet {
+namespace op {
+
+class CrossDeviceCopyOp : public Operator {
+ public:
+  void Forward(const OpContext &ctx,
+               const std::vector<TBlob> &in_data,
+               const std::vector<OpReqType> &req,
+               const std::vector<TBlob> &out_data,
+               const std::vector<TBlob> &aux_args) override {
+    // CrossDeviceCopy is specially handled by graph executor,
+    // We still re-use things such as InferShape in OperatorProperty
+    LOG(FATAL) << "Not Reached";
+  }
+
+  ExecType exec_type() const override {
+    // TODO(tianqi) Think of other way to blend cross device op into operator interface.
+    // declare the op as cross device,
+    return kCrossDeviceCopy;
+  }
+};
+
+class CrossDeviceCopyProp : public OperatorProperty {
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return std::map<std::string, std::string>();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    CHECK_EQ(in_shape->size(), 1) << "Input:[data]";
+    const TShape &dshape = in_shape->at(0);
+    if (dshape.ndim() == 0) return false;
+    out_shape->clear();
+    out_shape->push_back(dshape);
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    return new CrossDeviceCopyProp();
+  }
+
+  std::string TypeString() const override {
+    return "_CrossDeviceCopy";
+  }
+
+  Operator* CreateOperator(Context ctx) const override {
+    return new CrossDeviceCopyOp();
+  }
+};
+
+
+MXNET_REGISTER_OP_PROPERTY(_CrossDeviceCopy, CrossDeviceCopyProp)
+.describe("Special op to copy data cross device");
+}  // namespace op
+}  // namespace mxnet

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -74,7 +74,7 @@ Storage::Handle StorageImpl::Alloc(size_t size, Context ctx) {
             ptr = new CurrentStorageManager<storage::GPUDeviceStorage>();
             break;
           }
-          default: LOG(FATAL) <<  "Unimplemented device";
+          default: LOG(FATAL) <<  "Unimplemented device " << ctx.dev_type;
         }
         return ptr;
       });

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -268,31 +268,170 @@ GraphExecutor::~GraphExecutor() {
   }
 }
 
-void GraphExecutor::InitGraph(const Symbol &symbol, Context ctx, bool need_backward) {
+void GraphExecutor::InitGraph(const Symbol &symbol,
+                              const Context& default_ctx,
+                              const std::map<std::string, Context>& ctx_map,
+                              const std::vector<NDArray> &in_args,
+                              const std::vector<NDArray> &arg_grad_store,
+                              const std::vector<OpReqType> &grad_req_type,
+                              bool need_backward) {
   // initialize all internal data structures
   graph_.FromSymbol(symbol);
-  num_forward_nodes_  = graph_.nodes.size();
   if (need_backward) {
     graph_.MakeBackwardPass(&head_grad_nodes_, &arg_grads_);
   }
-  // reorganize so backward node always follow forward
-  // note that this may not be the case, because existence of head_grad_nodes
+  // assign context, this will change the graph.
+  std::vector<Context> ctx_assignment;
+  this->AssignContext(default_ctx, ctx_map,
+                      in_args, arg_grad_store, grad_req_type,
+                      &ctx_assignment);
+
+  // organize topo order so that backward node always falls after forward.
+  std::vector<uint32_t> head_nodes;
+  for (const auto& head : graph_.heads) {
+    head_nodes.push_back(head.source_id);
+  }
+  std::sort(head_nodes.begin(), head_nodes.end());
+  head_nodes.resize(std::unique(head_nodes.begin(), head_nodes.end()) - head_nodes.begin());
+  std::vector<uint32_t> fwd_nodes = graph_.PostDFSOrder(head_nodes);
+  std::unordered_set<uint32_t> fwd_set(fwd_nodes.begin(), fwd_nodes.end());
   std::vector<uint32_t> topo = graph_.TopoSort();
   std::vector<uint32_t>  backward;
   for (uint32_t nid : topo) {
-    if (nid < num_forward_nodes_) {
+    if (fwd_set.count(nid) != 0) {
       topo_order_.push_back(nid);
     } else {
       backward.push_back(nid);
     }
   }
+  num_forward_nodes_ = fwd_nodes.size();
   topo_order_.insert(topo_order_.end(), backward.begin(), backward.end());
+
   // setup all the operator nodes data structure
   op_nodes_.resize(graph_.nodes.size());
   for (size_t i = 0; i < graph_.nodes.size(); ++i) {
-    op_nodes_[i].ctx = ctx;
+    op_nodes_[i].ctx = ctx_assignment[i];
     op_nodes_[i].outputs.resize(GetNumOutputs(i));
   }
+}
+
+void GraphExecutor::AssignContext(const Context default_ctx,
+                                  const std::map<std::string, Context>& ctx_map,
+                                  const std::vector<NDArray> &in_args,
+                                  const std::vector<NDArray> &arg_grad_store,
+                                  const std::vector<OpReqType> &grad_req_type,
+                                  std::vector<Context> *ctx_plan) {
+  ctx_plan->resize(graph_.nodes.size());
+  std::vector<bool> assigned(graph_.nodes.size(), false);
+  // assign context of node to the binded version
+  for (size_t i = 0; i < graph_.arg_nodes.size(); ++i) {
+    uint32_t nid = graph_.arg_nodes[i];
+    assigned[nid] = true;
+    ctx_plan->at(nid) = in_args[i].ctx();
+  }
+  if (arg_grads_.size() != 0) {
+    for (size_t i = 0; i < arg_grads_.size(); ++i) {
+      if (grad_req_type[i] == kNullOp) continue;
+      auto& e = arg_grads_[i];
+      if (!assigned[e.source_id]) {
+        assigned[e.source_id] = true;
+        ctx_plan->at(e.source_id) = arg_grad_store[i].ctx();
+      } else {
+        CHECK(ctx_plan->at(e.source_id) == arg_grad_store[i].ctx())
+            << "Inconsistent gradient context requirment";
+      }
+    }
+  }
+
+  // topological sort
+  std::vector<uint32_t> topo = graph_.TopoSort();
+  // forward prop
+  for (uint32_t nid : topo) {
+    if (assigned[nid]) continue;
+    auto it = graph_.nodes[nid].attr.find("ctx_group");
+    if (it != graph_.nodes[nid].attr.end()) {
+      const std::string& group = it->second;
+      if (ctx_map.count(group) != 0) {
+        assigned[nid] = true;
+        ctx_plan->at(nid) = ctx_map.at(group);
+      } else {
+        CHECK(ctx_map.size() == 0)
+            << "Context for group " << group << " is not provided in group2ctx map";
+      }
+    }
+    if (assigned[nid]) continue;
+    const StaticGraph::Node& node = graph_.nodes[nid];
+    if (node.is_backward() && assigned[node.backward_source_id]) {
+      ctx_plan->at(nid) = ctx_plan->at(node.backward_source_id);
+      assigned[nid] = true;
+      continue;
+    }
+    for (const StaticGraph::DataEntry& e : node.inputs) {
+      if (assigned[e.source_id]) {
+        ctx_plan->at(nid) = ctx_plan->at(e.source_id);
+        assigned[nid] = true;
+        break;
+      }
+    }
+  }
+  for (size_t i = 0; i < head_grad_nodes_.size(); ++i) {
+    auto& e = graph_.heads[i];
+    uint32_t nid = head_grad_nodes_[i];
+    if (assigned[e.source_id]) {
+      ctx_plan->at(nid) = ctx_plan->at(e.source_id);
+      assigned[nid] = true;
+    }
+  }
+  // backward prop
+  for (auto it = topo.rbegin(); it != topo.rend(); ++it) {
+    const uint32_t nid = *it;
+    if (!assigned[nid]) continue;
+    for (const StaticGraph::DataEntry& e : graph_.nodes[nid].inputs) {
+      if (!assigned[e.source_id]) {
+        ctx_plan->at(e.source_id) = ctx_plan->at(nid);
+        assigned[nid] = true;
+      }
+    }
+  }
+  // assign rest to default context
+  for (uint32_t nid : topo) {
+    if (!assigned[nid]) ctx_plan->at(nid) = default_ctx;
+  }
+  // make sure head gradient is consitent with final operator
+  for (size_t i = 0; i < head_grad_nodes_.size(); ++i) {
+    auto& e = graph_.heads[i];
+    uint32_t nid = head_grad_nodes_[i];
+    ctx_plan->at(nid) = ctx_plan->at(e.source_id);
+  }
+  // automatically create copy node
+  std::map<StaticGraph::DataEntry, std::map<Context, uint32_t> > copy_node;
+  std::vector<StaticGraph::Node> new_nodes;
+
+  for (uint32_t nid : topo) {
+    Context curr_ctx = ctx_plan->at(nid);
+    for (StaticGraph::DataEntry& e : graph_.nodes[nid].inputs) {
+      if (ctx_plan->at(e.source_id) == curr_ctx) continue;
+
+      // create copy node
+      std::map<Context, uint32_t>& rmap = copy_node[e];
+      if (rmap.count(curr_ctx) == 0) {
+        uint32_t new_node_id = static_cast<uint32_t>(graph_.nodes.size() + new_nodes.size());
+        // add a new node
+        StaticGraph::Node new_node = StaticGraph::CreateCopyNode(e);
+        std::ostringstream os;
+        os << graph_.nodes[e.source_id].name << '_' << e.index << "_copynode";
+        new_node.name = os.str();
+        new_nodes.push_back(new_node);
+        rmap[curr_ctx] = new_node_id;
+        ctx_plan->push_back(curr_ctx);
+        CHECK_EQ(ctx_plan->size(), new_node_id + 1);
+      }
+      // muttate e
+      e = StaticGraph::DataEntry(rmap[curr_ctx], 0);
+    }
+  }
+  graph_.nodes.insert(graph_.nodes.end(), new_nodes.begin(), new_nodes.end());
+  CHECK_EQ(graph_.nodes.size(), ctx_plan->size());
 }
 
 void GraphExecutor::InitDataEntryInfo(const std::vector<NDArray> &in_args,
@@ -306,6 +445,8 @@ void GraphExecutor::InitDataEntryInfo(const std::vector<NDArray> &in_args,
     DataEntryInfo &info = op_nodes_[graph_.arg_nodes[i]].outputs[0];
     info.type = kBindByExternal;
     info.data = in_args[i];
+    CHECK(info.data.ctx() == op_nodes_[graph_.arg_nodes[i]].ctx)
+        << "Argument NDArray's context must match the operator's context assignment";
   }
   // setup ref for head nodes
   for (StaticGraph::DataEntry e : graph_.heads) {
@@ -327,6 +468,8 @@ void GraphExecutor::InitDataEntryInfo(const std::vector<NDArray> &in_args,
       info.type = kBindByExternal;
       info.op_req = grad_req_type[i];
       info.data = arg_grad_store[i];
+      CHECK(info.data.ctx() == op_nodes_[grad_source.source_id].ctx)
+          << "Gradient holder NDArray's context must match the operator's context assignment";
       ++info.ref_count;
       op_nodes_[grad_source.source_id].activated = true;
     }
@@ -347,7 +490,6 @@ void GraphExecutor::InitDataEntryInfo(const std::vector<NDArray> &in_args,
       }
     }
   }
-
   // shape inference
   std::vector<std::vector<TShape> > out_shapes(op_nodes_.size());
   std::vector<std::vector<TShape> > aux_shapes(op_nodes_.size());
@@ -374,6 +516,8 @@ void GraphExecutor::InitDataEntryInfo(const std::vector<NDArray> &in_args,
       info.type = kBindByExternal;
       if (graph_.nodes[i].backward_source_id == -1) {
         info.data = aux_states[aux_ndarray_idx++];
+        CHECK(info.data.ctx() == op_nodes_[i].ctx)
+            << "Auxiliary NDArray's context must match the operator's context assignment";
       } else {
         CHECK_NE(graph_.nodes[i].backward_source_id, -1)
           << "Input auxiliary NDArray is less than required";
@@ -567,7 +711,7 @@ void GraphExecutor::InitOpNodes() {
     for (DataEntryInfo& info : op_node.outputs) {
       if (info.type == kTobeBindByExternal) allow_cache = false;
     }
-    if (allow_cache) {
+    if (allow_cache && op_node.op->exec_type() != Operator::kCrossDeviceCopy) {
       op_node.cached_exec = GetOpExecEntry(nid);
       op_node.cached_opr = Engine::Get()->NewOperator(
           op_node.cached_exec.exec_fun,
@@ -584,6 +728,15 @@ void GraphExecutor::RunOps(bool is_train, size_t topo_start, size_t topo_end) {
     if (!op_nodes_[nid].activated) continue;
     if (graph_.nodes[nid].is_variable()) continue;
     OpNode& opnode = op_nodes_[nid];
+    // special handle cross device copy op
+    if (opnode.op->exec_type() == Operator::kCrossDeviceCopy) {
+      CHECK_EQ(graph_.nodes[nid].inputs.size(), 1);
+      CHECK_EQ(opnode.outputs.size(), 1);
+      auto in = graph_.nodes[nid].inputs[0];
+      CopyFromTo(op_nodes_[in.source_id].outputs[in.index].data,
+                 &(opnode.outputs[0].data));
+      continue;
+    }
     opnode.op_ctx.is_train = is_train;
     if (opnode.cached_opr != nullptr) {
       Engine::Get()->Push(opnode.cached_opr, opnode.ctx);
@@ -604,7 +757,10 @@ void GraphExecutor::Print(std::ostream &os) const {
   for (size_t i = 0; i < topo_order_.size(); ++i) {
     uint32_t nid = topo_order_[i];
     if (!op_nodes_[nid].activated) continue;
-    os << "Op " << i << ":" << graph_.nodes[nid].name << '\n';
+    os << "Op " << i << ":" << graph_.nodes[nid].name << " ctx=";
+    Context ctx = op_nodes_[nid].ctx;
+    os << (ctx.dev_mask() == cpu::kDevMask? "cpu" : "gpu");
+    os << '(' << ctx.dev_id << ")\n";
     for (size_t j = 0; j < op_nodes_[nid].outputs.size(); ++j) {
       const DataEntryInfo &info = op_nodes_[nid].outputs[j];
       os << "\toutput[" << j << "]: shape=" << info.shape;
@@ -645,6 +801,8 @@ void GraphExecutor::Backward(const std::vector<NDArray> &head_grads) {
       DataEntryInfo &info = op_nodes_[nid].outputs[0];
       CHECK_EQ(info.type, kTobeBindByExternal);
       info.data = head_grads[i];
+      CHECK(op_nodes_[nid].ctx == head_grads[i].ctx())
+          << "Head Gradient context do not match the context of output op";
     }
   } else {
     // check all the head_grad_nodes need to have zero ref_count
@@ -661,13 +819,15 @@ void GraphExecutor::Backward(const std::vector<NDArray> &head_grads) {
 }
 
 Executor *Executor::Bind(Symbol symbol,
-                         Context ctx,
+                         const Context& default_ctx,
+                        const std::map<std::string, Context>& group2ctx,
                          const std::vector<NDArray> &in_args,
                          const std::vector<NDArray> &arg_grad_store,
                          const std::vector<OpReqType> &grad_req_type,
                          const std::vector<NDArray> &aux_states) {
   GraphExecutor *exec = new GraphExecutor();
-  exec->Init(symbol, ctx, in_args, arg_grad_store, grad_req_type, aux_states);
+  exec->Init(symbol, default_ctx, group2ctx,
+             in_args, arg_grad_store, grad_req_type, aux_states);
   return exec;
 }
 }  // namespace mxnet

--- a/src/symbol/static_graph.h
+++ b/src/symbol/static_graph.h
@@ -176,6 +176,13 @@ class StaticGraph {
    */
   std::vector<uint32_t> TopoSort() const;
   /*!
+   * \brief Get a post DFS order traversal order from the head nodes.
+   *  Post DFS order is a special case of Topological order.
+   * \param heads The head of the node.
+   * \return a post DFS visit order of nodes that can reach heads.
+   */
+  std::vector<uint32_t> PostDFSOrder(const std::vector<uint32_t>& head_nodes) const;
+  /*!
    * \brief infer the node shapes in the computation graph.
    *
    *  When calling this function, user can setup the shape information known into right position.
@@ -222,6 +229,7 @@ class StaticGraph {
    */
   void MakeBackwardPass(std::vector<uint32_t> *head_grad_nodes,
                         std::vector<DataEntry> *arg_grads);
+
   /*!
    * \brief Convert symbol into static graph.
    * \param symbol the symbol to convert from.
@@ -235,6 +243,12 @@ class StaticGraph {
    * \return a created ElementWiseSum node
    */
   static Node CreateSumNode(const std::vector<DataEntry> &grad_source);
+  /*!
+   * \brief create a copy node.
+   * \param source the Source data
+   * \return a created _CrossDeviceCopy node
+   */
+  static Node CreateCopyNode(const DataEntry& source);
 };
 }  // namespace mxnet
 

--- a/tests/python/unittest/test_model_parallel.py
+++ b/tests/python/unittest/test_model_parallel.py
@@ -1,0 +1,54 @@
+import numpy as np
+import mxnet as mx
+
+def reldiff(a, b):
+    diff = np.sum(np.abs(a - b))
+    norm = np.sum(np.abs(a))
+    if diff == 0:
+        return 0
+    reldiff = diff  / norm
+    return reldiff
+
+def test_chain():
+    n = 2
+    data1 = mx.sym.Variable('data1')
+    data2 = mx.sym.Variable('data2')
+    with mx.AttrScope(ctx_group='dev1'):
+        net = data1 + data2
+        net = net * 3
+
+    with mx.AttrScope(ctx_group='dev2'):
+        net = net + data1
+
+    with mx.Context(mx.cpu(0)):
+        shape = (4, 5)
+        arr = [mx.nd.empty(shape) for i in range(n)]
+        arr_grad = [mx.nd.empty(shape) for i in range(n)]
+
+    exec1 = net.bind(mx.cpu(),
+                     args=arr,
+                     args_grad=arr_grad,
+                     group2ctx={'dev1': mx.cpu(0), 'dev2': mx.cpu(1)})
+    arr[0][:] = 1.0
+    arr[1][:] = 2.0
+    arr2 = [a.copyto(mx.cpu()) for a in arr]
+    arr_grad2 = [a.copyto(mx.cpu()) for a in arr_grad]
+    exec2 = net.bind(mx.cpu(),
+                     args=arr2,
+                     args_grad=arr_grad2)
+
+    # Show the execution plan that involves copynode
+    print(exec1.debug_str())
+    exec1.forward()
+    exec2.forward()
+    assert reldiff(exec1.outputs[0].asnumpy(), exec2.outputs[0].asnumpy()) < 1e-6
+    out_grad = mx.nd.empty(shape, mx.cpu(1))
+    out_grad[:] = 1.0
+    exec1.backward([out_grad])
+    exec2.backward([out_grad.copyto(mx.cpu())])
+    for a, b in zip(arr_grad, arr_grad2):
+        assert reldiff(a.asnumpy(), b.asnumpy()) < 1e-6
+
+
+if __name__ == '__main__':
+    test_chain()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -415,28 +415,28 @@ def test_binary_op_duplicate_input():
 
 def test_abs():
     data = mx.symbol.Variable('data')
-    shape = (3, 4)    
+    shape = (3, 4)
     data_tmp = np.ones(shape)
     data_tmp[:]=5
     arr_data = mx.nd.array(data_tmp)
-    arr_grad = mx.nd.empty(shape) 
+    arr_grad = mx.nd.empty(shape)
     arr_grad[:]=3
-    
+
     test = mx.sym.abs(data)
     exe_test = test.bind(mx.cpu(), args=[arr_data], args_grad=[arr_grad])
     exe_test.forward()
     out = exe_test.outputs[0].asnumpy()
     npout = abs(data_tmp)
     assert reldiff(out, npout) < 1e-6
-    
+
     out_grad = mx.nd.empty(shape)
     out_grad[:] = 2;
     npout_grad = out_grad.asnumpy()
     npout_grad = npout_grad * np.sign(data_tmp)
     exe_test.backward(out_grad)
     assert reldiff(arr_grad.asnumpy(), npout_grad) < 1e-6
-    
-if __name__ == '__main__': 
+
+if __name__ == '__main__':
     test_binary_op_duplicate_input()
     test_elementwise_sum()
     test_concat()


### PR DESCRIPTION
- The user can annotate a ```ctx_group``` property on each of the operator
- During bind, a ```group2ctx``` map can be provided to specify mapping from group to device.
- Copy node is automatically inserted.

Tested on CPU, hope someone can take over to test on GPU and do model parallel tests on cases such as LSTM.