### PR TITLE
Fix issue #1116

### DIFF
--- a/example/rnn/char_lstm.ipynb
+++ b/example/rnn/char_lstm.ipynb
@@ -8,7 +8,9 @@
     "This example aims to show how to use lstm to build a char level language model, and generate text from it. \n",
     "We use a tiny shakespeare text for demo purpose. \n",
     "\n",
-    "Data can be found at [https://github.com/dmlc/web-data/tree/master/mxnet/tinyshakespeare](https://github.com/dmlc/web-data/tree/master/mxnet/tinyshakespeare). "
+    "Data can be found at [https://github.com/dmlc/web-data/tree/master/mxnet/tinyshakespeare](https://github.com/dmlc/web-data/tree/master/mxnet/tinyshakespeare). ",
+    "\n",
+    "If running for the first time, download the data by running the following commands: cd example/rnn ; ./get_ptb_data.sh"
    ]
   },
   {
@@ -48,9 +50,8 @@
     "num_embed = 256\n",
     "num_lstm_layer = 2\n",
     "num_round = 21\n",
-    "learning_rate= 1\n",
+    "learning_rate= 0.01\n",
     "wd=0.00001\n",
-    "momentum=0.0\n",
     "clip_gradient=1\n",
     "update_period = 1\n"
    ]
@@ -138,7 +139,7 @@
     }
    ],
    "source": [
-    "X, dic, lookup_table = make_batch(\"./input.txt\", batch_size=batch_size, seq_lenth=seq_len)\n",
+    "X, dic, lookup_table = make_batch(\"./data/input.txt\", batch_size=batch_size, seq_lenth=seq_len)\n",
     "vocab = len(dic)"
    ]
   },
@@ -443,7 +444,6 @@
     "                update_period=update_period,\n",
     "                learning_rate=learning_rate,\n",
     "                wd=wd,\n",
-    "                momentum=momentum,\n",
     "                clip_gradient=clip_gradient)"
    ]
   },

--- a/example/rnn/get_ptb_data.sh
+++ b/example/rnn/get_ptb_data.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 RNN_DIR=$(cd `dirname $0`; pwd)
 DATA_DIR="${RNN_DIR}/data/"
@@ -8,6 +8,7 @@ if [[ ! -d "${DATA_DIR}" ]]; then
   mkdir -p ${DATA_DIR}
 fi
 
-wget -P ${DATA_DIR} https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/ptb/ptb.train.txt; 
+wget -P ${DATA_DIR} https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/ptb/ptb.train.txt;
 wget -P ${DATA_DIR} https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/ptb/ptb.valid.txt;
 wget -P ${DATA_DIR} https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/ptb/ptb.test.txt;
+wget -P ${DATA_DIR} https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/tinyshakespeare/input.txt;


### PR DESCRIPTION
- the learning rate is too big, leading to NRR=Infinity and Prep=Infinity
- the optimizer was changed from 'sgd' to 'rmsprop', but the hyperparameters were not updated: there is no 'momentum' hyperparameter in rmsprop.
- the 'input.txt' file is not automatically downloaded when running the ./get_ptb_data.sh script
- the script get_ptb_data.sh script should use [#!/usr/bin/env](http://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my)