### PR TITLE
support nvidia/nccl for gpu direct communication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ else
 	CFLAGS+= -DMXNET_USE_OPENCV=0
 endif
 
+ifeq ($(USE_NCCL), 1)
+	CFLAGS += -DMXNET_USE_NCCL=1
+	LDFLAGS += -lnccl
+endif
+
 ifeq ($(USE_OPENMP), 1)
 	CFLAGS += -fopenmp
 endif

--- a/example/image-classification/README.md
+++ b/example/image-classification/README.md
@@ -168,8 +168,8 @@ recommend to use CUDNN.
   [doc/developer-guide/multi_node.md](../../doc/developer-guide/multi_node.md)
   for more information)
   1. For a single machine, often the default `local` is good enough. But you may want
-  to use `local_allreduce_device` for models with size >> 100MB such as AlexNet
-  and VGG. But also note that `local_allreduce_device` takes more GPU memory than
+  to use `device` for models with size >> 100MB such as AlexNet
+  and VGG. But also note that `device` takes more GPU memory than
   others.
   2. For multiple machines, we recommend to try `dist_sync` first. But if the
   model size is quite large or you use a large number of machines, you may want to use `dist_async`.
@@ -232,7 +232,7 @@ python train_cifar10.py --batch-size 128 --lr 0.1 --lr-factor .94 --num-epoch 50
   | TitanX | 1 | 1 | 96 | `none` | 14,545 |
   | - | - | 2 | - | `local` | 19,692 |
   | - | - | 4 | - | - | 20,014 |
-  | - | - | 2 | - | `local_allreduce_device` | 9,142 |
+  | - | - | 2 | - | `device` | 9,142 |
   | - | - | 4 | - | - | 8,533 |
   | - | - | - | 384 | - | 5,161 |
 

--- a/example/image-classification/README.md
+++ b/example/image-classification/README.md
@@ -211,15 +211,17 @@ python train_cifar10.py --batch-size 128 --lr 0.1 --lr-factor .94 --num-epoch 50
 
 ### ILSVRC 12
 
-<!-- #### Alexnet -->
+#### Alexnet
 
-<!-- `train_imagenet.py` with `--network alexnet` -->
+`train_imagenet.py` with `--network alexnet`
 
-<!-- - time for one epoch: -->
-
-<!--   | 1 x GTX 980 | 2 x GTX 980  | 4 x GTX 980  | -->
-<!--   | ----------- | ------------ | ------------ | -->
-<!--   | 2,413 sec | 1,244 sec | 906 sec | -->
+  | Cluster | # machines | # GPUs | batch size | kvstore | sec per epoch |
+  | --- | --- | --- | --- | --- | ---: |
+  | TitanX | 1 | 1 | 1,024 | `none` | 2,206 |
+  | - | - | 2 | - | `local` | 1,333 |
+  | - | - | 4 | - | - | 1,280 |
+  | - | - | 2 | - | `device` | 1,289 |
+  | - | - | 4 | - | - | 603 |
 
 #### VGG
 
@@ -227,7 +229,7 @@ python train_cifar10.py --batch-size 128 --lr 0.1 --lr-factor .94 --num-epoch 50
 
 - Performance
 
-  | Cluster | # machines | # GPUs | batch size | kvstore | epoch time |
+  | Cluster | # machines | # GPUs | batch size | kvstore | sec per epoch |
   | --- | --- | --- | --- | --- | ---: |
   | TitanX | 1 | 1 | 96 | `none` | 14,545 |
   | - | - | 2 | - | `local` | 19,692 |
@@ -242,7 +244,7 @@ python train_cifar10.py --batch-size 128 --lr 0.1 --lr-factor .94 --num-epoch 50
 
 - Performance
 
