### PR TITLE
Add dilate option for convolution for semantic segmentation

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -336,8 +336,10 @@ class ConvolutionProp : public OperatorProperty {
     CHECK(ksize_x <= dshape[3] && ksize_y <= dshape[2])
         << "kernel size exceed input";
     (*out_shape)[conv::kOut][1] = param_.num_filter;
-    (*out_shape)[conv::kOut][2] = (dshape[2] + 2 * param_.pad[0] - (param_.dilate[0] == 1 ? ksize_y : ksize_y * param_.dilate[0] - 1)) / param_.stride[0] + 1;
-    (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] - (param_.dilate[1] == 1 ? ksize_x : ksize_x * param_.dilate[1] - 1)) / param_.stride[1] + 1;
+    (*out_shape)[conv::kOut][2] = (dshape[2] + 2 * param_.pad[0] -
+        (param_.dilate[0] == 1 ? ksize_y : ksize_y * param_.dilate[0] - 1)) / param_.stride[0] + 1;
+    (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] -
+        (param_.dilate[1] == 1 ? ksize_x : ksize_x * param_.dilate[1] - 1)) / param_.stride[1] + 1;
     return true;
   }
 

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -30,6 +30,7 @@ enum ConvolutionOpResource {kTempSpace};
 struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
   TShape kernel;
   TShape stride;
+  TShape dilate;
   TShape pad;
   uint32_t num_filter;
   uint32_t num_group;
@@ -40,6 +41,8 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
     DMLC_DECLARE_FIELD(kernel).describe("convolution kernel size: (y, x)");
     DMLC_DECLARE_FIELD(stride).set_default(TShape(shape, shape + 2))
     .describe("convolution stride: (y, x)");
+    DMLC_DECLARE_FIELD(dilate).set_default(TShape(shape, shape + 2))
+    .describe("convolution dilate: (y, x)");
     shape[0] = shape[1] = 0;
     DMLC_DECLARE_FIELD(pad).set_default(TShape(shape, shape + 2))
     .describe("pad for convolution: (y, x)");
@@ -105,14 +108,18 @@ class ConvolutionOp : public Operator {
                                     param_.kernel[0],
                                     param_.kernel[1],
                                     param_.stride[0],
-                                    param_.stride[1]);
+                                    param_.stride[1],
+                                    param_.dilate[0],
+                                    param_.dilate[1]);
       } else {
         temp_col = unpack_patch2col(pad(data.Slice(i, i + step),
                                         param_.pad[0], param_.pad[1]),
                                     param_.kernel[0],
                                     param_.kernel[1],
                                     param_.stride[0],
-                                    param_.stride[1]);
+                                    param_.stride[1],
+                                    param_.dilate[0],
+                                    param_.dilate[1]);
       }
       const index_t gstride = temp_col.size(0) / param_.num_group;
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
@@ -181,13 +188,17 @@ class ConvolutionOp : public Operator {
                                      param_.kernel[0],
                                      param_.kernel[1],
                                      param_.stride[0],
-                                     param_.stride[1]);
+                                     param_.stride[1],
+                                     param_.dilate[0],
+                                     param_.dilate[1]);
       } else {
         temp_col = unpack_patch2col(pad(data.Slice(i, i + step), param_.pad[0], param_.pad[1]),
                                      param_.kernel[0],
                                      param_.kernel[1],
                                      param_.stride[0],
-                                     param_.stride[1]);
+                                     param_.stride[1],
+                                     param_.dilate[0],
+                                     param_.dilate[1]);
       }
       const index_t gstride = temp_col.size(0) / param_.num_group;
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
@@ -209,7 +220,8 @@ class ConvolutionOp : public Operator {
                                      data.Slice(i, i + step).shape_,
                                      param_.kernel[0],
                                      param_.kernel[1],
-                                     param_.stride[0]);
+                                     param_.stride[0],
+                                     param_.dilate[0]);
         } else {
           Shape<4> pshape = data.Slice(i, i + step).shape_;
           pshape[2] += 2 * param_.pad[0];
@@ -218,7 +230,8 @@ class ConvolutionOp : public Operator {
                                           pshape,
                                           param_.kernel[0],
                                           param_.kernel[1],
-                                          param_.stride[0]),
+                                          param_.stride[0],
+                                          param_.dilate[0]),
                                           gdata[i][0].shape_);
         }
       }
@@ -318,11 +331,13 @@ class ConvolutionProp : public OperatorProperty {
         << "incorrect kernel size: " << param_.kernel;
     CHECK_GE(param_.stride.Size(), 0) \
         << "incorrect stride size: " << param_.stride;
+    CHECK_GE(param_.dilate.Size(), 0) \
+        << "incorrect dilate size: " << param_.dilate;
     CHECK(ksize_x <= dshape[3] && ksize_y <= dshape[2])
         << "kernel size exceed input";
     (*out_shape)[conv::kOut][1] = param_.num_filter;
-    (*out_shape)[conv::kOut][2] = (dshape[2] + 2 * param_.pad[0] - ksize_y) / param_.stride[0] + 1;
-    (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] - ksize_x) / param_.stride[1] + 1;
+    (*out_shape)[conv::kOut][2] = (dshape[2] + 2 * param_.pad[0] - (param_.dilate[0] == 1 ? ksize_y : ksize_y * param_.dilate[0] - 1)) / param_.stride[0] + 1;
+    (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] - (param_.dilate[1] == 1 ? ksize_x : ksize_x * param_.dilate[1] - 1)) / param_.stride[1] + 1;
     return true;
   }
 

