### PR TITLE
Add grad_scale parameter for RegressionOutput

### DIFF
--- a/src/operator/regression_output.cc
+++ b/src/operator/regression_output.cc
@@ -10,12 +10,13 @@ namespace mxnet {
 namespace op {
 
 template<>
-Operator *CreateRegressionOutputOp<cpu>(reg_enum::RegressionOutputType type) {
+Operator *CreateRegressionOutputOp<cpu>(reg_enum::RegressionOutputType type,
+                                        RegressionOutputParam param) {
   switch (type) {
     case reg_enum::kLinear:
-      return new RegressionOutputOp<cpu, mshadow::op::identity, mshadow::op::minus>();
+      return new RegressionOutputOp<cpu, mshadow::op::identity, mshadow::op::minus>(param);
     case reg_enum::kLogistic:
-      return new RegressionOutputOp<cpu, mshadow_op::sigmoid, mshadow::op::minus>();
+      return new RegressionOutputOp<cpu, mshadow_op::sigmoid, mshadow::op::minus>(param);
     default:
       LOG(FATAL) << "unknown activation type " << type;
   }
@@ -25,19 +26,24 @@ Operator *CreateRegressionOutputOp<cpu>(reg_enum::RegressionOutputType type) {
 // DO_BIND_DISPATCH comes from operator_common.h
 template<reg_enum::RegressionOutputType type>
 Operator *RegressionOutputProp<type>::CreateOperator(Context ctx) const {
-  DO_BIND_DISPATCH(CreateRegressionOutputOp, type);
+  DO_BIND_DISPATCH(CreateRegressionOutputOp, type, param_);
 }
+
+DMLC_REGISTER_PARAMETER(RegressionOutputParam);
 
 MXNET_REGISTER_OP_PROPERTY(LinearRegressionOutput, RegressionOutputProp<reg_enum::kLinear>)
 .describe("Use linear regression for final output, this is used on final output of a net.")
 .add_argument("data", "Symbol", "Input data to function.")
-.add_argument("label", "Symbol", "Input label to function.");
+.add_argument("label", "Symbol", "Input label to function.")
+.add_arguments(RegressionOutputParam::__FIELDS__());
 
 MXNET_REGISTER_OP_PROPERTY(LogisticRegressionOutput, RegressionOutputProp<reg_enum::kLogistic>)
 .describe("Use Logistic regression for final output, this is used on final output of a net.\n"
           "Logistic regression is suitable for binary classification "
           "or probability prediction tasks.")
 .add_argument("data", "Symbol", "Input data to function.")
-.add_argument("label", "Symbol", "Input label to function.");
+.add_argument("label", "Symbol", "Input label to function.")
+.add_arguments(RegressionOutputParam::__FIELDS__());
+
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/regression_output.cu
+++ b/src/operator/regression_output.cu
@@ -10,12 +10,12 @@ namespace mxnet {
 namespace op {
 
 template<>
-Operator *CreateRegressionOutputOp<gpu>(reg_enum::RegressionOutputType type) {
+Operator *CreateRegressionOutputOp<gpu>(reg_enum::RegressionOutputType type, RegressionOutputParam param) {
   switch (type) {
     case reg_enum::kLinear:
-      return new RegressionOutputOp<gpu, mshadow::op::identity, mshadow::op::minus>();
+      return new RegressionOutputOp<gpu, mshadow::op::identity, mshadow::op::minus>(param);
     case reg_enum::kLogistic:
-      return new RegressionOutputOp<gpu, mshadow_op::sigmoid, mshadow::op::minus>();
+      return new RegressionOutputOp<gpu, mshadow_op::sigmoid, mshadow::op::minus>(param);
     default:
       LOG(FATAL) << "unknown activation type " << type;
   }

--- a/src/operator/softmax_output-inl.h
+++ b/src/operator/softmax_output-inl.h
@@ -89,17 +89,13 @@ class SoftmaxOutputOp : public Operator {
       Tensor<xpu, 3> out = out_data[softmaxout_enum::kOut].get_with_shape<xpu, 3, real_t>(s3, s);
       Tensor<xpu, 3> grad = in_grad[softmaxout_enum::kData].get_with_shape<xpu, 3, real_t>(s3, s);
       SoftmaxGrad(grad, out, label);
-      if (param_.grad_scale < 1.0) {
-        grad *= param_.grad_scale;
-      }
+      grad *= param_.grad_scale;
     } else {
       Tensor<xpu, 1> label = in_data[softmaxout_enum::kLabel].get<xpu, 1, real_t>(s);
       Tensor<xpu, 2> out = out_data[softmaxout_enum::kOut].FlatTo2D<xpu, real_t>(s);
       Tensor<xpu, 2> grad = in_grad[softmaxout_enum::kData].FlatTo2D<xpu, real_t>(s);
       SoftmaxGrad(grad, out, label);
-      if (param_.grad_scale < 1.0) {
-        grad *= param_.grad_scale;
-      }
+      grad *= param_.grad_scale;
     }
   }
 


### PR DESCRIPTION
1. Add grad_scale parameter for RegressionOutput
2. Fix grad_scale in SoftmaxOutput. Currently, when grad_scale is > 1.0, it will be igonored.