### PR TITLE
Add Random operator.

### DIFF
--- a/src/operator/random-inl.h
+++ b/src/operator/random-inl.h
@@ -1,0 +1,192 @@
+/*!
+ * \file random-inl.h
+ * \brief Symbolic layer for random number generation.
+ * \author Sebastian Nowozin
+*/
+
+#ifndef MXNET_OPERATOR_RANDOM_INL_H_
+#define MXNET_OPERATOR_RANDOM_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <algorithm>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "./operator_common.h"
+#include "./mshadow_op.h"
+
+#include <iostream>
+
+namespace random_enum {
+enum RandomOpOutputs { kOut };
+enum RandomOpType { kUniform, kGaussian };
+enum RandomOpForwardResource { kRandom };
+}  // namespace random_enum
+
+namespace mxnet {
+namespace op {
+
+struct RandomParam : public dmlc::Parameter<RandomParam> {
+  int num_output;
+  int random_type;
+  DMLC_DECLARE_PARAMETER(RandomParam) {
+    DMLC_DECLARE_FIELD(num_output).set_range(1, 1 << 30)
+    .describe("Number of output elements");
+    DMLC_DECLARE_FIELD(random_type)
+    .add_enum("uniform", random_enum::kUniform)
+    .add_enum("gaussian", random_enum::kGaussian)
+    .describe("Type of random numbers to generate");
+  }
+};  // struct RandomParam
+
+template<typename xpu>
+class RandomOp : public Operator {
+ public:
+  explicit RandomOp(RandomParam param) {
+    this->random_type_ = param.random_type;
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_states) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(out_data.size(), 1);
+
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    Tensor<xpu, 2> out = out_data[random_enum::kOut].FlatTo2D<xpu, real_t>(s);
+
+    Random<xpu> *prnd = ctx.requested[random_enum::kRandom].get_random<xpu>(s);
+    if (random_type_ == random_enum::kUniform) {
+       out = prnd->uniform(out.shape_);
+    } else if (random_type_ == random_enum::kGaussian) {
+       out = prnd->gaussian(out.shape_);
+    }
+	// Need Assign?
+    //Assign(out, req[random::kOut], data * mask);
+    //Assign(out, req[dropout::kOut], F<mshadow_op::identity>(data));
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_states) {
+    // No inputs and thus no gradient
+  }
+
+ private:
+  int random_type_;
+};  // class RandomOp
+
+
+template<typename xpu>
+Operator *CreateOp(RandomParam param);
+
+#if DMLC_USE_CXX11
+class RandomProp : public OperatorProperty {
+ public:
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    // XXX: how to do automatic shape inference here?
+    //
+    // Ideally we would like to avoid specifying the num_output value
+    // altogether and instead fill an arbitrary sized array.
+    // For example, the Random symbol may be useful to implement variational
+    // Bayes parameter learning and any parametrized layer knows the size of
+    // its parameter array.  It seems current shape inference is purely
+    // feedforward which does not allow us to "backpropagate" shape
+    // information from output.
+    //
+    // I would like to be able to write:
+    // if (out_shape->size() == 0) {
+    //   return false;
+    // } else {
+    //   // Nothing to do.
+    //   return true;
+    // }
+    //
+    // By making multiple passes over the symbolic graph all dependencies
+    // could be resolved if the next layer consuming the random output can
+    // provide shape information about its input.
+
+    SHAPE_ASSIGN_CHECK(*out_shape, random_enum::kOut, Shape1(param_.num_output));
+
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new RandomProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "Random";
+  }
+
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    return { };
+  }
+
+  std::vector<std::pair<int, void*> > BackwardInplaceOption(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data,
+    const std::vector<void*> &in_grad) const override {
+    return { };
+  }
+
+  std::vector<std::pair<int, void*> > ForwardInplaceOption(
+    const std::vector<int> &in_data,
+    const std::vector<void*> &out_data) const override {
+    return { };
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+    const std::vector<TShape> &in_shape) const override {
+    return { ResourceRequest::kRandom };
+  }
+
+  std::vector<std::string> ListArguments() const override {
+    return { };
+  }
+
+  int NumOutputs() const override {
+    return 1;
+  }
+
+  std::vector<std::string> ListOutputs() const override {
+    return {"output"};
+  }
+
+  Operator* CreateOperator(Context ctx) const override;
+
+ private:
+  RandomParam param_;
+};  // class RandomProp
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_RANDOM_INL_H_

