### PR TITLE
[WIP] ndarray type support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,10 +198,18 @@ rpkg:	roxygen
 	cp -rf dmlc-core/include/* R-package/inst/include/
 	R CMD build --no-build-vignettes R-package
 
+ifneq ($(EXTRA_OPERATORS),)
 clean:
 	$(RM) -r build lib bin *~ */*~ */*/*~ */*/*/*~
 	cd $(DMLC_CORE); make clean; cd -
 	cd $(PS_PATH); make clean; cd -
+	$(RM) -r $(EXTRA_OPERATORS)/build
+else
+clean:
+	$(RM) -r build lib bin *~ */*~ */*/*~ */*/*/*~
+	cd $(DMLC_CORE); make clean; cd -
+	cd $(PS_PATH); make clean; cd -
+endif
 
 clean_all: clean
 

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -147,6 +147,26 @@ MXNET_DLL int MXNDArrayCreate(const mx_uint *shape,
                               int dev_id,
                               int delay_alloc,
                               NDArrayHandle *out);
+
+/*!
+ * \brief create a NDArray with specified shape and data type
+ * \param shape the pointer to the shape
+ * \param ndim the dimension of the shape
+ * \param dev_type device type, specify device we want to take
+ * \param dev_id the device id of the specific device
+ * \param delay_alloc whether to delay allocation until
+ *    the narray is first mutated
+ * \param dtype data type of created array
+ * \param out the returning handle
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXNDArrayCreateEx(const mx_uint *shape,
+                              mx_uint ndim,
+                              int dev_type,
+                              int dev_id,
+                              int delay_alloc,
+                              int dtype,
+                              NDArrayHandle *out);
 /*!
  * \brief create a NDArray handle that is loaded from raw bytes.
  * \param buf the head of the raw bytes
@@ -205,7 +225,7 @@ MXNET_DLL int MXNDArrayLoad(const char* fname,
  * \param size the memory size we want to copy from.
  */
 MXNET_DLL int MXNDArraySyncCopyFromCPU(NDArrayHandle handle,
-                                       const mx_float *data,
+                                       const void *data,
                                        size_t size);
 /*!
  * \brief Perform a synchronize copyto a continugous CPU memory region.
@@ -219,7 +239,7 @@ MXNET_DLL int MXNDArraySyncCopyFromCPU(NDArrayHandle handle,
  * \param size the memory size we want to copy into.
  */
 MXNET_DLL int MXNDArraySyncCopyToCPU(NDArrayHandle handle,
-                                     mx_float *data,
+                                     void *data,
                                      size_t size);
 /*!
  * \brief Wait until all the pending writes with respect NDArray are finished.
@@ -277,6 +297,14 @@ MXNET_DLL int MXNDArrayGetShape(NDArrayHandle handle,
  */
 MXNET_DLL int MXNDArrayGetData(NDArrayHandle handle,
                                mx_float **out_pdata);
+/*!
+ * \brief get the type of the data in NDArray
+ * \param handle the handle to the narray
+ * \param out_dtype pointer holder to get type of data
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXNDArrayGetDType(NDArrayHandle handle,
+                               int *out_dtype);
 /*!
  * \brief get the context of the NDArray
  * \param handle the handle to the narray

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -36,6 +36,7 @@ class MXNET_API NDArray {
    * \param shape the shape of array
    * \param ctx context of NDArray
    * \param delay_alloc whether delay the allocation
+   * \param dtype data type of this ndarray
    */
   NDArray(const TShape &shape, Context ctx,
           bool delay_alloc = false, int dtype = mshadow::default_type_flag)