-  | Cluster | # machines | # GPUs | batch size | kvstore | epoch time |
+  | Cluster | # machines | # GPUs | batch size | kvstore | sec per epoch |
   | --- | --- | --- | --- | --- | ---: |
   | GTX980 | 1 | 1 |  32 | `local` | 13,210 |
   | - | - | 2 |  64 | - | 7,198 |

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -889,6 +889,13 @@ MXNET_DLL int MXKVStorePull(KVStoreHandle handle,
                             const int* keys,
                             NDArrayHandle* vals,
                             int priority);
+
+MXNET_DLL int MXKVStorePushPulll(KVStoreHandle handle,
+                                 mx_uint num,
+                                 const int* keys,
+                                 NDArrayHandle* push_vals,
+                                 NDArrayHandle* pull_vals,
+                                 int priority);
 /*!
  * \brief user-defined updater for the kvstore
  * It's this updater's responsibility to delete \a recv and \a local

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -890,6 +890,16 @@ MXNET_DLL int MXKVStorePull(KVStoreHandle handle,
                             NDArrayHandle* vals,
                             int priority);
 
+/*!
+ * \brief push and then pull
+ * \param handle handle to the kvstore
+ * \param num the number of key-value pairs
+ * \param keys the list of keys
+ * \param push_vals the list of values for pushing
+ * \param pull_vals the list of values for pulling
+ * \param priority the priority of the action
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXKVStorePushPull(KVStoreHandle handle,
                                  mx_uint num,
                                  const int* keys,

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -890,7 +890,7 @@ MXNET_DLL int MXKVStorePull(KVStoreHandle handle,
                             NDArrayHandle* vals,
                             int priority);
 
-MXNET_DLL int MXKVStorePushPulll(KVStoreHandle handle,
+MXNET_DLL int MXKVStorePushPull(KVStoreHandle handle,
                                  mx_uint num,
                                  const int* keys,
                                  NDArrayHandle* push_vals,

--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -124,6 +124,14 @@ class KVStore {
                     const std::vector<NDArray*>& values,
                     int priority = 0) = 0;
 
+  virtual void PushPull(const std::vector<int>& keys,
+                        const std::vector<NDArray>& push_values,
+                        const std::vector<NDArray*>& pull_values,
+                        int priority = 0) {
+    Push(keys, push_values, priority);
+    Pull(keys, pull_values, priority);
+  }
+
   /**
    * \brief the prototype of user-defined updater
    */

--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -124,6 +124,19 @@ class KVStore {
                     const std::vector<NDArray*>& values,
                     int priority = 0) = 0;
 
+
+  /*!
+   * \brief perform push and then pull
+   *
+   * PushPull is equal to call Push and then Pull. Howerver the former could be
+   * more efficient than the latter.
+   * \param keys the list of keys
+
+   * \param push_values the list of values for pushing
+   * \param pull_values the list of buffers for the pulled data, they should be
+   * preallocated. pull_values could be identical to push_values
+   * \param priority Priority of the action.
+   */
   virtual void PushPull(const std::vector<int>& keys,
                         const std::vector<NDArray>& push_values,
                         const std::vector<NDArray*>& pull_values,

--- a/make/config.mk
+++ b/make/config.mk
@@ -77,6 +77,10 @@ else
 USE_STATIC_MKL = NONE
 endif
 
+# whether use nvidia NCCL for GPU communication.
+# One need to install NCCL https://github.com/nvidia/nccl
+USE_NCCL = 0
+
 #----------------------------
 # distributed computing
 #----------------------------

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -228,6 +228,13 @@ class KVStore(object):
             self.handle, mx_uint(len(ckeys)), ckeys, cvals,
             ctypes.c_int(priority)))
 
