### PR TITLE
revert to sgd

### DIFF
--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -391,7 +391,7 @@ class FeedForward(BASE_ESTIMATOR):
         The additional keyword arguments passed to optimizer.
     """
     def __init__(self, symbol, ctx=None,
-                 num_epoch=None, epoch_size=None, optimizer='ccsgd',
+                 num_epoch=None, epoch_size=None, optimizer='sgd',
                  initializer=Uniform(0.01),
                  numpy_batch_size=128,
                  arg_params=None, aux_params=None,


### PR DESCRIPTION
@piiswrong In kvstore, 
```
 File "../../python/mxnet/kvstore.py", line 251, in set_optimizer
    optim_str = pickle.dumps(optimizer, 0)
```

it requires optimizer to can be dumped, but current ccSGD doesn't support. So revert first.
