### PR TITLE
More info about CUDA in library requirements

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -35,7 +35,8 @@ The minimal building requirement is
 
 Optional libraries
 
-- CUDA to run on nvidia GPUs
+- `CUDA Toolkit >= v7.0` to run on nvidia GPUs
+  - Requires GPU with support for `Compute Capability >= 2.0`
 - CUDNN to accelerate the GPU computation (only CUDNN 3 is supported)
 - opencv for image augmentation
 


### PR DESCRIPTION
As an owner of an old GPU, I ran into trouble trying to compile the project with CUDA capability.
This project uses `nvrtc`, which has been available since CUDA Toolkit v7.0 and requires Compute Model 2.0 or greater (which my GPU does not support).