+    def push_pull(self, key, value, out, priority=0):
+        ckeys, cpushvals = _ctype_key_value(key, value)
+        ckey2, cpullvals = _ctype_key_value(key, out)
+        check_call(_LIB.MXKVStorePushPull(
+            self.handle, mx_uint(len(ckeys)), ckeys, cpushvals, cpullvals,
+            ctypes.c_int(priority)))
+
     def set_optimizer(self, optimizer):
         """Register an optimizer to the store
 

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -229,6 +229,27 @@ class KVStore(object):
             ctypes.c_int(priority)))
 
     def push_pull(self, key, value, out, priority=0):
+        """ Push and the pull a single value or a sequence of values
+
+        This function is equal to call push and then pull. However, the former
+        could be more efficient.
+
+        Parameters
+        ----------
+        key : int or list of int
+            Keys
+
+        value : NDArray or list of NDArray or list of list of NDArray
+            According values for push
+
+        out: NDArray or list of NDArray or list of list of NDArray
+            According values for pull, out could be identical to value.
+
+        priority : int, optional
+            The priority of the push operation.
+            The higher the priority, the faster this action is likely
+            to be executed before other push actions.
+        """
         ckeys, cpushvals = _ctype_key_value(key, value)
         ckey2, cpullvals = _ctype_key_value(key, out)
         check_call(_LIB.MXKVStorePushPull(

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -251,7 +251,7 @@ class KVStore(object):
             to be executed before other push actions.
         """
         ckeys, cpushvals = _ctype_key_value(key, value)