--- a/src/operator/random-inl.h
+++ b/src/operator/random-inl.h
@@ -1,4 +1,5 @@
 /*!
+ * Copyright (c) 2015 by Contributors
  * \file random-inl.h
  * \brief Symbolic layer for random number generation.
  * \author Sebastian Nowozin
@@ -17,8 +18,6 @@
 #include <utility>
 #include "./operator_common.h"
 #include "./mshadow_op.h"
-
-#include <iostream>
 
 namespace random_enum {
 enum RandomOpOutputs { kOut };
@@ -67,9 +66,9 @@ class RandomOp : public Operator {
     } else if (random_type_ == random_enum::kGaussian) {
        out = prnd->gaussian(out.shape_);
     }
-	// Need Assign?
-    //Assign(out, req[random::kOut], data * mask);
-    //Assign(out, req[dropout::kOut], F<mshadow_op::identity>(data));
+    // Need Assign?
+    // Assign(out, req[random::kOut], data * mask);
+    // Assign(out, req[dropout::kOut], F<mshadow_op::identity>(data));
   }
 
   virtual void Backward(const OpContext &ctx,

--- a/src/operator/random-inl.h
+++ b/src/operator/random-inl.h
@@ -29,11 +29,11 @@ namespace mxnet {
 namespace op {
 
 struct RandomParam : public dmlc::Parameter<RandomParam> {
-  int num_output;
+  TShape target_shape;
   int random_type;
   DMLC_DECLARE_PARAMETER(RandomParam) {
-    DMLC_DECLARE_FIELD(num_output).set_range(1, 1 << 30)
-    .describe("Number of output elements");
+    DMLC_DECLARE_FIELD(target_shape)
+    .describe("Target shape");
     DMLC_DECLARE_FIELD(random_type)
     .add_enum("uniform", random_enum::kUniform)
     .add_enum("gaussian", random_enum::kGaussian)
@@ -103,31 +103,9 @@ class RandomProp : public OperatorProperty {
   bool InferShape(std::vector<TShape> *in_shape,
                   std::vector<TShape> *out_shape,
                   std::vector<TShape> *aux_shape) const override {
-    using namespace mshadow;
-    // XXX: how to do automatic shape inference here?
-    //
-    // Ideally we would like to avoid specifying the num_output value
-    // altogether and instead fill an arbitrary sized array.
-    // For example, the Random symbol may be useful to implement variational
-    // Bayes parameter learning and any parametrized layer knows the size of
-    // its parameter array.  It seems current shape inference is purely
-    // feedforward which does not allow us to "backpropagate" shape
-    // information from output.
-    //
-    // I would like to be able to write:
-    // if (out_shape->size() == 0) {
-    //   return false;
-    // } else {
-    //   // Nothing to do.
-    //   return true;
-    // }
-    //
-    // By making multiple passes over the symbolic graph all dependencies
-    // could be resolved if the next layer consuming the random output can
-    // provide shape information about its input.
-
-    SHAPE_ASSIGN_CHECK(*out_shape, random_enum::kOut, Shape1(param_.num_output));
-
+    // Automatic shape inference for operators without inputs is not supported
+    // yet, therefore the target_shape needs to be provided by the user.
+    SHAPE_ASSIGN_CHECK(*out_shape, random_enum::kOut, param_.target_shape);
     return true;
   }
 

--- a/src/operator/random-inl.h
+++ b/src/operator/random-inl.h
@@ -45,7 +45,6 @@ template<typename xpu>
 class RandomOp : public Operator {
  public:
   explicit RandomOp(RandomParam param) {
-    this->target_shape = param.target_shape;
     this->random_type_ = param.random_type;
   }
 

--- a/src/operator/random-inl.h
+++ b/src/operator/random-inl.h
@@ -45,6 +45,7 @@ template<typename xpu>
 class RandomOp : public Operator {
  public:
   explicit RandomOp(RandomParam param) {
+    this->target_shape = param.target_shape;
     this->random_type_ = param.random_type;
   }
 

--- a/src/operator/random.cc
+++ b/src/operator/random.cc
@@ -1,0 +1,30 @@
+/*!
+ * \file random.cc
+ * \brief
+ * \author Sebastian Nowozin
+*/
+
+#include "./random-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<cpu>(RandomParam param) {
+  return new RandomOp<cpu>(param);
+}
+
+// DO_BIND_DISPATCH comes from operator_common.h
+Operator *RandomProp::CreateOperator(Context ctx) const {
+  DO_BIND_DISPATCH(CreateOp, param_);
+}
+
+DMLC_REGISTER_PARAMETER(RandomParam);
+
+MXNET_REGISTER_OP_PROPERTY(Random, RandomProp)
+.describe("Generate random numbers")
+.add_arguments(RandomParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet
+
+

--- a/src/operator/random.cc
+++ b/src/operator/random.cc
@@ -1,4 +1,5 @@
 /*!
+ * Copyright (c) 2015 by Contributors
  * \file random.cc
  * \brief
  * \author Sebastian Nowozin

--- a/src/operator/random.cu
+++ b/src/operator/random.cu
@@ -1,0 +1,19 @@
+/*!
+ * \file random.cc
+ * \brief
+ * \author Sebastian Nowozin
+*/
+
+#include "./random-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<gpu>(RandomParam param) {
+  return new RandomOp<gpu>(param);
+}
+}  // namespace op
+}  // namespace mxnet
+
+
+

--- a/src/operator/random.cu
+++ b/src/operator/random.cu
@@ -1,4 +1,5 @@
 /*!
+ * Copyright (c) 2015 by Contributors
  * \file random.cc
  * \brief
  * \author Sebastian Nowozin


### PR DESCRIPTION
Add a symbolic operator for random number generation.

Only two types of random numbers are supported at the moment:
1. Uniform U(0,1) random numbers.
2. Normal N(0,1) random numbers.


### Example
To use it, you currently need to supply the `num_output` argument to specify the size of the output.
Here is an example Python code

```
import mxnet as mx

R = mx.sym.Random(num_output=32, random_type="gaussian")
A = mx.sym.Activation(data=R, act_type="relu")

A_exec = A.bind(ctx=mx.cpu(), args={})
A_exec.forward()
print A_exec.outputs[0].asnumpy()
```

### This PR may not be ready for merging yet, for the following reasons:
I have not found a way to do shape inference automatically because there are no inputs to this operator and the current `InferShape` interface seems to be purely feedforward.  I would appreciate any comment on how shape inference can be done automatically.

### Rationale for Random layer
I would like to use this operator for drawing random parameters of other layers, for example using `weights=R`, where `R` is a Random layer.  To make this convenient, in principle, the downstream layers (say, a fully connected layer) know the size of their parameter array and could "backpropagate" the shape information to the output of the Random layer, but this seems not supported by the InferShape interface at the moment.  See also the comment in the current `InferShape` implementation of the commit.