### PR TITLE
[matlab] support feature extraction

### DIFF
--- a/example/image-classification/README.md
+++ b/example/image-classification/README.md
@@ -211,15 +211,34 @@ python train_cifar10.py --batch-size 128 --lr 0.1 --lr-factor .94 --num-epoch 50
 
 ### ILSVRC 12
 
-#### `train_imagenet.py` with `--network alexnet`
+<!-- #### Alexnet -->
 
-- time for one epoch:
+<!-- `train_imagenet.py` with `--network alexnet` -->
 
-  | 1 x GTX 980 | 2 x GTX 980  | 4 x GTX 980  |
-  | ----------- | ------------ | ------------ |
-  | 2,413 sec | 1,244 sec | 906 sec |
+<!-- - time for one epoch: -->
 
-#### `train_imagenet.py` with `--network inception-bn`
+<!--   | 1 x GTX 980 | 2 x GTX 980  | 4 x GTX 980  | -->
+<!--   | ----------- | ------------ | ------------ | -->
+<!--   | 2,413 sec | 1,244 sec | 906 sec | -->
+
+#### VGG
+
+`train_imagenet.py` with `--network vgg`
+
+- Performance
+
+  | Cluster | # machines | # GPUs | batch size | kvstore | epoch time |
+  | --- | --- | --- | --- | --- | ---: |
+  | TitanX | 1 | 1 | 96 | `none` | 14,545 |
+  | - | - | 2 | - | `local` | 19,692 |
+  | - | - | 4 | - | - | 20,014 |
+  | - | - | 2 | - | `local_allreduce_device` | 9,142 |
+  | - | - | 4 | - | - | 8,533 |
+  | - | - | - | 384 | - | 5,161 |
+
+#### Inception with Batch Normalization
+
+`train_imagenet.py` with `--network inception-bn`
 
 - Performance
 

--- a/include/mxnet/c_predict_api.h
+++ b/include/mxnet/c_predict_api.h
@@ -37,6 +37,7 @@ typedef void *NDListHandle;
  * \return The last error happened at the predictor.
  */
 MXNET_DLL const char* MXGetLastError();