--- a/src/operator/deconvolution-inl.h
+++ b/src/operator/deconvolution-inl.h
@@ -30,7 +30,6 @@ namespace deconv {
 struct DeconvolutionParam : public dmlc::Parameter<DeconvolutionParam> {
   TShape kernel;
   TShape stride;
-  TShape dilate;
   TShape pad;
   uint32_t num_filter;
   uint32_t num_group;
@@ -41,8 +40,6 @@ struct DeconvolutionParam : public dmlc::Parameter<DeconvolutionParam> {
     DMLC_DECLARE_FIELD(kernel).describe("deconvolution kernel size: (y, x)");
     DMLC_DECLARE_FIELD(stride).set_default(TShape(shape, shape + 2))
     .describe("deconvolution stride: (y, x)");
-    DMLC_DECLARE_FIELD(dilate).set_default(TShape(shape, shape + 2))
-    .describe("deconvolution dilate: (y, x)");
     shape[0] = shape[1] = 0;
     DMLC_DECLARE_FIELD(pad).set_default(TShape(shape, shape + 2))
     .describe("pad for deconvolution: (y, x)");
@@ -108,8 +105,7 @@ class DeconvolutionOp : public Operator {
                                     param_.kernel[1],
                                     param_.stride[0],
                                     param_.stride[1],
-                                    param_.dilate[0],
-                                    param_.dilate[1]);
+                                    1, 1);  // Deconvolution only support dilate equals 1
       } else {
         temp_col = unpack_patch2col(pad(out.Slice(i, i + step),
                                         param_.pad[0], param_.pad[1]),
@@ -117,8 +113,7 @@ class DeconvolutionOp : public Operator {
                                     param_.kernel[1],
                                     param_.stride[0],
                                     param_.stride[1],
-                                    param_.dilate[0],
-                                    param_.dilate[1]);
+                                    1, 1);  // Deconvolution only support dilate equals 1
       }
       const index_t gstride = temp_col.size(0) / param_.num_group;
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
@@ -132,7 +127,7 @@ class DeconvolutionOp : public Operator {
                                    param_.kernel[0],
                                    param_.kernel[1],
                                    param_.stride[0],
-                                   param_.dilate[0]);
+                                   1);  // Deconvolution only support dilate equals 1
       } else {
         Shape<4> pshape = out.Slice(i, i + step).shape_;
         pshape[2] += 2 * param_.pad[0];
@@ -142,7 +137,7 @@ class DeconvolutionOp : public Operator {
                                         param_.kernel[0],
                                         param_.kernel[1],
                                         param_.stride[0],
-                                        param_.dilate[0]),
+                                        1),  // Deconvolution only support dilate equals 1
                                         out[i][0].shape_);
       }
     }
@@ -202,16 +197,14 @@ class DeconvolutionOp : public Operator {
                                      param_.kernel[1],
                                      param_.stride[0],
                                      param_.stride[1],
-                                     param_.dilate[0],
-                                     param_.dilate[1]);
+                                     1, 1);  // Deconvolution only support dilate equals 1
       } else {
         temp_col = unpack_patch2col(pad(grad.Slice(i, i + step), param_.pad[0], param_.pad[1]),
                                      param_.kernel[0],
                                      param_.kernel[1],
                                      param_.stride[0],
                                      param_.stride[1],
-                                     param_.dilate[0],
-                                     param_.dilate[1]);
+                                     1, 1);  // Deconvolution only support dilate equals 1
       }
       const index_t gstride = temp_col.size(0) / param_.num_group;
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
@@ -329,8 +322,6 @@ class DeconvolutionProp : public OperatorProperty {
         << "incorrect kernel size: " << param_.kernel;
     CHECK_GE(param_.stride.Size(), 0) \
         << "incorrect stride size: " << param_.stride;
-    CHECK_EQ(param_.dilate.Size(), 1) \
-        << "Dilate not supported in deconvolution, incorrect stride size: " << param_.stride;
     (*out_shape)[deconv::kOut][1] = param_.num_filter;
     (*out_shape)[deconv::kOut][2] = param_.stride[0] * (dshape[2] - 1) +
         ksize_y - 2 * param_.pad[0];


### PR DESCRIPTION
Add dilate option for convolution / deconvolution, used for semantic segmentation.

Detail could be found in the following paper and their code.

Semantic Image Segmentation with Deep Convolutional Nets and Fully Connected CRFs.
Liang-Chieh Chen, George Papandreou, Iasonas Kokkinos, Kevin Murphy, and Alan L. Yuille
ICLR 2015