### PR TITLE
Make Executor::SetMonitorCallback take std::function as parameter

### DIFF
--- a/example/autoencoder/autoencoder.py
+++ b/example/autoencoder/autoencoder.py
@@ -134,7 +134,7 @@ class AutoEncoderModel(model.MXModel):
     def layerwise_pretrain(self, X, batch_size, n_iter, optimizer, l_rate, decay, lr_scheduler=None):
         def l2_norm(label, pred):
             return np.mean(np.square(label-pred))/2.0
-        solver = Solver('sgd', momentum=0.9, wd=decay, learning_rate=l_rate, lr_scheduler=lr_scheduler)
+        solver = Solver(optimizer, momentum=0.9, wd=decay, learning_rate=l_rate, lr_scheduler=lr_scheduler)
         solver.set_metric(mx.metric.CustomMetric(l2_norm))
         solver.set_monitor(Monitor(1000))
         data_iter = mx.io.NDArrayIter({'data': X}, batch_size=batch_size, shuffle=True,
@@ -154,7 +154,7 @@ class AutoEncoderModel(model.MXModel):
     def finetune(self, X, batch_size, n_iter, optimizer, l_rate, decay, lr_scheduler=None):
         def l2_norm(label, pred):
            return np.mean(np.square(label-pred))/2.0
-        solver = Solver('sgd', momentum=0.9, wd=decay, learning_rate=l_rate, lr_scheduler=lr_scheduler)
+        solver = Solver(optimizer, momentum=0.9, wd=decay, learning_rate=l_rate, lr_scheduler=lr_scheduler)
         solver.set_metric(mx.metric.CustomMetric(l2_norm))
         solver.set_monitor(Monitor(1000))
         data_iter = mx.io.NDArrayIter({'data': X}, batch_size=batch_size, shuffle=True,

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -56,7 +56,8 @@ typedef void *OptimizerCreator;
 typedef void *OptimizerHandle;
 
 MXNET_EXTERN_C typedef void (*ExecutorMonitorCallback)(const char*,
-                                                       NDArrayHandle);
+                                                       NDArrayHandle,
+                                                       void *);
 
 MXNET_EXTERN_C {
 struct NativeOpInfo {
@@ -730,7 +731,8 @@ MXNET_DLL int MXExecutorBindX(SymbolHandle symbol_handle,
  * \brief set a call back to notify the completion of operation
  */
 MXNET_DLL int MXExecutorSetMonitorCallback(ExecutorHandle handle,
-                                           ExecutorMonitorCallback callback);
+                                           ExecutorMonitorCallback callback,
+                                           void* callback_handle);
 //--------------------------------------------
 // Part 5: IO Interface
 //--------------------------------------------

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -55,8 +55,8 @@ typedef void *OptimizerCreator;
 /*! \brief handle to Optimizer*/
 typedef void *OptimizerHandle;
 
-MXNET_EXTERN_C typedef void (*ExcecutorMonitorCallback)(const char*,
-                                                        NDArrayHandle);
+MXNET_EXTERN_C typedef void (*ExecutorMonitorCallback)(const char*,
+                                                       NDArrayHandle);
 
 MXNET_EXTERN_C {
 struct NativeOpInfo {
@@ -730,7 +730,7 @@ MXNET_DLL int MXExecutorBindX(SymbolHandle symbol_handle,
  * \brief set a call back to notify the completion of operation
  */
 MXNET_DLL int MXExecutorSetMonitorCallback(ExecutorHandle handle,
-                                           ExcecutorMonitorCallback callback);
+                                           ExecutorMonitorCallback callback);
 //--------------------------------------------
 // Part 5: IO Interface
 //--------------------------------------------

--- a/include/mxnet/symbolic.h
+++ b/include/mxnet/symbolic.h
@@ -321,9 +321,13 @@ class Executor {
                         const std::vector<OpReqType> &grad_req_type,
                         const std::vector<NDArray> &aux_states);
   /*!
+   * \brief the prototype of user-defined monitor callback
+   */
+  typedef std::function<void(const char*, void*)> MonitorCallback;
+  /*!
    * \brief Install a callback to notify the completion of operation.
    */
-  virtual void SetMonitorCallback(ExcecutorMonitorCallback callback) {}
+  virtual void SetMonitorCallback(const MonitorCallback& callback) {}
 };  // class operator
 }  // namespace mxnet
 #endif  // MXNET_SYMBOLIC_H_

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -824,10 +824,14 @@ int MXExecutorBindX(SymbolHandle symbol_handle,
 }
 
 int MXExecutorSetMonitorCallback(ExecutorHandle handle,
-                                 ExcecutorMonitorCallback callback) {
+                                 ExecutorMonitorCallback callback) {
   API_BEGIN();
+  std::function<void(const char*, void*)> clbk
+  = [callback](const char *name, void* handle) {
+    callback(name, handle);
+  };
   Executor *exec = static_cast<Executor*>(handle);
-  exec->SetMonitorCallback(callback);
+  exec->SetMonitorCallback(clbk);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -824,11 +824,14 @@ int MXExecutorBindX(SymbolHandle symbol_handle,
 }
 
 int MXExecutorSetMonitorCallback(ExecutorHandle handle,
-                                 ExecutorMonitorCallback callback) {
+                                 ExecutorMonitorCallback callback,
+                                 void* callback_handle) {
   API_BEGIN();
+  ExecutorMonitorCallback callback_temp = callback;
+  void* callback_handle_temp = callback_handle;
   std::function<void(const char*, void*)> clbk
-  = [callback](const char *name, void* handle) {
-    callback(name, handle);
+  = [callback_temp, callback_handle_temp](const char *name, void* handle) {
+    callback_temp(name, handle, callback_handle_temp);
   };
   Executor *exec = static_cast<Executor*>(handle);
   exec->SetMonitorCallback(clbk);

--- a/src/symbol/graph_executor.h
+++ b/src/symbol/graph_executor.h
@@ -32,7 +32,8 @@ class GraphExecutor : public Executor {
   }
   void Print(std::ostream &os) const override; // NOLINT(*)
   // install callback
-  void SetMonitorCallback(ExcecutorMonitorCallback callback) {
+  void SetMonitorCallback(const MonitorCallback& callback) {
+    CHECK(callback) << "invalid callback";
     monitor_callback_ = callback;
   }
   // implement Executor::Bind, only call it once.


### PR DESCRIPTION
I change it as the way implemented in KVStore->set_updater, because it is necessary for supporting JNI callback function (scala-package in progress).

In order to support JNI callback, we have to bind the function with a jobject, (see https://github.com/javelinjs/mxnet/blob/scala-package-cc/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc#L217), which is impossible when we deal with a pure C function ptr. 

And here is what I'm going to do once this PR is accepted: https://github.com/javelinjs/mxnet/blob/scala-package-cc/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc#L466

Please let me know if there exists any better solution.

This PR also includes a typo fixing and a minor bug in example/autoencoder.