### PR TITLE
fixes workspace being bigger than anticipated

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -240,8 +240,11 @@ class ConvolutionOp : public Operator {
                                      param_.num_filter / param_.num_group,
                                      oshape[2] * oshape[3]);
     const uint64_t workspace_size = param_.workspace;  // In elements of sizeof(real_t)
-    index_t nstep = std::max(std::min(static_cast<index_t>(workspace_size / shape_colunit_.Size()),
-                                      ishape[0]), 1U);
+    index_t nstep = std::max(
+        std::min(
+          static_cast<index_t>(workspace_size / (shape_colunit_.Size() + shape_dstunit_.Size())),
+          ishape[0]),
+        1U);
     index_t nop = (ishape[0] + nstep - 1) / nstep;
     nstep_ = (ishape[0] + nop - 1) / nop;
 


### PR DESCRIPTION
The workspace required is calculated in the end as `shape_colunit_.Size() * nstep_ + shape_dstunit_.Size() * nstep_` in order to stay within the memory requirements given by workspace `nstep` must be also calculated taking into account the memory requirement for `dstunit`.

Otherwise for large `shape_dstunit_.Size()`, the code would underestimate the memory requirements for `dstunit`.

This might now be to conservative. @antinucleon You wrote the original code, what do you think?