### PR TITLE
Handle grayscale images as training data.

### DIFF
--- a/src/io/iter_normalize.h
+++ b/src/io/iter_normalize.h
@@ -176,10 +176,14 @@ class ImageNormalizeIter : public IIterator<DataInst> {
         rand_uniform(rnd_) * param_.max_random_illumination * 2 - param_.max_random_illumination;
 
     if (param_.mean_r > 0.0f || param_.mean_g > 0.0f || param_.mean_b > 0.0f) {
-      // substract mean value
-      data[0] -= param_.mean_r;
-      data[1] -= param_.mean_g;
-      data[2] -= param_.mean_b;
+      // If the input has 3 channels, we substract the mean value on each
+      if (data.shape_[0] == 3) {
+        data[0] -= param_.mean_r;
+        data[1] -= param_.mean_g;
+        data[2] -= param_.mean_b;
+      } else {
+        data[0] -= param_.mean_r;
+      }
       if ((param_.rand_mirror && coin_flip(rnd_)) || param_.mirror) {
         outimg_ = mirror(data * contrast + illumination) * param_.scale;
       } else {

--- a/tools/im2rec.cc
+++ b/tools/im2rec.cc
@@ -25,6 +25,7 @@ int main(int argc, char *argv[]) {
   if (argc < 4) {
     printf("Usage: <image.lst> <image_root_dir> <output.rec> [additional parameters in form key=value]\n"\
            "Possible additional parameters:\n"\
+           "\tcolor=USE_COLOR[default=1] Use color (1) or gray image (0)\n"\
            "\tresize=newsize resize the shorter edge of image to the newsize, original images will be packed by default\n"\
            "\tlabel_width=WIDTH[default=1] specify the label_width in the list, by default set to 1\n"\
            "\tnsplit=NSPLIT[default=1] used for part generation, logically split the image.list to NSPLIT parts by position\n"\
@@ -39,6 +40,7 @@ int main(int argc, char *argv[]) {
   int partid = 0;
   int center_crop = 0;
   int quality = 80;
+  int color_mode = CV_LOAD_IMAGE_COLOR;
   for (int i = 4; i < argc; ++i) {
     char key[128], val[128];
     if (sscanf(argv[i], "%[^=]=%s", key, val) == 2) {
@@ -48,6 +50,7 @@ int main(int argc, char *argv[]) {
       if (!strcmp(key, "part")) partid = atoi(val);
       if (!strcmp(key, "center_crop")) center_crop = atoi(val);
       if (!strcmp(key, "quality")) quality = atoi(val);
+      if (!strcmp(key, "color")) color_mode = atoi(val);
     }
   }
   if (new_size > 0) {
@@ -57,6 +60,9 @@ int main(int argc, char *argv[]) {
   }
   if (center_crop) {
     LOG(INFO) << "Center cropping to square";
+  }
+  if (color_mode == 0) {
+    LOG(INFO) << "Use gray images";
   }
   
   using namespace dmlc;
@@ -119,7 +125,7 @@ int main(int argc, char *argv[]) {
     }
     delete fi;
     if (new_size > 0) {
-      cv::Mat img = cv::imdecode(decode_buf, CV_LOAD_IMAGE_COLOR);
+      cv::Mat img = cv::imdecode(decode_buf, color_mode);
       CHECK(img.data != NULL) << "OpenCV decode fail:" << path;
       if (center_crop) {
         if (img.rows > img.cols) {


### PR DESCRIPTION
This PR allows to create a dataset with grayscale images (1 channel).
* Add a color parameter in the tool im2rec, to choose color mode (color, or grayscale)
* Decode rec dataset without forcing color mode (so, keep the color mode of the encoded data)
* Substract mean on 1 channel only for grayscale image
#805