@@ -202,7 +203,6 @@ class MXNET_API NDArray {
    *
    * \param data the data source to copy from.
    * \param size the size of the source array, in sizeof(DType) not raw btyes.
-   * \param dtype the data type of source array.
    */
   void SyncCopyFromCPU(const void *data, size_t size) const;
   /*!
@@ -214,7 +214,6 @@ class MXNET_API NDArray {
    *
    * \param data the data source to copyinto.
    * \param size the memory size we want to copy into, in sizeof(DType) not raw btyes.
-   * \param dtype the data type of target array.
    */
   void SyncCopyToCPU(void *data, size_t size) const;
   /*!

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -38,8 +38,9 @@ class MXNET_API NDArray {
    * \param delay_alloc whether delay the allocation
    */
   NDArray(const TShape &shape, Context ctx,
-          bool delay_alloc = false)
-      : ptr_(std::make_shared<Chunk>(shape.Size(), ctx, delay_alloc)), shape_(shape), offset_(0) {
+          bool delay_alloc = false, int dtype = mshadow::default_type_flag)
+      : ptr_(std::make_shared<Chunk>(shape.Size(), ctx, delay_alloc, dtype)),
+        shape_(shape), offset_(0), dtype_(dtype) {
   }
   /*!
    * \brief constructing a static NDArray that shares data with TBlob
@@ -61,14 +62,23 @@ class MXNET_API NDArray {
    * \return the data TBlob
    */
   inline TBlob data() const {
-    return TBlob(static_cast<real_t*>(ptr_->shandle.dptr) + offset_, \
-                 shape_, ptr_->shandle.ctx.dev_mask());
+    MSHADOW_TYPE_SWITCH(dtype_, DType, {
+      return TBlob(static_cast<DType*>(ptr_->shandle.dptr)
+        + offset_, shape_, ptr_->shandle.ctx.dev_mask());
+    });
+    return TBlob();
   }
   /*!
    * \return the context of NDArray, this function is only valid when the NDArray is not empty
    */
   inline Context ctx() const {
     return ptr_->shandle.ctx;
+  }
+  /*!
+   * \return the data type of NDArray, this function is only valid when the NDArray is not empty
+   */
+  inline int dtype() const {
+    return dtype_;
   }
   /*! \return whether this ndarray is not initialized */
   inline bool is_none() const {
@@ -191,9 +201,10 @@ class MXNET_API NDArray {
    *  not wrapped by NDArray(thus dependency not being tracked).
    *
    * \param data the data source to copy from.
-   * \param size the memory size we want to copy from.
+   * \param size the size of the source array, in sizeof(DType) not raw btyes.
+   * \param dtype the data type of source array.
    */
-  void SyncCopyFromCPU(const real_t *data, size_t size) const;
+  void SyncCopyFromCPU(const void *data, size_t size) const;
   /*!
    * \brief Do a synchronize copy to a continugous CPU memory region.
    *
@@ -202,9 +213,10 @@ class MXNET_API NDArray {
    *  not wrapped by NDArray(thus dependency not being tracked).
    *
    * \param data the data source to copyinto.
-   * \param size the memory size we want to copy into.
+   * \param size the memory size we want to copy into, in sizeof(DType) not raw btyes.
+   * \param dtype the data type of target array.
    */
-  void SyncCopyToCPU(real_t *data, size_t size) const;
+  void SyncCopyToCPU(void *data, size_t size) const;
   /*!
    * \brief Slice a NDArray
    * \param begin begin index in first dim
@@ -291,13 +303,13 @@ class MXNET_API NDArray {
         shandle.ctx = Context::GPU(dev_id);
       }
       shandle.dptr = data.dptr_;
-      shandle.size = data.shape_.Size() * sizeof(real_t);
+      shandle.size = data.shape_.Size() * mshadow::mshadow_sizeof(data.type_flag_);
     }
     /*! \brief construct a new chunk */
-    Chunk(uint64_t size, Context ctx, bool delay_alloc_)
+    Chunk(uint64_t size, Context ctx, bool delay_alloc_, int dtype)
         : static_data(false), delay_alloc(true) {
       var = Engine::Get()->NewVariable();
-      shandle.size = size * sizeof(real_t);
+      shandle.size = size * mshadow::mshadow_sizeof(dtype);
       shandle.ctx = ctx;
       if (!delay_alloc_) this->CheckAndAlloc();
     }
@@ -326,6 +338,8 @@ class MXNET_API NDArray {
   TShape shape_;
   /*! \brief offset in chunk */
   size_t offset_;
+  /*! \brief type of data */
+  int dtype_;
 };
 
 /*!

--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -61,12 +61,12 @@ struct Resource {
    * \return the mshadow random number generator requested.
    * \tparam xpu the device type of random number generator.
    */
-  template<typename xpu>
-  inline mshadow::Random<xpu>* get_random(
+  template<typename xpu, typename DType>
+  inline mshadow::Random<xpu, DType>* get_random(
       mshadow::Stream<xpu> *stream) const {
     CHECK_EQ(req.type, ResourceRequest::kRandom);
-    mshadow::Random<xpu> *ret =
-        static_cast<mshadow::Random<xpu>*>(ptr_);
+    mshadow::Random<xpu, DType> *ret =
+        static_cast<mshadow::Random<xpu, DType>*>(ptr_);
     ret->set_stream(stream);
     return ret;
   }

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -46,6 +46,7 @@ _LIB = _load_lib()
 mx_uint = ctypes.c_uint
 mx_float = ctypes.c_float
 mx_float_p = ctypes.POINTER(mx_float)
+mx_real_t = np.float32
 NDArrayHandle = ctypes.c_void_p
 FunctionHandle = ctypes.c_void_p
 SymbolCreatorHandle = ctypes.c_void_p

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -7,11 +7,27 @@ import warnings
 import sys
 import numpy as np
 from .base import _LIB, string_types, numeric_types
-from .base import c_array, py_str, c_str
-from .base import mx_uint, mx_float, mx_float_p, NDArrayHandle, FunctionHandle
+from .base import c_array, py_str, c_str, mx_real_t
+from .base import mx_uint, mx_float, NDArrayHandle, FunctionHandle
 from .base import ctypes2buffer
 from .base import check_call, ctypes2docstring
 from .context import Context
+
+_DTYPE_NP_TO_MX = {
+    np.float32 : 0,
+    np.float64 : 1,
+    np.float16 : 2,
+    np.uint8   : 3,
+    np.int32   : 4
+}
+
+_DTYPE_MX_TO_NP = {
+    0 : np.float32,
+    1 : np.float64,
+    2 : np.float16,
+    3 : np.uint8,
+    4 : np.int32
+}
 
 def _new_empty_handle():
     """Return a new empty handle.
@@ -26,7 +42,7 @@ def _new_empty_handle():
     check_call(_LIB.MXNDArrayCreateNone(ctypes.byref(hdl)))
     return hdl
 
-def _new_alloc_handle(shape, ctx, delay_alloc):
+def _new_alloc_handle(shape, ctx, delay_alloc, dtype=mx_real_t):
     """Return a new handle with specified shape and context.
 
     Empty handle is only used to hold results
@@ -36,12 +52,13 @@ def _new_alloc_handle(shape, ctx, delay_alloc):
     a new empty ndarray handle
     """
     hdl = NDArrayHandle()
-    check_call(_LIB.MXNDArrayCreate(
+    check_call(_LIB.MXNDArrayCreateEx(
         c_array(mx_uint, shape),
         mx_uint(len(shape)),
         ctypes.c_int(ctx.device_typeid),
         ctypes.c_int(ctx.device_id),
         ctypes.c_int(int(delay_alloc)),
+        ctypes.c_int(int(_DTYPE_NP_TO_MX[np.dtype(dtype).type])),
         ctypes.byref(hdl)))
     return hdl
 
@@ -230,16 +247,16 @@ class NDArray(object):
         """
         if not isinstance(source_array, np.ndarray):
             try:
-                source_array = np.array(source_array, dtype=np.float32)
+                source_array = np.array(source_array, dtype=self.dtype)
             except:
                 raise TypeError('array must be an array_like data,' +
                                 'type %s is not supported' % str(type(array)))
-        source_array = np.ascontiguousarray(source_array, dtype=np.float32)
+        source_array = np.ascontiguousarray(source_array, dtype=self.dtype)
         if source_array.shape != self.shape:
             raise ValueError('array shape do not match the shape of NDArray')
         check_call(_LIB.MXNDArraySyncCopyFromCPU(
             self.handle,
-            source_array.ctypes.data_as(mx_float_p),
+            source_array.ctypes.data_as(ctypes.c_void_p),
             ctypes.c_size_t(source_array.size)))
 
     def _slice(self, start, stop):
@@ -307,6 +324,19 @@ class NDArray(object):
             self.handle, ctypes.byref(dev_typeid), ctypes.byref(dev_id)))
         return Context(Context.devtype2str[dev_typeid.value], dev_id.value)
 
+    @property
+    def dtype(self):
+        """Get data type of current NDArray.
+
+        Returns
+        -------
+        an numpy.dtype object representing type of current ndarray
+        """
+        mx_dtype = ctypes.c_int()
+        check_call(_LIB.MXNDArrayGetDType(
+            self.handle, ctypes.byref(mx_dtype)))
+        return _DTYPE_MX_TO_NP[mx_dtype.value]
+
     def asnumpy(self):
         """Return a copied numpy array of current array.
 
@@ -315,10 +345,10 @@ class NDArray(object):
         array : numpy.ndarray
             A copy of array content.
         """
-        data = np.empty(self.shape, dtype=np.float32)
+        data = np.empty(self.shape, dtype=self.dtype)
         check_call(_LIB.MXNDArraySyncCopyToCPU(
             self.handle,
-            data.ctypes.data_as(mx_float_p),
+            data.ctypes.data_as(ctypes.c_void_p),
             ctypes.c_size_t(data.size)))
         return data
 
@@ -335,6 +365,23 @@ class NDArray(object):
         if self.shape != (1,):
             raise ValueError("The current array is not a scalar")
         return self.asnumpy()[0]
+
+    def astype(self, dtype):
+        """Return a copied numpy array of current array with specified type.
+
+        Parameters
+        ----------
+        dtype : numpy.dtype or string
+            Desired type of result array.
+
+        Returns
+        -------
+        array : numpy.ndarray
+            A copy of array content.
+        """
+        res = empty(self.shape, ctx=self.context, dtype=dtype)
+        self.copyto(res)
+        return res
 
     def copyto(self, other):
         """Copy the content of current array to other.
@@ -360,7 +407,7 @@ class NDArray(object):
                 return
             return NDArray._copyto(self, out=other)
         elif isinstance(other, Context):
-            hret = NDArray(_new_alloc_handle(self.shape, other, True))
+            hret = NDArray(_new_alloc_handle(self.shape, other, True, self.dtype))
             return NDArray._copyto(self, out=hret)
         else:
             raise TypeError('copyto do not support type ' + str(type(other)))
@@ -388,7 +435,7 @@ def onehot_encode(indices, out):
     # pylint: enable= no-member, protected-access
 
 
-def empty(shape, ctx=None):
+def empty(shape, ctx=None, dtype=mx_real_t):
     """Create an empty uninitialized new NDArray, with specified shape.
 
     Parameters
@@ -408,9 +455,9 @@ def empty(shape, ctx=None):
         shape = (shape, )
     if ctx is None:
         ctx = Context.default_ctx
-    return NDArray(handle=_new_alloc_handle(shape, ctx, False))
+    return NDArray(handle=_new_alloc_handle(shape, ctx, False, dtype))
 
-def zeros(shape, ctx=None):
+def zeros(shape, ctx=None, dtype=mx_real_t):
     """Create a new NDArray filled with 0, with specified shape.
 
     Parameters
@@ -425,11 +472,11 @@ def zeros(shape, ctx=None):
     out: Array
         The created NDArray.
     """
-    arr = empty(shape, ctx)
+    arr = empty(shape, ctx, dtype)
     arr[:] = 0.0
     return arr
 
-def ones(shape, ctx=None):
+def ones(shape, ctx=None, dtype=mx_real_t):
     """Create a new NDArray filled with 1, with specified shape.
 
     Parameters
@@ -444,12 +491,12 @@ def ones(shape, ctx=None):
     out: Array
         The created NDArray.
     """
-    arr = empty(shape, ctx)
+    arr = empty(shape, ctx, dtype)
     arr[:] = 1.0
     return arr
 
 
-def array(source_array, ctx=None):
+def array(source_array, ctx=None, dtype=mx_real_t):
     """Create a new NDArray that copies content from source_array.
 
     Parameters
@@ -468,10 +515,10 @@ def array(source_array, ctx=None):
 
     if not isinstance(source_array, np.ndarray):
         try:
-            source_array = np.array(source_array, dtype=np.float32)
+            source_array = np.array(source_array, dtype=dtype)
         except:
             raise TypeError('source_array must be array like object')
-    arr = empty(source_array.shape, ctx)
+    arr = empty(source_array.shape, ctx, dtype)
     arr[:] = source_array
     return arr
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -128,6 +128,22 @@ int MXNDArrayCreate(const mx_uint *shape,
   API_END();
 }
 
+int MXNDArrayCreateEx(const mx_uint *shape,
+                    mx_uint ndim,
+                    int dev_type,
+                    int dev_id,
+                    int delay_alloc,
+                    int dtype,
+                    NDArrayHandle *out) {
+  API_BEGIN();
+  *out = new NDArray(
+      TShape(shape, shape + ndim),
+      Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id),
+      delay_alloc != 0,
+      dtype);
+  API_END();
+}
+
 int MXNDArrayLoadFromRawBytes(const void *buf,
                               size_t size,
                               NDArrayHandle *out) {
@@ -156,7 +172,7 @@ int MXNDArraySaveRawBytes(NDArrayHandle handle,
 }
 
 int MXNDArraySyncCopyFromCPU(NDArrayHandle handle,
-                             const mx_float *data,
+                             const void *data,
                              size_t size) {
   API_BEGIN();
   static_cast<NDArray*>(handle)->SyncCopyFromCPU(data, size);
@@ -164,7 +180,7 @@ int MXNDArraySyncCopyFromCPU(NDArrayHandle handle,
 }
 
 int MXNDArraySyncCopyToCPU(NDArrayHandle handle,
-                           mx_float *data,
+                           void *data,
                            size_t size) {
   API_BEGIN();
   static_cast<NDArray*>(handle)->SyncCopyToCPU(data, size);
@@ -288,6 +304,18 @@ int MXNDArrayGetData(NDArrayHandle handle,
     *out_pdata = b.FlatTo2D<cpu, mx_float>().dptr_;
   } else {
     *out_pdata = nullptr;
+  }
+  API_END();
+}
+
+int MXNDArrayGetDType(NDArrayHandle handle,
+                     int *out_dtype) {
+  API_BEGIN();
+  NDArray *arr = static_cast<NDArray*>(handle);
+  if (!arr->is_none()) {
+    *out_dtype = arr->dtype();
+  } else {
+    *out_dtype = -1;
   }
   API_END();
 }

--- a/src/common/tblob_op_registry.cc
+++ b/src/common/tblob_op_registry.cc
@@ -279,9 +279,10 @@ void TBlobOpRegEntryImpl::RegisterUnary() {
     if (unary_infer_ != nullptr) dshape = unary_infer_(dshape);
 
     if (out->is_none()) {
-      *out = NDArray(dshape, src.ctx(), true);
+      *out = NDArray(dshape, src.ctx(), true, src.dtype());
     } else {
       CHECK(out->ctx() == src.ctx()) << "target context mismatch";
+      CHECK(out->dtype() == src.dtype()) << "target data type mismatch";
       CHECK(out->shape() == dshape) << "target shape mismatch "
       << out->shape() << " vs. " << dshape;
     }

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -34,7 +34,7 @@ void BinaryOp(const NDArray &lhs,
   }
   // if out is none, allocate space
   if (out->is_none()) {
-    *out = NDArray(OP::GetShape(lhs.shape(), rhs.shape()), lhs.ctx(), true);
+    *out = NDArray(OP::GetShape(lhs.shape(), rhs.shape()), lhs.ctx(), true, lhs.dtype());
   } else {
     // no check if both of them are on cpu
     if (lhs.ctx().dev_mask() != cpu::kDevMask ||
@@ -118,7 +118,7 @@ void ScalarOp(const NDArray &lhs,
               const real_t &rhs,
               NDArray *out) {
   if (out->is_none()) {
-    *out = NDArray(lhs.shape(), lhs.ctx(), true);
+    *out = NDArray(lhs.shape(), lhs.ctx(), true, lhs.dtype());
   } else {
     CHECK(out->ctx() == lhs.ctx()) << "target context mismatch";
     CHECK(out->shape() == lhs.shape()) << "target shape mismatch";
@@ -276,7 +276,7 @@ void ClipOp(const NDArray &src,
             const real_t &a_min, const real_t &a_max,
             NDArray *out) {
   if (out->is_none()) {
-    *out = NDArray(src.shape(), src.ctx(), true);
+    *out = NDArray(src.shape(), src.ctx(), true, src.dtype());
   } else {
     CHECK(out->ctx() == src.ctx()) << "target context mismatch";
     CHECK(out->shape() == src.shape()) << "target shape mismatch";
@@ -466,12 +466,9 @@ void NDArray::Save(dmlc::Stream *strm) const {
   }
   // save type flag
   int32_t type_flag = save_data.type_flag_;
-  CHECK(type_flag == mshadow::DataType<real_t>::kFlag)
-      << "Only support float NDArray so far";
   strm->Write(&type_flag, sizeof(type_flag));
   CHECK(save_data.CheckContiguous());
-  // save data: need to change this after more type mask is supported
-  size_t type_size = sizeof(real_t);
+  size_t type_size = mshadow::mshadow_sizeof(type_flag);
   strm->Write(save_data.dptr_, type_size * shape_.Size());
 }
 
@@ -488,12 +485,10 @@ bool NDArray::Load(dmlc::Stream *strm) {
   // load type flag
   int32_t type_flag;
   if (strm->Read(&type_flag, sizeof(type_flag)) != sizeof(type_flag)) return false;
-  CHECK(type_flag == mshadow::DataType<real_t>::kFlag)
-      << "Only support float NDArray so far, type_flag=" << type_flag;
   // load data into CPU
-  NDArray temp(shape, Context::CPU());
+  NDArray temp(shape, Context::CPU(), false, type_flag);
   TBlob load_data = temp.data();
-  size_t type_size = sizeof(real_t);
+  size_t type_size = mshadow::mshadow_sizeof(type_flag);
   size_t nread = type_size * shape.Size();
 
   if (strm->Read(load_data.dptr_, nread) != nread) return false;
@@ -536,19 +531,19 @@ void NDArray::Load(dmlc::Stream* fi,
 }
 
 NDArray NDArray::Copy(Context ctx) const {
-  NDArray ret(shape(), ctx, true);
+  NDArray ret(shape(), ctx, true, dtype_);
   CopyFromTo(*this, &ret);
   return ret;
 }
 
-void NDArray::SyncCopyFromCPU(const real_t *data, size_t size) const {
+void NDArray::SyncCopyFromCPU(const void *data, size_t size) const {
   this->WaitToWrite();
   TShape dshape = this->shape();
   CHECK_EQ(dshape.Size(), size)
       << "Memory size do not match";
   Context ctx = this->ctx();
   TBlob dst = this->data();
-  TBlob src((real_t*)data, dshape, cpu::kDevMask); // NOLINT(*)
+  TBlob src((void*)data, dshape, cpu::kDevMask, this->dtype_); // NOLINT(*)
 
   RunContext run_ctx;
   run_ctx.stream = nullptr;
@@ -568,14 +563,14 @@ void NDArray::SyncCopyFromCPU(const real_t *data, size_t size) const {
   }
 }
 
-void NDArray::SyncCopyToCPU(real_t *data, size_t size) const {
+void NDArray::SyncCopyToCPU(void *data, size_t size) const {
   this->WaitToRead();
   TShape dshape = this->shape();
   CHECK_EQ(dshape.Size(), size)
       << "Memory size do not match";
   Context ctx = this->ctx();
   TBlob src = this->data();
-  TBlob dst(data, dshape, cpu::kDevMask); // NOLINT(*)
+  TBlob dst(data, dshape, cpu::kDevMask, this->dtype_); // NOLINT(*)
 
   RunContext run_ctx;
   run_ctx.stream = nullptr;

--- a/src/ndarray/ndarray_function-inl.h
+++ b/src/ndarray/ndarray_function-inl.h
@@ -40,9 +40,15 @@ inline void EvalBinary_(const TBlob &lhs, const TBlob &rhs,
                         TBlob *ret, RunContext ctx) {
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  ret->FlatTo2D<xpu, real_t>(s)
-      = F<typename OP::mshadow_op>(lhs.FlatTo2D<xpu, real_t>(s),
-                                   rhs.FlatTo2D<xpu, real_t>(s));
+  CHECK_EQ(ret->type_flag_, lhs.type_flag_)
+    << "Only support input/output with the same data type";
+  CHECK_EQ(ret->type_flag_, rhs.type_flag_)
+    << "Only support input/output with the same data type";
+  MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+    ret->FlatTo2D<xpu, DType>(s)
+      = F<typename OP::mshadow_op>(lhs.FlatTo2D<xpu, DType>(s),
+                                   rhs.FlatTo2D<xpu, DType>(s));
+  });
 }
 
 template<typename xpu, typename OP>
@@ -50,9 +56,14 @@ inline void EvalDot_(const TBlob &lhs, const TBlob &rhs,
                      TBlob *ret, RunContext ctx) {
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  ret->FlatTo2D<xpu, real_t>(s)
-    = dot(lhs.FlatTo2D<xpu, real_t>(s),
-          rhs.FlatTo2D<xpu, real_t>(s));
+  CHECK_EQ(ret->type_flag_, lhs.type_flag_)
+    << "Only support input/output with the same data type";
+  CHECK_EQ(ret->type_flag_, rhs.type_flag_)
+    << "Only support input/output with the same data type";
+  MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+    ret->FlatTo2D<xpu, DType>(s) = dot(lhs.FlatTo2D<xpu, DType>(s),
+                                       rhs.FlatTo2D<xpu, DType>(s));
+  });
 }
 
 template<typename xpu, typename OP>
@@ -60,9 +71,16 @@ inline void EvalOneHot_(const TBlob &index, const TBlob &rhs,
                         TBlob *ret, RunContext ctx) {
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  ret->get<xpu, 2, real_t>(s)
-      = one_hot_encode(index.get<xpu, 1, real_t>(s),
-                       rhs.shape_[1]);
+  // TODO(eric): support mixed type encoding, i.e. int index and float rhs.
+  CHECK_EQ(ret->type_flag_, mshadow::default_type_flag)
+    << "one_hot_encode only support float32 as input/output";
+  CHECK_EQ(rhs.type_flag_, mshadow::default_type_flag)
+    << "one_hot_encode only support float32 as input/output";
+  CHECK_EQ(index.type_flag_, mshadow::default_type_flag)
+    << "one_hot_encode only support float32 as input/output";
+  ret->get<xpu, 2, real_t>(s) =
+    one_hot_encode(index.get<xpu, 1, real_t>(s),
+                   rhs.shape_[1]);
 }
 
 template<typename xpu, typename OP>
@@ -70,6 +88,13 @@ inline void EvalMatChooseRowElem_(const TBlob &lhs, const TBlob &rhs,
                                   TBlob *ret, RunContext ctx) {
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  // TODO(eric): support mixed type choose, i.e. int index and float rhs.
+  CHECK_EQ(ret->type_flag_, mshadow::default_type_flag)
+    << "mat_choose_row_element only support float32 as input/output";
+  CHECK_EQ(rhs.type_flag_, mshadow::default_type_flag)
+    << "mat_choose_row_element only support float32 as input/output";
+  CHECK_EQ(lhs.type_flag_, mshadow::default_type_flag)
+    << "mat_choose_row_element only support float32 as input/output";
   ret->get<xpu, 1, real_t>(s)
       = mat_choose_row_element(lhs.get<xpu, 2, real_t>(s),
                                rhs.get<xpu, 1, real_t>(s));
@@ -80,15 +105,20 @@ inline void EvalScalar_(const TBlob &lhs, const real_t &rhs,
                         TBlob *ret, RunContext ctx) {
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  CHECK_EQ(ret->type_flag_, lhs.type_flag_)
+    << "Only support input/output with the same data type";
   if (reverse) {
-    ret->FlatTo2D<xpu, real_t>(s)
-      = F<typename OP::mshadow_op>(rhs, lhs.FlatTo2D<xpu, real_t>(s));
+    MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+      ret->FlatTo2D<xpu, DType>(s)
+        = F<typename OP::mshadow_op>(scalar(DType(rhs)), lhs.FlatTo2D<xpu, DType>(s));
+    });
   } else {
-    ret->FlatTo2D<xpu, real_t>(s)
-      = F<typename OP::mshadow_op>(lhs.FlatTo2D<xpu, real_t>(s), rhs);
+    MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+      ret->FlatTo2D<xpu, DType>(s)
+        = F<typename OP::mshadow_op>(lhs.FlatTo2D<xpu, DType>(s), scalar(DType(rhs)));
+    });
   }
 }
-
 
 template<>
 void EvalClip<DEVICE>(const TBlob &src, const real_t &a_min, const real_t &a_max,
@@ -96,10 +126,14 @@ void EvalClip<DEVICE>(const TBlob &src, const real_t &a_min, const real_t &a_max
   typedef DEVICE xpu;
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  ret->FlatTo2D<xpu, real_t>(s)
-    = F<ClipMax::mshadow_op>(
-        F<ClipMin::mshadow_op>(src.FlatTo2D<xpu, real_t>(s), a_min),
-        a_max);
+  CHECK_EQ(ret->type_flag_, src.type_flag_)
+    << "Only support input/output with the same data type";
+  MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+    ret->FlatTo2D<xpu, DType>(s)
+      = F<ClipMax::mshadow_op>(
+          F<ClipMin::mshadow_op>(src.FlatTo2D<xpu, DType>(s), scalar(DType(a_min))),
+          scalar(DType(a_max)));
+  });
 }
 
 template<>
@@ -111,9 +145,24 @@ void EvalRandom<DEVICE, UniformDistribution>(
     RunContext ctx) {
   typedef DEVICE xpu;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  mshadow::Tensor<xpu, 2, real_t> tmp = ret->FlatTo2D<xpu, real_t>(s);
-  mshadow::Random<xpu> *prnd = resource.get_random<xpu>(s);
-  prnd->SampleUniform(&tmp, a, b);
+  switch (ret->type_flag_) {
+  case mshadow::kFloat32:
+    {
+      mshadow::Random<xpu, float> *prnd = resource.get_random<xpu, float>(s);
+      mshadow::Tensor<xpu, 2, float> tmp = ret->FlatTo2D<xpu, float>(s);
+      prnd->SampleUniform(&tmp, float(a), float(b));  // NOLINT(*)
+      break;
+    }
+  case mshadow::kFloat64:
+    {
+      mshadow::Random<xpu, double> *prnd = resource.get_random<xpu, double>(s);
+      mshadow::Tensor<xpu, 2, double> tmp = ret->FlatTo2D<xpu, double>(s);
+      prnd->SampleUniform(&tmp, double(a), double(b));  // NOLINT(*)
+      break;
+    }
+  default:
+    LOG(FATAL) << "Random only support float32 and float64";
+  }
 }
 
 template<>
@@ -125,15 +174,32 @@ void EvalRandom<DEVICE, GaussianDistribution>(
     RunContext ctx) {
   typedef DEVICE xpu;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  mshadow::Tensor<xpu, 2, real_t> tmp = ret->FlatTo2D<xpu, real_t>(s);
-  mshadow::Random<xpu> *prnd = resource.get_random<xpu>(s);
-  prnd->SampleGaussian(&tmp, mu, sigma);
+  switch (ret->type_flag_) {
+  case mshadow::kFloat32:
+    {
+      mshadow::Random<xpu, float> *prnd = resource.get_random<xpu, float>(s);
+      mshadow::Tensor<xpu, 2, float> tmp = ret->FlatTo2D<xpu, float>(s);
+      prnd->SampleGaussian(&tmp, float(mu), float(sigma));  // NOLINT(*)
+      break;
+    }
+  case mshadow::kFloat64:
+    {
+      mshadow::Random<xpu, double> *prnd = resource.get_random<xpu, double>(s);
+      mshadow::Tensor<xpu, 2, double> tmp = ret->FlatTo2D<xpu, double>(s);
+      prnd->SampleGaussian(&tmp, double(mu), double(sigma));  // NOLINT(*)
+      break;
+    }
+  default:
+    LOG(FATAL) << "Random only support float32 and float64";
+  }
 }
 
 template<>
 void Eval<DEVICE>(const real_t &rhs, TBlob *ret, RunContext ctx) {
   mshadow::Stream<DEVICE> *s = ctx.get_stream<DEVICE>();
-  ret->FlatTo2D<DEVICE, real_t>(s) = rhs;
+  MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+    ret->FlatTo2D<DEVICE, DType>(s) = DType(rhs);
+  });
 }
 
 template<>
@@ -144,39 +210,45 @@ void ElementwiseSum<DEVICE>(const std::vector<TBlob> source,
   using namespace mshadow;
   using namespace mshadow::expr;
   Stream<xpu> *s = ctx.get_stream<xpu>();
-  Tensor<xpu, 2> out = dst->FlatTo2D<xpu, real_t>(s);
-
-  switch (source.size()) {
-    case 2: {
-      Tensor<xpu, 2> in_0 = source[0].FlatTo2D<xpu, real_t>(s);
-      Tensor<xpu, 2> in_1 = source[1].FlatTo2D<xpu, real_t>(s);
-      out = in_0 + in_1;
-      break;
-    }
-    case 3: {
-      Tensor<xpu, 2> in_0 = source[0].FlatTo2D<xpu, real_t>(s);
-      Tensor<xpu, 2> in_1 = source[1].FlatTo2D<xpu, real_t>(s);
-      Tensor<xpu, 2> in_2 = source[2].FlatTo2D<xpu, real_t>(s);
-      out = in_0 + in_1 + in_2;
-      break;
-    }
-    case 4: {
-      Tensor<xpu, 2> in_0 = source[0].FlatTo2D<xpu, real_t>(s);
-      Tensor<xpu, 2> in_1 = source[1].FlatTo2D<xpu, real_t>(s);
-      Tensor<xpu, 2> in_2 = source[2].FlatTo2D<xpu, real_t>(s);
-      Tensor<xpu, 2> in_3 = source[3].FlatTo2D<xpu, real_t>(s);
-      out = in_0 + in_1 + in_2 + in_3;
-      break;
-    }
-    default: {
-      Tensor<xpu, 2> in_0 = source[0].FlatTo2D<xpu, real_t>(s);
-      out = F<mshadow::op::identity>(in_0);
-      for (size_t i = 1; i < source.size(); ++i) {
-        out += source[i].FlatTo2D<xpu, real_t>(s);
-      }
-      break;
-    }
+  for (size_t i = 1; i < source.size(); ++i) {
+    CHECK_EQ(source[i].type_flag_, dst->type_flag_)
+      << "Only support input/output with the same data type";
   }
+  MSHADOW_TYPE_SWITCH(dst->type_flag_, DType, {
+    Tensor<xpu, 2, DType> out = dst->FlatTo2D<xpu, DType>(s);
+
+    switch (source.size()) {
+      case 2: {
+        Tensor<xpu, 2, DType> in_0 = source[0].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> in_1 = source[1].FlatTo2D<xpu, DType>(s);
+        out = in_0 + in_1;
+        break;
+      }
+      case 3: {
+        Tensor<xpu, 2, DType> in_0 = source[0].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> in_1 = source[1].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> in_2 = source[2].FlatTo2D<xpu, DType>(s);
+        out = in_0 + in_1 + in_2;
+        break;
+      }
+      case 4: {
+        Tensor<xpu, 2, DType> in_0 = source[0].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> in_1 = source[1].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> in_2 = source[2].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> in_3 = source[3].FlatTo2D<xpu, DType>(s);
+        out = in_0 + in_1 + in_2 + in_3;
+        break;
+      }
+      default: {
+        Tensor<xpu, 2, DType> in_0 = source[0].FlatTo2D<xpu, DType>(s);
+        out = F<mshadow::op::identity>(in_0);
+        for (size_t i = 1; i < source.size(); ++i) {
+          out += source[i].FlatTo2D<xpu, DType>(s);
+        }
+        break;
+      }
+    }
+  });
 }
 
 // declarations

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -14,8 +14,17 @@ template<>
 void Copy<cpu, cpu>(const TBlob &from, TBlob *to,
                     Context from_ctx, Context to_ctx,
                     RunContext ctx) {
-  mshadow::Copy(to->FlatTo2D<cpu, real_t>(),
-                from.FlatTo2D<cpu, real_t>());
+  MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
+    if (to->type_flag_ == from.type_flag_) {
+        mshadow::Copy(to->FlatTo2D<cpu, DType>(),
+                      from.FlatTo2D<cpu, DType>());
+    } else {
+        MSHADOW_TYPE_SWITCH(from.type_flag_, SrcDType, {
+            to->FlatTo2D<cpu, DType>() =
+                mshadow::expr::tcast<DType>(from.FlatTo2D<cpu, SrcDType>());
+        })
+    }
+  })
 }
 }  // namespace ndarray
 }  // namespace mxnet

--- a/src/ndarray/ndarray_function.cu
+++ b/src/ndarray/ndarray_function.cu
@@ -9,18 +9,26 @@ template<>
 void Copy<cpu, gpu>(const TBlob &from, TBlob *to,
                     Context from_ctx, Context to_ctx,
                     RunContext ctx) {
-  mshadow::Copy(to->FlatTo2D<gpu, real_t>(),
-                from.FlatTo2D<cpu, real_t>(),
-                static_cast<mshadow::Stream<gpu>*>(ctx.stream));
+  CHECK_EQ(to->type_flag_, from.type_flag_)
+    << "Source and target must have the same data type when copying across devices.";
+  MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
+    mshadow::Copy(to->FlatTo2D<gpu, DType>(),
+                  from.FlatTo2D<cpu, DType>(),
+                  static_cast<mshadow::Stream<gpu>*>(ctx.stream));
+  });
 }
 
 template<>
 void Copy<gpu, cpu>(const TBlob &from, TBlob *to,
                     Context from_ctx, Context to_ctx,
                     RunContext ctx) {
-  mshadow::Copy(to->FlatTo2D<cpu, real_t>(),
-                from.FlatTo2D<gpu, real_t>(),
-                static_cast<mshadow::Stream<gpu>*>(ctx.stream));
+  CHECK_EQ(to->type_flag_, from.type_flag_)
+    << "Source and target must have the same data type when copying across devices.";
+  MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
+    mshadow::Copy(to->FlatTo2D<cpu, DType>(),
+                  from.FlatTo2D<gpu, DType>(),
+                  static_cast<mshadow::Stream<gpu>*>(ctx.stream));
+  });
 }
 
 template<>
@@ -28,20 +36,32 @@ void Copy<gpu, gpu>(const TBlob &from, TBlob *to,
                     Context from_ctx, Context to_ctx,
                     RunContext ctx) {
   if (from_ctx.dev_id == to_ctx.dev_id) {
-     mshadow::Copy(to->FlatTo2D<gpu, real_t>(),
-                   from.FlatTo2D<gpu, real_t>(),
-                   static_cast<mshadow::Stream<gpu>*>(ctx.stream));
-   } else {
-     CHECK(from.CheckContiguous() && to->CheckContiguous())
-         << "copy across only support continugous memory";
-     mshadow::Stream<gpu> *s = static_cast<mshadow::Stream<gpu>*>(ctx.stream);
-     CHECK(s != NULL) << "need stream in GPU context";
-     cudaMemcpyPeerAsync(to->dptr_,
-                         to_ctx.dev_id,
-                         from.dptr_,
-                         from_ctx.dev_id,
-                         from.shape_.Size() * sizeof(real_t),
-                         s->stream_);
+    mshadow::Stream<gpu>* s = static_cast<mshadow::Stream<gpu>*>(ctx.stream);
+    MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
+      if (to->type_flag_ == from.type_flag_) {
+        mshadow::Copy(to->FlatTo2D<gpu, DType>(s),
+                      from.FlatTo2D<gpu, DType>(s),
+                      s);
+      } else {
+        MSHADOW_TYPE_SWITCH(from.type_flag_, SrcDType, {
+          to->FlatTo2D<gpu, DType>(s) =
+            mshadow::expr::tcast<DType>(from.FlatTo2D<gpu, SrcDType>(s));
+        })
+      }
+    })
+  } else {
+    CHECK(from.CheckContiguous() && to->CheckContiguous())
+      << "copy across only support continugous memory";
+    CHECK_EQ(to->type_flag_, from.type_flag_)
+      << "Source and target must have the same data type when copying across devices.";
+    mshadow::Stream<gpu> *s = static_cast<mshadow::Stream<gpu>*>(ctx.stream);
+    CHECK(s != NULL) << "need stream in GPU context";
+    cudaMemcpyPeerAsync(to->dptr_,
+                        to_ctx.dev_id,
+                        from.dptr_,
+                        from_ctx.dev_id,
+                        from.shape_.Size() * mshadow::mshadow_sizeof(to->type_flag_),
+                        s->stream_);
   }
 }
 }  // namespace ndarray

--- a/src/ndarray/ndarray_function.h
+++ b/src/ndarray/ndarray_function.h
@@ -43,7 +43,8 @@ struct Div : public BinaryBase {
 
 struct ClipMin : public BinaryBase {
   struct mshadow_op {
-    MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
+    template<typename DType>
+    MSHADOW_XINLINE static DType Map(DType a, DType b) {
       if (a < b) {
         return b;
       } else {
@@ -55,7 +56,8 @@ struct ClipMin : public BinaryBase {
 
 struct ClipMax : public BinaryBase {
   struct mshadow_op {
-    MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
+    template<typename DType>
+    MSHADOW_XINLINE static DType Map(DType a, DType b) {
       if (a > b) {
         return b;
       } else {

--- a/src/ndarray/unary_function-inl.h
+++ b/src/ndarray/unary_function-inl.h
@@ -6,6 +6,7 @@
 #ifndef MXNET_NDARRAY_UNARY_FUNCTION_INL_H_
 #define MXNET_NDARRAY_UNARY_FUNCTION_INL_H_
 
+#include <vector>
 #include "../common/tblob_op_registry.h"
 #include "../operator/mshadow_op.h"
 #include "../operator/operator_common.h"
@@ -28,8 +29,12 @@ void UnaryForward_(const TBlob &src,
   using namespace mxnet::op;
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  mshadow::Tensor<xpu, 2> out = ret->FlatTo2D<xpu, real_t>(s);
-  Assign(out, req, F<OP>(src.FlatTo2D<xpu, real_t>(s)));
+  CHECK_EQ(ret->type_flag_, src.type_flag_)
+    << "Unary function only support input/output with the same type";
+  MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+    mshadow::Tensor<xpu, 2, DType> out = ret->FlatTo2D<xpu, DType>(s);
+    Assign(out, req, F<OP>(src.FlatTo2D<xpu, DType>(s)));
+  });
 }
 
 // backward function that takes input value of the op
@@ -42,10 +47,16 @@ void UnaryBackwardUseIn_(const arg::OutGrad& out_grad,
   using namespace mxnet::op;
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  mshadow::Tensor<xpu, 2> igrad = in_grad->FlatTo2D<xpu, real_t>(s);
-  Assign(igrad, req,
-         (F<OP>(in_data0.data.FlatTo2D<xpu, real_t>(s)) *
-         out_grad.data.FlatTo2D<xpu, real_t>()));
+  CHECK_EQ(in_grad->type_flag_, out_grad.data.type_flag_)
+    << "Unary function only support input/output with the same type";
+  CHECK_EQ(in_grad->type_flag_, in_data0.data.type_flag_)
+    << "Unary function only support input/output with the same type";
+  MSHADOW_TYPE_SWITCH(in_grad->type_flag_, DType, {
+    mshadow::Tensor<xpu, 2, DType> igrad = in_grad->FlatTo2D<xpu, DType>(s);
+    Assign(igrad, req,
+           (F<OP>(in_data0.data.FlatTo2D<xpu, DType>(s)) *
+           out_grad.data.FlatTo2D<xpu, DType>()));
+  });
 }
 
 // backward function that takes output value of the op
@@ -58,10 +69,16 @@ void UnaryBackwardUseOut_(const arg::OutGrad& out_grad,
   using namespace mxnet::op;
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  mshadow::Tensor<xpu, 2> igrad = in_grad->FlatTo2D<xpu, real_t>(s);
-  Assign(igrad, req,
-         (F<OP>(out_value.data.FlatTo2D<xpu, real_t>(s)) *
-         out_grad.data.FlatTo2D<xpu, real_t>()));
+  CHECK_EQ(in_grad->type_flag_, out_grad.data.type_flag_)
+    << "Unary function only support input/output with the same type";
+  CHECK_EQ(in_grad->type_flag_, out_value.data.type_flag_)
+    << "Unary function only support input/output with the same type";
+  MSHADOW_TYPE_SWITCH(in_grad->type_flag_, DType, {
+    mshadow::Tensor<xpu, 2, DType> igrad = in_grad->FlatTo2D<xpu, DType>(s);
+    Assign(igrad, req,
+           (F<OP>(out_value.data.FlatTo2D<xpu, DType>(s)) *
+           out_grad.data.FlatTo2D<xpu, DType>()));
+  });
 }
 
 // return a shape of scalar
@@ -94,6 +111,35 @@ void Reduce(const TBlob &src,
       src.get_with_shape<xpu, 2, real_t>(mshadow::Shape2(1, src.shape_.Size()), s);
   out = mshadow::expr::reduce_except_dim<0, Reducer>(in);
 }
+
+template<typename xpu, typename Reducer, bool get_mask>
+void ReduceChannel(const TBlob &src,
+                   TBlob *ret,
+                   OpReqType req,
+                   RunContext ctx) {
+  using namespace mxnet::op;
+  using namespace mshadow;
+  using namespace mshadow::expr;
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  Tensor<xpu, 2> out = ret->get_with_shape<xpu, 2, real_t>(
+    Shape2(src.shape_[0], src.Size()/src.shape_[0]/src.shape_[1]),
+    s);
+  Tensor<xpu, 3> in = src.get_with_shape<xpu, 3, real_t>(
+    Shape3(src.shape_[0], src.shape_[1], src.Size()/src.shape_[0]/src.shape_[1]),
+    s);
+  out = reduce_with_axis<Reducer, get_mask>(in, 1);
+}
+
+// return a shape of ReduceChannel output
+inline TShape ReduceChannelShape(const TShape& ishape) {
+  std::vector<mshadow::index_t> shape;
+  shape.push_back(ishape[0]);
+  for (index_t i = 2; i < ishape.ndim(); ++i) {
+    shape.push_back(ishape[i]);
+  }
+  return TShape(shape.begin(), shape.end());
+}
+
 // Register all unary operations here
 // The true means inplace can be enabled.
 // abs
@@ -176,6 +222,12 @@ MXNET_REGISTER_TBLOB_FUN(min, XPU)
 MXNET_REGISTER_TBLOB_FUN(sum, XPU)
 .set_function(XPU::kDevMask, Reduce<XPU, mshadow::red::sum>, false, false)
 .set_shape_infer(ScalarShape)
+.describe("Take sum of the src."
+          "The result will be ndarray of shape (1,) on the same device.");
+// argmax channel
+MXNET_REGISTER_TBLOB_FUN(argmax_channel, XPU)
+.set_function(XPU::kDevMask, ReduceChannel<XPU, mshadow::red::maximum, true>, false, false)
+.set_shape_infer(ReduceChannelShape)
 .describe("Take sum of the src."
           "The result will be ndarray of shape (1,) on the same device.");
 }  // namespace ndarray

--- a/src/operator/dropout-inl.h
+++ b/src/operator/dropout-inl.h
@@ -58,7 +58,7 @@ class DropoutOp : public Operator {
     Tensor<xpu, 2> out = out_data[dropout::kOut].FlatTo2D<xpu, real_t>(s);
     if (ctx.is_train) {
       Tensor<xpu, 2> mask = out_data[dropout::kMask].FlatTo2D<xpu, real_t>(s);
-      Random<xpu> *prnd = ctx.requested[dropout::kRandom].get_random<xpu>(s);
+      Random<xpu> *prnd = ctx.requested[dropout::kRandom].get_random<xpu, real_t>(s);
       mask = F<mshadow_op::threshold>(prnd->uniform(mask.shape_), pkeep_) * (1.0f / pkeep_);
       Assign(out, req[dropout::kOut], data * mask);
     } else {

--- a/src/operator/leaky_relu-inl.h
+++ b/src/operator/leaky_relu-inl.h
@@ -105,7 +105,7 @@ class LeakyReLUOp : public Operator {
       }
       case leakyrelu::kRReLU: {
         if (ctx.is_train) {
-          Random<xpu>* prnd = ctx.requested[leakyrelu::kRandom].get_random<xpu>(s);
+          Random<xpu>* prnd = ctx.requested[leakyrelu::kRandom].get_random<xpu, real_t>(s);
           mask = prnd->uniform(mask.shape_);
           mask = mask * (param_.upper_bound - param_.lower_bound) + param_.lower_bound;
           Assign(out, req[leakyrelu::kOut], F<mshadow_op::xelu>(data, mask));

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -14,260 +14,301 @@ namespace op {
 namespace mshadow_op {
 /*! \brief identity Operation */
 struct identity {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return a;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(a);
   }
 };
 
 struct identity_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 1.0f;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(1.0f);
   }
 };
 
 
 struct negation {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return -a;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(-a);
   }
 };
 
 /*! \brief sigmoid unit */
 struct sigmoid {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 1.0f / (1.0f + expf(-a));
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(1.0f / (1.0f + expf(-a)));
   }
 };
 struct sigmoid_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return a * (1.0f - a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(a * (1.0f - a));
   }
 };
 /*! \brief Rectified Linear Operation */
 struct relu {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return a > 0.0f ? a : 0.0f;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(a > 0.0f ? a : 0.0f);
   }
 };
 struct relu_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return a > 0.0f ? 1.0f : 0.0f;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(a > 0.0f ? 1.0f : 0.0f);
   }
 };
 
 /*! \brief Leaky ReLU Operation */
 struct xelu {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a > 0.0f ? a : a * b;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a > 0.0f ? a : a * b);
   }
 };
 
 struct xelu_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a > 0.0f ? 1.0f : b;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a > 0.0f ? 1.0f : b);
   }
 };
 
 /*! \brief Exponential Linear Unit */
 struct elu {
-  MSHADOW_XINLINE static real_t Map(real_t x, real_t a) {
-    return x > 0.0f ? x : a * (expf(x) - 1.0f);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType x, DType a) {
+    return DType(x > 0.0f ? x : a * (expf(x) - 1.0f));
   }
 };
 
 struct elu_grad {
-  MSHADOW_XINLINE static real_t Map(real_t x, real_t a) {
-    return x > 0.0f ? 1.0f : a * expf(x);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType x, DType a) {
+    return DType(x > 0.0f ? 1.0f : a * expf(x));
   }
 };
 
 struct tanh {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return tanhf( a );
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(tanhf( a ));
   }
 };
 
 struct tanh_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 1.0f - a * a;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(1.0f - a * a);
   }
 };
 
 /*! \brief SoftReLU, also known as softplus activation. */
 struct softrelu {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return log1pf(expf(a));
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(log1pf(expf(a)));
   }
 };
 struct softrelu_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 1.0f - expf(-a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(1.0f - expf(-a));
   }
 };
 
 struct exp {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return expf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(expf(a));
   }
 };
 
 struct log {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return logf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(logf(a));
   }
 };
 
 struct log_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 1.0f / a;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(1.0f / a);
   }
 };
 
 struct cos {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return cosf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(cosf(a));
   }
 };
 
 struct cos_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return -sinf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(-sinf(a));
   }
 };
 
 struct sin {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return sinf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(sinf(a));
   }
 };
 
 struct sin_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return cosf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(cosf(a));
   }
 };
 struct square {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return a * a;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(a * a);
   }
 };
 
 struct square_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 2.0f * a;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(2.0f * a);
   }
 };
 
 /*! \brief used for generate Bernoulli mask */
 struct threshold {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a < b ? 1.0f : 0.0f;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a < b ? 1.0f : 0.0f);
   }
 };
 
 /*! \brief used for generate element of abs */
 struct abs {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return fabsf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(fabsf(a));
   }
 };
 
 /*! \brief used for generate element of power */
 struct sign {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    if (a < 0.0f) return -1.0f;
-    if (a > 0.0f) return 1.0f;
-    return 0.0f;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    if (a < 0.0f) return DType(-1.0f);
+    if (a > 0.0f) return DType(1.0f);
+    return DType(0.0f);
   }
 };
 struct sign_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 0.0f;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(0.0f);
   }
 };
 /*! \brief used for generate element of power */
 struct power {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return powf( a, b );
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(powf( a, b ));
   }
 };
 
 /*! \brief used for generate element of maximum */
 struct maximum {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a > b ? a : b;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a > b ? a : b);
   }
 };
 
 struct maximum_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a > b ? 1 : 0;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a > b ? 1 : 0);
   }
 };
 
 /*! \brief used for generate element of minimum */
 struct minimum {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a < b ? a : b;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a < b ? a : b);
   }
 };
 struct minimum_grad  {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a < b ? 1 : 0;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a < b ? 1 : 0);
   }
 };
 
 /*!\ \brief used for generate element sqrt */
 struct square_root {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return sqrt(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(sqrtf(a));
   }
 };
 
 struct square_root_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 0.5f / a;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(0.5f / a);
   }
 };
 
 /*!\ \brief used for generate element sqrt */
 struct reciprocal_square_root {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return 1.0/sqrt(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(1.0/sqrtf(a));
   }
 };
 
 struct reciprocal_square_root_grad {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return -(1.0 / (2.0 * a * sqrt(a)));
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(-(1.0 / (2.0 * a * sqrtf(a))));
   }
 };
 
 /*! \brief used for generate element of round */
 struct round {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return roundf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(roundf(a));
   }
 };
 
 /*! \brief used for generate element of ceil */
 struct ceil {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return ceilf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(ceilf(a));
   }
 };
 
 /*! \brief used for generate element of floor */
 struct floor {
-  MSHADOW_XINLINE static real_t Map(real_t a) {
-    return floorf(a);
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a) {
+    return DType(floorf(a));
   }
 };
 
 /*! \brief used for generate gradient of MAE loss*/
 struct minus_sign {
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    return a-b > 0.0f ? 1.0f : -1.0f;
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return DType(a-b > 0.0f ? 1.0f : -1.0f);
   }
 };
 

--- a/src/operator/softmax_output-inl.h
+++ b/src/operator/softmax_output-inl.h
@@ -101,7 +101,7 @@ class SoftmaxOutputOp : public Operator {
       } else {
           SoftmaxGrad(grad, out, label);
       }
-      grad *= param_.grad_scale;
+      grad *= param_.grad_scale/s3[2];
     } else {
       Tensor<xpu, 1> label = in_data[softmaxout_enum::kLabel].get<xpu, 1, real_t>(s);
       Tensor<xpu, 2> out = out_data[softmaxout_enum::kOut].FlatTo2D<xpu, real_t>(s);


### PR DESCRIPTION
This is a preliminary work for ndarray type support. It's not ready for merge. I'm posting this PR to solicit feedback. The corresponding mshadow PR: https://github.com/dmlc/mshadow/pull/89/files

- [x] NDArray class type support.
- [x] NDArrayFunction type support.
- [x] NDArray Unary Function type support.
- [x] Python ndarray interface type support.
- [ ] Symbolic type inference.
- [ ] Go over operators and implement type support.

~~I'll probably need to extend the c_api interface for NDArray when I implement python side. This probably will break all other front-end. Should we merge PRs and push together?~~
I added MX***Ex functions for dtype supporting interface.

This is a pretty big project. I can really use some help.
@tqchen Could you have a look?