+
 /*!
  * \brief create a predictor
  * \param symbol_json_str The JSON string of the symbol.
@@ -64,9 +65,42 @@ MXNET_DLL int MXPredCreate(const char* symbol_json_str,
                            const char** input_keys,
                            const mx_uint* input_shape_indptr,
                            const mx_uint* input_shape_data,
-                           PredictorHandle* out,
-                           int num_output_nodes = 0,
-                           const char** num_output_keys = NULL);
+                           PredictorHandle* out);
+
+/*!
+ * \brief create a predictor wich customized outputs
+ * \param symbol_json_str The JSON string of the symbol.
+ * \param param_bytes The in-memory raw bytes of parameter ndarray file.
+ * \param param_size The size of parameter ndarray file.
+ * \param dev_type The device type, 1: cpu, 2:gpu
+ * \param dev_id The device id of the predictor.
+ * \param num_input_nodes Number of input nodes to the net,
+ *    For feedforward net, this is 1.
+ * \param input_keys The name of input argument.
+ *    For feedforward net, this is {"data"}
+ * \param input_shape_indptr Index pointer of shapes of each input node.
+ *    The length of this array = num_input_nodes + 1.
+ *    For feedforward net that takes 4 dimensional input, this is {0, 4}.
+ * \param input_shape_data A flatted data of shapes of each input node.
+ *    For feedforward net that takes 4 dimensional input, this is the shape data.
+ * \param num_output_nodes Number of output nodes to the net,
+ * \param output_keys The name of output argument.
+ *    For example {"global_pool"}
+ * \param out The created predictor handle.
+ * \return 0 when success, -1 when failure.
+ */
+
+MXNET_DLL int MXPredCreatePartialOut(const char* symbol_json_str,
+                                     const void* param_bytes,
+                                     int param_size,
+                                     int dev_type, int dev_id,
+                                     mx_uint num_input_nodes,
+                                     const char** input_keys,
+                                     const mx_uint* input_shape_indptr,
+                                     const mx_uint* input_shape_data,
+                                     mx_uint num_output_nodes,
+                                     const char** output_keys,
+                                     PredictorHandle* out);
 /*!
  * \brief Get the shape of output node.
  *  The returned shape_data and shape_ndim is only valid before next call to MXPred function.

--- a/include/mxnet/c_predict_api.h
+++ b/include/mxnet/c_predict_api.h
@@ -64,7 +64,9 @@ MXNET_DLL int MXPredCreate(const char* symbol_json_str,
                            const char** input_keys,
                            const mx_uint* input_shape_indptr,
                            const mx_uint* input_shape_data,
-                           PredictorHandle* out);
+                           PredictorHandle* out,
+                           int num_output_nodes = 0,
+                           const char** num_output_keys = NULL);
 /*!
  * \brief Get the shape of output node.
  *  The returned shape_data and shape_ndim is only valid before next call to MXPred function.

--- a/matlab/+mxnet/model.m
+++ b/matlab/+mxnet/model.m
@@ -15,8 +15,10 @@ properties (Access = private)
   predictor
 % the previous input size
   prev_input_size
-% the previous device id, -1 means cpu
+% the previous device id
   prev_dev_id
+% the previous device type (cpu or gpu)
+  prev_dev_type
 end
 
 methods
@@ -26,6 +28,7 @@ methods
   obj.prev_input_size = zeros(1,4);
   obj.verbose = 1;
   obj.prev_dev_id = -1;
+  obj.prev_dev_type = -1;
   end
 
   function delete(obj)
@@ -64,21 +67,11 @@ methods
   end
 
 
-  function outputs = forward(obj, imgs, varargin)
+  function outputs = forward(obj, input, varargin)
   %FORWARD perform forward
   %
-  % OUT = MODEL.FORWARD(imgs) returns the forward (prediction) outputs of a list
-  % of images, where imgs can be either a single image with the format
-  %\
-  %   width x height x channel
-  %
-  % which is return format of `imread` or a list of images with format
-  %
-  %   width x height x channel x num_images
-  %
-  % MODEL.FORWARD(imgs, 'gpu', [0, 1]) uses GPU 0 and 1 for prediction
-  %
-  % MODEL.FORWARD(imgs, {'conv4', 'conv5'}) extract outputs for two internal layers
+  % OUT = MODEL.FORWARD(input) returns the forward (prediction) outputs of a list
+  % of input examples
   %
   % Examples
   %
@@ -107,47 +100,44 @@ methods
       dev_id = varargin{2};
       varargin = varargin(3:end);
     end
-
   end
+
+  siz = size(input);
+  assert(length(siz) >= 2);
 
   % convert from matlab order (col-major) into c order (row major):
-  siz = size(imgs);
-  if length(siz) == 2
-    imgs = permute(imgs, [2, 1]);
-    siz = [siz, 1, 1];
-  elseif length(siz) == 3
-    imgs = permute(imgs, [2, 1, 3]);
-    siz = [siz, 1];
-  elseif length(siz) == 4
-    imgs = permute(imgs, [2, 1, 3, 4]);
-  else
-    error('imgs shape error')
-  end
+  input = obj.convert_ndarray(input);
 
-  if any(siz ~= obj.prev_input_size)
+
+  if length(siz) ~= length(obj.prev_input_size) || ...
+        any(siz ~= obj.prev_input_size) || ...
+        dev_type ~= obj.prev_dev_type || ...
+        length(dev_id) ~= length(obj.prev_dev_id) || ...
+        any(dev_id ~= obj.prev_dev_id)
     obj.free_predictor()
   end
   obj.prev_input_size = siz;
+  obj.prev_dev_type = dev_type;
+  obj.prev_dev_id = dev_id;
 
   if obj.predictor.Value == 0
-    if obj.verbose
-      fprintf('create predictor with input size ');
-      fprintf('%d ', siz);
-      fprintf('\n');
-    end
+    fprintf('create predictor with input size ');
+    fprintf('%d ', siz);
+    fprintf('\n');
+    csize = [ones(1, 4-length(siz)), siz(end:-1:1)];
     callmxnet('MXPredCreatePartialOut', obj.symbol, ...
               libpointer('voidPtr', obj.params), ...
               length(obj.params), ...
               int32(dev_type), int32(dev_id), ...
               1, {'data'}, ...
               uint32([0, 4]), ...
-              uint32(siz(end:-1:1)), ...
+              uint32(csize), ...
               0, {}, ...
               obj.predictor);
   end
 
   % feed input
-  callmxnet('MXPredSetInput', obj.predictor, 'data', single(imgs(:)), uint32(numel(imgs)));
+  callmxnet('MXPredSetInput', obj.predictor, 'data', single(input(:)), uint32(numel(input)));
   % forward
   callmxnet('MXPredForward', obj.predictor);
 
@@ -157,16 +147,20 @@ methods
   callmxnet('MXPredGetOutputShape', obj.predictor, 0, out_shape, out_dim);
   assert(out_dim.Value <= 4);
   out_siz = out_shape.Value(1:out_dim.Value);
-  out_siz = double(out_siz(:)');
+  out_siz = double(out_siz(end:-1:1))';
 
   % get output
-  out = libpointer('singlePtr', single(ones(out_siz)));
+  out = libpointer('singlePtr', single(zeros(out_siz)));
 
   callmxnet('MXPredGetOutput', obj.predictor, 0, ...
             out, uint32(prod(out_siz)));
 
   % TODO convert from c order to matlab order...
   outputs = out.Value;
+  % outputs = obj.convert_ndarray(out.Value);
+  if length(out_siz) > 2
+    outputs = convert_ndarray(outputs);
+  end
   end
 end
 
@@ -177,6 +171,12 @@ methods (Access = private)
     callmxnet('MXPredFree', obj.predictor);
     obj.predictor = libpointer('voidPtr', 0);
   end
+  end
+
+  function Y = convert_ndarray(obj, X)
+  % convert between matlab's col major and c's row major
+  siz = size(X);
+  Y = permute(X, [2 1 3:length(siz)]);
   end
 end
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -2,8 +2,57 @@
 
 ### How to use
 
-The only requirment is build mxnet to get `lib/libmxnet.so`. Then run `demo` in
-matlab.
+The only requirment is build mxnet to get `lib/libmxnet.so`. Sample usage
+
+- Load model and data:
+
+  ```matlab
+  img = single(imresize(imread('cat.png'), [224 224])) - 120;
+  model = mxnet.model;
+  model.load('model/Inception_BN', 39);
+  ```
+
+- Get prediction:
+
+  ```matlab
+  pred = model.forward(img);
+  ```
+
+- Do feature extraction on GPU 0:
+
+  ```matlab
+  feas = model.forward(img, 'gpu', 0, {'max_pool_5b_pool', 'global_pool', 'fc'});
+  ```
+
+- See [demo.m](demo.m) for more examples
+
+### Note on Implementation
+
+We use `loadlibrary` to load mxnet library directly into Matlab and `calllib`
+to call functions. Note that Matlab uses column-major to store N-dim array while
+and MXNet uses row-major. Assume we create a tensor in matlab with
+
+```matlab
+X = zeros([2,3,4,5]);
+```
+
+If we pass the memory of `X` into MXNet directly, then the shape will be
+`[5,4,3,2]` in MXNet.
+
+When processing images, MXNet assumes the data layout is
+
+```c++
+example x channel x width x height
+```
+
+while we often store images in matlab by
+
+```matlab
+width x height x channel x example
+```
+
+So we should permuate the order by `X = permute(X, [2, 1, 3, 4])` before pass
+`X` into MXNet.
 
 ### FAQ
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -28,31 +28,30 @@ The only requirment is build mxnet to get `lib/libmxnet.so`. Sample usage
 
 ### Note on Implementation
 
-We use `loadlibrary` to load mxnet library directly into Matlab and `calllib`
-to call functions. Note that Matlab uses column-major to store N-dim array while
-and MXNet uses row-major. Assume we create a tensor in matlab with
+We use `loadlibrary` to load mxnet library directly into Matlab and `calllib` to
+call MXNet functions. Note that Matlab uses the column-major to store N-dim
+arraies while and MXNet uses the row-major. So assume we create an array in
+matlab with
 
 ```matlab
 X = zeros([2,3,4,5]);
 ```
 
-If we pass the memory of `X` into MXNet directly, then the shape will be
-`[5,4,3,2]` in MXNet.
-
-When processing images, MXNet assumes the data layout is
+If we pass the memory of `X` into MXNet, then the correct shape will be
+`[5,4,3,2]` in MXNet. When processing images, MXNet assumes the data layout is
 
 ```c++
 example x channel x width x height
 ```
 
-while we often store images in matlab by
+while in matlab we often store images by
 
 ```matlab
 width x height x channel x example
 ```
 
-So we should permuate the order by `X = permute(X, [2, 1, 3, 4])` before pass
-`X` into MXNet.
+So we should permuate the dimensions by `X = permute(X, [2, 1, 3, 4])` before
+passing `X` into MXNet.
 
 ### FAQ
 

--- a/matlab/demo.m
+++ b/matlab/demo.m
@@ -34,18 +34,22 @@ fclose(fid);
 [p, i] = max(pred);
 fprintf('the best result is %s, with probability %f\n', labels{i}, p)
 
-%% Print all layers in the symbol
+%% Print the last 10 layers in the symbol
 
-% sym = model.parse_symbol();
-% layers = {};
-% for i = 1 : length(sym.nodes)
-%   if ~strcmp(sym.nodes{i}.op, 'null')
-%     layers{end+1} = sym.nodes{i}.name;
-%   end
-% end
-% layers
+sym = model.parse_symbol();
+layers = {};
+for i = 1 : length(sym.nodes)
+  if ~strcmp(sym.nodes{i}.op, 'null')
+    layers{end+1} = sym.nodes{i}.name;
+  end
+end
+fprintf('layer name: %s\n', layers{end-10:end})
 
-%% Extract feature
+%% Extract feature from internal layers
 
-% TODO
-%%
+feas = model.forward(img, {'max_pool_5b_pool', 'global_pool', 'fc'});
+feas(:)
+
+%% If GPU is available
+% feas = model.forward(img, 'gpu', 0, {'max_pool_5b_pool', 'global_pool', 'fc'});
+% feas(:)

--- a/matlab/demo.m
+++ b/matlab/demo.m
@@ -15,7 +15,7 @@ model.load('model/Inception_BN', 39);
 
 %% Load and resize the image
 img = imresize(imread('cat.png'), [224 224]);
-
+img = single(img) - 120;
 %% Run prediction
 pred = model.forward(img);
 
@@ -32,7 +32,6 @@ fclose(fid);
 
 %% find the predict label
 [p, i] = max(pred);
-
 fprintf('the best result is %s, with probability %f\n', labels{i}, p)
 
 %% Print all layers in the symbol

--- a/matlab/tests/prepare_data.m
+++ b/matlab/tests/prepare_data.m
@@ -1,0 +1,36 @@
+%% download cifar10 dataset
+system('wget https://www.cs.toronto.edu/~kriz/cifar-10-matlab.tar.gz')
+system('tar -xzvf cifar-10-matlab.tar.gz')
+load cifar-10-batches-mat/test_batch.mat
+
+%% convert test dataset of cifar10, and save
+X = reshape(data', [32, 32, 3, 10000]);
+X = permute(X, [2 1 3 4]);
+Y = labels + 1;
+
+
+save cifar10-test X Y
+%% preview one picture
+imshow(imresize(X(:,:,:,2), [128, 128]))
+
+%%
+
+!wget http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
+!wget http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
+!gunzip t10k-images-idx3-ubyte.gz
+!gunzip t10k-labels-idx1-ubyte.gz
+
+%%
+
+fid = fopen('t10k-images-idx3-ubyte', 'r');
+d = fread(fid, inf, '*uint8');
+fclose(fid);
+X = reshape(d(17:end), [28 28 1 10000]);
+X = permute(X, [2 1 3 4]);
+
+fid = fopen('t10k-labels-idx1-ubyte', 'r');
+d = fread(fid, inf, '*uint8');
+fclose(fid);
+Y = d(9:end) + 1;
+
+save mnist-test X Y

--- a/matlab/tests/test_prediction.m
+++ b/matlab/tests/test_prediction.m
@@ -34,6 +34,11 @@ err = err / length(Y);
 fprintf('prediction error: %f\n', err)
 
 %%
+% ix = 1:2;
+% x = X(:,:,:,ix);
+% pred = model.forward(x, {'pooling1', 'fullyconnected1', 'softmax'});
+
+%%
 % batch = 1000;
 % e = 0;
 % for i = 1 : batch

--- a/matlab/tests/test_prediction.m
+++ b/matlab/tests/test_prediction.m
@@ -1,0 +1,100 @@
+%% prepare
+
+addpath('..')
+
+if ~exist('mnist-test.mat', 'file')
+  system('wget --no-check-certificate https://github.com/dmlc/web-data/raw/master/mxnet/matlab/mnist-test.mat');
+end
+
+if ~exist('model/mnist-lenet-0-0010.params', 'file')
+  system('wget --no-check-certificate https://github.com/dmlc/web-data/raw/master/mxnet/matlab/mnist-lenet.tar.gz');
+  system('tar -zxf mnist-lenet.tar.gz');
+end
+
+%% load data and model
+
+load mnist-test
+clear model
+model = mxnet.model;
+model.load('model/mnist-lenet-0', 10);
+
+%% predict
+
+err = 0;
+batch = 1000;
+for i = 1 : length(Y) / batch
+  ix = (i-1)*batch+1 : i*batch;
+  x = X(:,:,:,ix);
+  pred = model.forward(x, 'gpu', 0);
+  [~, k] = max(pred);
+  err = err + nnz(k ~= Y(ix)');
+end
+
+err = err / length(Y);
+fprintf('prediction error: %f\n', err)
+
+%%
+% batch = 1000;
+% e = 0;
+% for i = 1 : batch
+%   x = single(X(:,:,:,i));
+%   pred = model.forward(x);
+%   [~, k] = max(pred);
+%   e = e + (k == Y(i));
+% end
+
+% e / batch
+
+% %% load data
+% load cifar10-test.mat
+% img_mean = [123.68, 116.779, 103.939];
+
+% %%
+% clear model
+% model = mxnet.model;
+% model.load('model/cifar10-incept-bn-0', 20);
+
+% %%
+% batch = 100;
+% x = zeros(28,28,3,batch);
+% for i = 1 : batch
+%   x(:,:,:,i) = single(imresize(X(:,:,:,i), [28, 28]));
+%   x = x(:,:,[3 2 1],:);
+% end
+% % x = permute(x, [2 1 3 4]);
+
+% x = x - 120;
+% % for i = 1 : 3
+% %   x(:,:,i,:) = x(:,:,i,:) - img_mean(i);
+% % end
+
+
+% pred = model.forward(x, 'gpu', 0);
+
+% [~,i] = max(reshape(pred(:), 10, batch));
+% nnz(i' == Y(1:batch)) / length(i)
+
+% %%
+
+% batch = 100;
+% e = 0;
+% for i = 1 : batch
+%   x = single(imresize(X(:,:,:,i), [28, 28])) - 120;
+%   for j = 1 : 3
+%     x(:,:,j) = x(:,:,j);
+%   end
+%   pred = model.forward(x);
+%   [~, k] = max(pred);
+%   e = e + (k == Y(i));
+% end
+
+% e / batch
+
+
+% %% load bin
+
+% a = fopen('mean.bin', 'r');
+% yy = fread(a, 14, '*int32');
+% mm = fread(a, inf, '*single');
+% fclose(a)
+% % nn = mm(14:end-6);

--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -9,7 +9,8 @@
 #include <mxnet/symbolic.h>
 #include <mxnet/ndarray.h>
 #include <memory>
-
+#include <unordered_set>
+#include <unordered_map>
 #include "./c_api_error.h"
 
 using namespace mxnet;
@@ -43,7 +44,9 @@ int MXPredCreate(const char* symbol_json_str,
                  const char** input_keys,
                  const mx_uint* input_shape_indptr,
                  const mx_uint* input_shape_data,
-                 PredictorHandle* out) {
+                 PredictorHandle* out,
+                 int num_output_nodes,
+                 const char** num_output_keys) {
   MXAPIPredictor* ret = new MXAPIPredictor();
   API_BEGIN();
   Symbol sym;
@@ -54,9 +57,36 @@ int MXPredCreate(const char* symbol_json_str,
     dmlc::JSONReader reader(&is);
     sym.Load(&reader);
   }
+  // looks likely to output the internal results
+  if (num_output_nodes != 0) {
+    Symbol internal = sym.GetInternals();
+    std::vector<std::string> all_out = internal.ListOutputs();
+    std::vector<Symbol> out_syms(num_output_nodes);
+    for (int i = 0; i < num_output_nodes; ++i) {
+      std::string out_key(num_output_keys[i]);
+      for (size_t j = 0; j < all_out.size(); ++j) {
+        if (all_out[j] == out_key) {
+          out_syms[i] = internal[j];
+          break;
+        }
+        CHECK_NE(j, all_out.size() - 1) << "didn't find node name: " << out_key;
+      }
+    }
+    sym = Symbol::CreateGroup(out_syms);
+  }
+
   // load the parameters
   std::unordered_map<std::string, NDArray> arg_params, aux_params;
   {
+    std::unordered_set<std::string> arg_names, aux_names;
+    std::vector<std::string> arg_names_vec = sym.ListArguments();
+    std::vector<std::string> aux_names_vec = sym.ListAuxiliaryStates();
+    for (size_t i = 0; i < arg_names_vec.size(); ++i) {
+      arg_names.insert(arg_names_vec[i]);
+    }
+    for (size_t i = 0; i < aux_names_vec.size(); ++i) {
+      aux_names.insert(aux_names_vec[i]);
+    }
     std::vector<NDArray> data;
     std::vector<std::string> names;
     dmlc::MemoryFixedSizeStream fi((void*)param_bytes, param_size);  // NOLINT(*)
@@ -65,10 +95,16 @@ int MXPredCreate(const char* symbol_json_str,
         << "Invalid param file format";
     for (size_t i = 0; i < names.size(); ++i) {
       if (!strncmp(names[i].c_str(), "aux:", 4)) {
-        aux_params[std::string(names[i].c_str() + 4)]  = data[i];
+        std::string name(names[i].c_str() + 4);
+        if (aux_names.count(name) != 0) {
+          aux_params[name] = data[i];
+        }
       }
       if (!strncmp(names[i].c_str(), "arg:", 4)) {
-        arg_params[std::string(names[i].c_str() + 4)]  = data[i];
+        std::string name(names[i].c_str() + 4);
+        if (arg_names.count(name) != 0) {
+          arg_params[name] = data[i];
+        }
       }
     }
   }

--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -44,9 +44,33 @@ int MXPredCreate(const char* symbol_json_str,
                  const char** input_keys,
                  const mx_uint* input_shape_indptr,
                  const mx_uint* input_shape_data,
-                 PredictorHandle* out,
-                 int num_output_nodes,
-                 const char** num_output_keys) {
+                PredictorHandle* out) {
+  return MXPredCreatePartialOut(
+      symbol_json_str,
+      param_bytes,
+      param_size,
+      dev_type,
+      dev_id,
+      num_input_nodes,
+      input_keys,
+      input_shape_indptr,
+      input_shape_data,
+      0,
+      NULL,
+      out);
+}
+
+int MXPredCreatePartialOut(const char* symbol_json_str,
+                           const void* param_bytes,
+                           int param_size,
+                           int dev_type, int dev_id,
+                           mx_uint num_input_nodes,
+                           const char** input_keys,
+                           const mx_uint* input_shape_indptr,
+                           const mx_uint* input_shape_data,
+                           mx_uint num_output_nodes,
+                           const char** output_keys,
+                           PredictorHandle* out) {
   MXAPIPredictor* ret = new MXAPIPredictor();
   API_BEGIN();
   Symbol sym;
@@ -62,8 +86,8 @@ int MXPredCreate(const char* symbol_json_str,
     Symbol internal = sym.GetInternals();
     std::vector<std::string> all_out = internal.ListOutputs();
     std::vector<Symbol> out_syms(num_output_nodes);
-    for (int i = 0; i < num_output_nodes; ++i) {
-      std::string out_key(num_output_keys[i]);
+    for (mx_uint i = 0; i < num_output_nodes; ++i) {
+      std::string out_key(output_keys[i]);
       for (size_t j = 0; j < all_out.size(); ++j) {
         if (all_out[j] == out_key) {
           out_syms[i] = internal[j];

--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -88,6 +88,7 @@ int MXPredCreatePartialOut(const char* symbol_json_str,
     std::vector<Symbol> out_syms(num_output_nodes);
     for (mx_uint i = 0; i < num_output_nodes; ++i) {
       std::string out_key(output_keys[i]);
+      out_key += "_output";
       for (size_t j = 0; j < all_out.size(); ++j) {
         if (all_out[j] == out_key) {
           out_syms[i] = internal[j];


### PR DESCRIPTION
1. add `MXPredCreatePartialOut` in c_prediction_api to allow specifying the output layers. note that we cannot reuse `MXPredCreate` by adding optional argument `int num_output_nodes = 0` since matlab doesn't support it..

2. updated matlab/mxnet/model.m to support gpu and feature extraction

3. add titan-x performance numbers on image-classification