-        ckey2, cpullvals = _ctype_key_value(key, out)
+        _, cpullvals = _ctype_key_value(key, out)
         check_call(_LIB.MXKVStorePushPull(
             self.handle, mx_uint(len(ckeys)), ckeys, cpushvals, cpullvals,
             ctypes.c_int(priority)))

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -104,9 +104,10 @@ def _update_params(param_arrays, grad_arrays, updater, num_device,
             continue
         if kvstore:
             # push gradient, priority is negative index
-            kvstore.push(index, grad_list, priority=-index)
+            # kvstore.push(index, grad_list, priority=-index)
             # pull back the sum gradients, to the same locations.
-            kvstore.pull(index, grad_list, priority=-index)
+            # kvstore.pull(index, grad_list, priority=-index)
+            kvstore.push_pull(index, grad_list, grad_list, priority=-index)
         for k, p in enumerate(zip(arg_list, grad_list)):
             # faked an index here, to make optimizer create diff
             # state for the same index but on diff devs, TODO(mli)

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -991,6 +991,25 @@ int MXKVStorePull(KVStoreHandle handle,
   API_END();
 }
 
+int MXKVStorePushPull(KVStoreHandle handle,
+                      mx_uint num,
+                      const int* keys,
+                      NDArrayHandle* push_vals,
+                      NDArrayHandle* pull_vals,
+                      int priority) {
+  API_BEGIN();
+  std::vector<int> v_keys(num);
+  std::vector<NDArray> v_push_vals(num);
+  std::vector<NDArray*> v_pull_vals(num);
+  for (mx_uint i = 0; i < num; ++i) {
+    v_keys[i] = keys[i];
+    v_push_vals[i] = *static_cast<NDArray*>(push_vals[i]);
+    v_pull_vals[i] = static_cast<NDArray*>(pull_vals[i]);
+  }
+  static_cast<KVStore*>(handle)->PushPull(
+      v_keys, v_push_vals, v_pull_vals, priority);
+  API_END();
+}
 int MXKVStoreSetUpdater(KVStoreHandle handle,
                         MXKVStoreUpdater updater,
                         void* updater_handle) {

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1010,6 +1010,7 @@ int MXKVStorePushPull(KVStoreHandle handle,
       v_keys, v_push_vals, v_pull_vals, priority);
   API_END();
 }
+
 int MXKVStoreSetUpdater(KVStoreHandle handle,
                         MXKVStoreUpdater updater,
                         void* updater_handle) {

--- a/src/kvstore/kvstore.cc
+++ b/src/kvstore/kvstore.cc
@@ -31,9 +31,9 @@ KVStore* KVStore::Create(const char *type_name) {
              tname == "local_allreduce_device") {
     tname = "local_allreduce_device";
 #if MXNET_USE_CUDA && MXNET_USE_NCCL
-    kv = new kvstore::KVStoreDevice();
-#else
     kv = new kvstore::KVStoreNCCL();
+#else
+    kv = new kvstore::KVStoreDevice();
 #endif  // MXNET_USE_CUDA && MXNET_USE_NCCL
   } else if (tname == "dist_async" ||
              tname == "dist_sync" ||

--- a/src/kvstore/kvstore.cc
+++ b/src/kvstore/kvstore.cc
@@ -11,6 +11,11 @@
 #if MXNET_USE_DIST_KVSTORE
 #include "./kvstore_dist.h"
 #endif  // MXNET_USE_DIST_KVSTORE
+#if MXNET_USE_CUDA
+#if MXNET_USE_NCCL
+#include "./kvstore_nccl.h"
+#endif  // MXNET_USE_NCCL
+#endif  // MXNET_USE_CUDA
 
 namespace mxnet {
 
@@ -25,7 +30,11 @@ KVStore* KVStore::Create(const char *type_name) {
   } else if (tname == "device" ||
              tname == "local_allreduce_device") {
     tname = "local_allreduce_device";
+#if MXNET_USE_CUDA && MXNET_USE_NCCL
     kv = new kvstore::KVStoreDevice();
+#else
+    kv = new kvstore::KVStoreNCCL();
+#endif  // MXNET_USE_CUDA && MXNET_USE_NCCL
   } else if (tname == "dist_async" ||
              tname == "dist_sync" ||
              tname == "dist") {

--- a/src/kvstore/kvstore_nccl.h
+++ b/src/kvstore/kvstore_nccl.h
@@ -30,6 +30,7 @@ class KVStoreNCCL : public KVStore {
  public:
   KVStoreNCCL() {
     inited_nccl_ = false;
+    LOG(ERROR) << "use nccl";
   }
 
   virtual ~KVStoreNCCL() {

--- a/src/kvstore/kvstore_nccl.h
+++ b/src/kvstore/kvstore_nccl.h
@@ -30,7 +30,6 @@ class KVStoreNCCL : public KVStore {
  public:
   KVStoreNCCL() {
     inited_nccl_ = false;
-    LOG(ERROR) << "use nccl";
   }
 
   virtual ~KVStoreNCCL() {
@@ -186,6 +185,7 @@ class KVStoreNCCL : public KVStore {
     }
     // wait until finished
     for (size_t i = 0; i < devs_.size(); ++i) {
+      CUDACHECK(cudaSetDevice(devs_[i]));
       CUDACHECK(cudaStreamSynchronize(streams_[i]));
     }
   }

--- a/src/kvstore/kvstore_nccl.h
+++ b/src/kvstore/kvstore_nccl.h
@@ -1,0 +1,201 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file kvstore_nccl.h
+ * \brief Implementation of KVStore based on nvida/nccl
+ */
+#ifndef MXNET_KVSTORE_KVSTORE_NCCL_H_
+#define MXNET_KVSTORE_KVSTORE_NCCL_H_
+
+#include <nccl.h>
+#include <mxnet/kvstore.h>
+#include <algorithm>
+#include <vector>
+
+namespace mxnet {
+namespace kvstore {
+
+#define CUDACHECK(cmd) do {                              \
+    cudaError_t e = cmd;                                 \
+    CHECK(e == cudaSuccess) << "CUDA failure "           \
+                            << cudaGetErrorString(e);    \
+  } while(false)
+
+#define NCCLCHECK(cmd) do {                             \
+    ncclResult_t e = cmd;                               \
+    CHECK(e == ncclSuccess) << "NCLL failure "          \
+                            << ncclGetErrorString(e);   \
+  } while(false)
+
+class KVStoreNCCL : public KVStore {
+ public:
+  KVStoreNCCL() {
+    inited_nccl_ = false;
+  }
+
+  virtual ~KVStoreNCCL() {
+    for (size_t i = 0; i < devs_.size(); ++i) {
+      CUDACHECK(cudaSetDevice(devs_[i]));
+      CUDACHECK(cudaStreamDestroy(streams_[i]));
+    }
+    for (auto c : comms_) {
+      ncclCommDestroy(c);
+    }
+  }
+
+  void Init(const std::vector<int>& keys,
+            const std::vector<NDArray>& values) override {
+  }
+
+
+  void Push(const std::vector<int>& keys,
+            const std::vector<NDArray>& values,
+            int priority) override {
+    LOG(FATAL) << "sorry, not implemented yet";
+  }
+
+  void Pull(const std::vector<int>& keys,
+            const std::vector<NDArray*>& values,
+            int priority) override {
+    LOG(FATAL) << "sorry, not implemented yet";
+  }
+
+
+  void PushPull(const std::vector<int>& keys,
+                const std::vector<NDArray>& push_values,
+                const std::vector<NDArray*>& pull_values,
+                int priority) override {
+    // group values on the same key
+    CHECK_EQ(push_values.size(), pull_values.size());
+    std::vector<int> uniq_push_keys, uniq_pull_keys;
+    std::vector<std::vector<NDArray> > grouped_push_vals;
+    std::vector<std::vector<NDArray*> > grouped_pull_vals;
+    GroupKVPairs(keys, push_values, &uniq_push_keys, &grouped_push_vals);
+    GroupKVPairs(keys, pull_values, &uniq_pull_keys, &grouped_pull_vals);
+
+    // do allreduce one by one
+    CHECK_EQ(uniq_push_keys.size(), uniq_pull_keys.size());
+    for (size_t i = 0; i < uniq_push_keys.size(); ++i) {
+      CHECK_EQ(uniq_push_keys[i], uniq_pull_keys[i]);
+      const auto& push_vals = grouped_push_vals[i];
+      const auto& pull_vals = grouped_pull_vals[i];
+      CHECK_EQ(push_vals.size(), pull_vals.size());
+      size_t n = push_vals.size();
+
+      // init
+      if (!inited_nccl_) {
+        devs_.resize(n);
+        for (size_t j = 0; j < n; ++j) {
+          CHECK_EQ(push_vals[j].ctx().dev_type, Context::kGPU);
+          devs_[j] = push_vals[j].ctx().dev_id;
+        }
+        InitNCCL();
+      } else {
+        CHECK_EQ(devs_.size(), n);
+      }
+
+      // prepare data
+      size_t len = push_vals[0].shape().Size();
+      std::vector<engine::VarHandle> cvars, mvars(n);
+      std::vector<void*> sendbuff(n), recvbuff(n);
+      for (size_t j = 0; j < n; ++j) {
+        CHECK_EQ(push_vals[j].ctx().dev_type, Context::kGPU);
+        CHECK_EQ(pull_vals[j]->ctx().dev_type, Context::kGPU);
+        CHECK_EQ(push_vals[j].ctx().dev_id,
+                 pull_vals[j]->ctx().dev_id);
+        CHECK_EQ(push_vals[j].shape().Size(), len);
+        CHECK_EQ(pull_vals[j]->shape().Size(), len);
+
+        mvars[j] = pull_vals[j]->var();
+        if (pull_vals[j]->var() != push_vals[j].var()) {
+          cvars.push_back(push_vals[j].var());
+        }
+        sendbuff[j] = push_vals[j].data().dptr_;
+        recvbuff[j] = pull_vals[j]->data().dptr_;
+      }
+
+      // the callback which does the work
+      auto allreduce = [this, sendbuff, recvbuff, len] (
+          RunContext rctx, Engine::CallbackOnComplete cb) {
+        AllReduce(sendbuff, recvbuff, len);
+        cb();
+      };
+
+      CHECK_NOTNULL(Engine::Get())->PushAsync(
+          allreduce,
+          Context::CPUPinned(0),
+          cvars,
+          mvars,
+          FnProperty::kNormal, priority);
+    }
+  }
+
+ private:
+  /**
+   * \brief group values on keys
+   */
+  template <typename V>
+  void GroupKVPairs(const std::vector<int>& keys,
+                    const std::vector<V>& values,
+                    std::vector<int>* uniq_keys,
+                    std::vector<std::vector<V> >* grouped_vals) {
+    CHECK_EQ(keys.size(), values.size());
+    // TODO(mli) check if already sorted as an optimization
+    using Idx = std::pair<int, int>;
+    std::vector<Idx> idx(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+      idx[i].first = keys[i]; idx[i].second = i;
+    }
+    std::sort(idx.begin(), idx.end(), [](const Idx& a, const Idx& b) {
+        return a.first < b.first;
+      });
+
+    int pre_key = idx[0].first - 1;
+    for (auto i : idx) {
+      if (i.first != pre_key) {
+        uniq_keys->push_back(i.first);
+        grouped_vals->push_back({values[i.second]});
+        pre_key = i.first;;
+      } else {
+        grouped_vals->back().push_back(values[i.second]);
+      }
+    }
+  }
+
+  void InitNCCL() {
+    size_t n = devs_.size();
+    comms_.resize(n);
+    streams_.resize(n);
+    NCCLCHECK(ncclCommInitAll(comms_.data(), n, devs_.data()));
+    for (size_t i = 0; i < n; ++i) {
+      CUDACHECK(cudaSetDevice(devs_[i]));
+      CUDACHECK(cudaStreamCreate(&streams_[i]));
+    }
+    inited_nccl_ = true;
+  }
+
+  void AllReduce(const std::vector<void*>& sendbuff,
+                 const std::vector<void*>& recvbuff,
+                 size_t len) {
+    // do allreduce
+    for (size_t i = 0; i < devs_.size(); ++i) {
+      CUDACHECK(cudaSetDevice(devs_[i]));
+      NCCLCHECK(ncclAllReduce(
+          sendbuff[i], recvbuff[i],
+          len, ncclFloat, ncclSum, comms_[i], streams_[i]));
+    }
+    // wait until finished
+    for (size_t i = 0; i < devs_.size(); ++i) {
+      CUDACHECK(cudaStreamSynchronize(streams_[i]));
+    }
+  }
+
+  bool inited_nccl_;
+  std::vector<int> devs_;
+  std::vector<ncclComm_t> comms_;
+  std::vector<cudaStream_t> streams_;
+};
+
+} // namespace kvstore
+} // namespace mxnet
+
+#endif  // MXNET_KVSTORE_KVSTORE_NCCL_H_

--- a/src/kvstore/kvstore_nccl.h
+++ b/src/kvstore/kvstore_nccl.h
@@ -10,6 +10,7 @@
 #include <mxnet/kvstore.h>
 #include <algorithm>
 #include <vector>
+#include <utility>
 
 namespace mxnet {
 namespace kvstore {
@@ -18,13 +19,13 @@ namespace kvstore {
     cudaError_t e = cmd;                                 \
     CHECK(e == cudaSuccess) << "CUDA failure "           \
                             << cudaGetErrorString(e);    \
-  } while(false)
+  } while (false)
 
 #define NCCLCHECK(cmd) do {                             \
     ncclResult_t e = cmd;                               \
     CHECK(e == ncclSuccess) << "NCLL failure "          \
                             << ncclGetErrorString(e);   \
-  } while(false)
+  } while (false)
 
 class KVStoreNCCL : public KVStore {
  public:
@@ -196,7 +197,7 @@ class KVStoreNCCL : public KVStore {
   std::vector<cudaStream_t> streams_;
 };
 
-} // namespace kvstore
-} // namespace mxnet
+}  // namespace kvstore
+}  // namespace mxnet
 
 #endif  // MXNET_KVSTORE_KVSTORE_NCCL_H_


### PR DESCRIPTION
@hjk41 the implementation is done, to use it

1. install nccl
2. compile with USE_NCCL=1
3. it will take effect if `--kv-store device`, for example
```
python train_mnist.py --gpus 0,1 --kv-store device
```

however, nccl seems having bugs, or my implementation is wrong. the `ncclAllReduce` is blocked randomly, and it blocks every time when using `python train_imagnet.py --network vgg`.

for alexnet, i didn't see a big improvement for using nccl...