### PR TITLE
Enable scikit-learn cloning by passing memo parameter to __deepcopy__ method

### DIFF
--- a/python/mxnet/symbol.py
+++ b/python/mxnet/symbol.py
@@ -3,6 +3,7 @@
 """Symbolic configuration API of mxnet."""
 from __future__ import absolute_import
 
+import copy
 import ctypes
 from numbers import Number
 import sys
@@ -99,9 +100,9 @@ class Symbol(object):
         check_call(_LIB.MXSymbolFree(self.handle))
 
     def __copy__(self):
-        return self.__deepcopy__()
+        return copy.deepcopy(self)
 
-    def __deepcopy__(self):
+    def __deepcopy__(self, _):
         handle = SymbolHandle()
         check_call(_LIB.MXSymbolCopy(self.handle,
                                      ctypes.byref(handle)))
@@ -137,7 +138,7 @@ class Symbol(object):
         -------
         the resulting symbol
         """
-        s = self.__deepcopy__()
+        s = copy.deepcopy(self)
         s._compose(*args, **kwargs)
         return s
 

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import mxnet as mx
 from common import models
@@ -29,6 +30,13 @@ def test_symbol_compose():
     multi_out = mx.symbol.Group([composed, net1])
     assert len(multi_out.list_outputs()) == 2
 
+
+def test_symbol_copy():
+    data = mx.symbol.Variable('data')
+    data_2 = copy.deepcopy(data)
+    data_3 = copy.copy(data)
+    assert data.tojson() == data_2.tojson()
+    assert data.tojson() == data_3.tojson()
 
 
 def test_symbol_internal():


### PR DESCRIPTION
I was trying to use the `FeedForward` class as a drop-in replacement for some scikit learn estimators but noticed that cloning failed because the `Symbol.__deepcopy__`  method doesn't accept a `memo` parameter.

On master, running the following snipped produced the error message further down.
```python
from sklearn.datasets import load_boston
from sklearn.cross_validation import cross_val_score
import mxnet as mx
import numpy as np

np.random.seed(1)

boston = load_boston()
X, y = boston.data, boston.target

data = mx.symbol.Variable('data')
fc = mx.symbol.FullyConnected(data=data, num_hidden=32)
act = mx.symbol.Activation(data=fc, act_type='relu')
out = mx.symbol.FullyConnected(data=act, num_hidden=1)

# Just naming it softmax to avoid the following.
# mxnet.base.MXNetError: [22:29:37] src/symbol/symbol.cc:121: Symbol.InterShapeKeyword 
# argument name softmax_label not found.
lin = mx.symbol.LinearRegressionOutput(data=out, name='softmax')

mlp = mx.model.FeedForward(ctx=mx.cpu(), symbol=lin, num_epoch=10)

score = cross_val_score(mlp, X, y, scoring='mean_squared_error')
print(score)
```

```python
Traceback (most recent call last):
  File "clone_example.py", line 22, in <module>
    score = cross_val_score(mlp, X, y, scoring='mean_squared_error')
  File "/usr/lib/python2.7/site-packages/sklearn/cross_validation.py", line 1433, in cross_val_score
    for train, test in cv)
  File "/usr/lib/python2.7/site-packages/sklearn/externals/joblib/parallel.py", line 804, in __call__
    while self.dispatch_one_batch(iterator):
  File "/usr/lib/python2.7/site-packages/sklearn/externals/joblib/parallel.py", line 657, in dispatch_one_batch
    tasks = BatchedCalls(itertools.islice(iterator, batch_size))
  File "/usr/lib/python2.7/site-packages/sklearn/externals/joblib/parallel.py", line 68, in __init__
    self.items = list(iterator_slice)
  File "/usr/lib/python2.7/site-packages/sklearn/cross_validation.py", line 1433, in <genexpr>
    for train, test in cv)
  File "/usr/lib/python2.7/site-packages/sklearn/base.py", line 51, in clone
    new_object_params[name] = clone(param, safe=False)
  File "/usr/lib/python2.7/site-packages/sklearn/base.py", line 42, in clone
    return copy.deepcopy(estimator)
  File "/usr/lib64/python2.7/copy.py", line 174, in deepcopy
    y = copier(memo)
TypeError: __deepcopy__() takes exactly 1 argument (2 given)
```

I made a PR which seems to fix the issue with cloning for me, but I'm unfamiliar with mxnet so I'm not sure it's correct or wouldn't break anything else.