### PR TITLE
fix the chunk_size

### DIFF
--- a/tools/make_list.py
+++ b/tools/make_list.py
@@ -34,7 +34,7 @@ def make_list(prefix_out, root, recursive, exts, num_chunks, train_ratio):
     image_list = list_image(root, recursive, exts)
     random.shuffle(image_list)
     N = len(image_list)
-    chunk_size = N/num_chunks
+    chunk_size = ( N+num_chunks-1 )/num_chunks
     for i in xrange(num_chunks):
         chunk = image_list[i*chunk_size:(i+1)*chunk_size]
         if num_chunks > 1:


### PR DESCRIPTION
fix the chunk_size
[0,1,2,3,4] if nsplit is 3,the chunk_size is 5/3=1, and we get [[0],[1],[2]] and lose [3,4]
if use the new cal method 
chunk_size is (5+3-1)/3 => 7/3 =2 , and we get [[0,1],[2,3],[4]] and nothing lose