### PR TITLE
[R] close #837 and other misc update

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mxnet
 Type: Package
 Title: MXNet
 Version: 0.5
-Date: 2015-10-02
+Date: 2015-12-23
 Author: Tianqi Chen, Qiang Kou, Tong He
 Maintainer: Qiang Kou <qkou@umail.iu.edu>
 Description: MXNet is a deep learning framework designed for both efficiency

--- a/R-package/demo/00Index
+++ b/R-package/demo/00Index
@@ -1,1 +1,7 @@
+basic_bench                 Basic benchmark
+basic_executor              Basic executor operations
+basic_kvstore               Basic kvstore operations
+basic_model                 Basic model operations
 basic_ndarray               Basic ndarray operations
+basic_random                Basic random number generators
+basic_symbol                Basic symbol operations

--- a/R-package/src/io.cc
+++ b/R-package/src/io.cc
@@ -151,7 +151,6 @@ DataIterCreateFunction::DataIterCreateFunction
   const char **arg_names;
   const char **arg_type_infos;
   const char **arg_descriptions;
-  const char *key_var_num_args;
 
   MX_CALL(MXDataIterGetIterInfo(
       handle_, &name, &description, &num_args,

--- a/R-package/src/symbol.cc
+++ b/R-package/src/symbol.cc
@@ -109,7 +109,7 @@ Symbol::RObjectType Symbol::GetInternals() const {
 
 Symbol::RObjectType Symbol::GetOutput(mx_uint index) const {
   SymbolHandle out;
-  MX_CALL(MXSymbolGetOutput(handle_, index, &out));
+  MX_CALL(MXSymbolGetOutput(handle_, index - 1, &out));
   return Symbol::RObject(out);
 }
 
@@ -315,6 +315,8 @@ void Symbol::InitRcppModule() {
       .method("get.internals", &Symbol::GetInternals,
               "Get a symbol that contains all the internals")
       .method("get.output", &Symbol::GetOutput,
+              "Get index-th output symbol of current one")
+      .method("[[", &Symbol::GetOutput,
               "Get index-th output symbol of current one")
       .method("infer.shape", &Symbol::InferShape,
               "Inference the shape information given unknown ones");


### PR DESCRIPTION
Right now we allow the `[[]]` on a symbol, see below:

```
slice_gates = mx.symbol.SliceChannel(gates, num_outputs = 4, name = "slice")

slice_gates[[1]]
```