### PR TITLE
Speed up kaggle-ndsb2 example Preprocessing 

### DIFF
--- a/example/kaggle-ndsb2/Preprocessing.py
+++ b/example/kaggle-ndsb2/Preprocessing.py
@@ -57,7 +57,7 @@ def write_label_csv(fname, frames, label_map):
 
 def get_data(lst,preproc):
    data = []
-   result=[]
+   result = []
    for path in lst:
        f = dicom.read_file(path)
        img = preproc(f.pixel_array.astype(float) / np.max(f.pixel_array))
@@ -75,13 +75,13 @@ def get_data(lst,preproc):
 def write_data_csv(fname, frames, preproc):
    """Write data to csv file"""
    fdata = open(fname, "w")
-   dr=Parallel()(delayed(get_data)(lst,preproc) for lst in frames)
-   data,result=zip(*dr)
+   dr = Parallel()(delayed(get_data)(lst,preproc) for lst in frames)
+   data,result = zip(*dr)
    for entry in data:
       fdata.write(','.join(entry)+'\r\n')
    print("All finished, %d slices in total" % len(data))
    fdata.close()
-   result=np.ravel(result)
+   result = np.ravel(result)
    return result
 
 

--- a/example/kaggle-ndsb2/Preprocessing.py
+++ b/example/kaggle-ndsb2/Preprocessing.py
@@ -10,6 +10,7 @@ import scipy
 import numpy as np
 import dicom
 from skimage import io, transform
+from joblib import Parallel, delayed
 
 def mkdir(fname):
    try:
@@ -53,29 +54,33 @@ def write_label_csv(fname, frames, label_map):
    fo.close()
 
 
+def get_data(lst):
+   data = []
+   result=[]
+   for path in lst:
+       f = dicom.read_file(path)
+       img = crop_resize(f.pixel_array.astype(float) / np.max(f.pixel_array),64)
+       dst_path = path.rsplit(".", 1)[0] + ".64x64.jpg"
+       scipy.misc.imsave(dst_path, img)
+       result.append(dst_path)
+       data.append(img)
+   data = np.array(data, dtype=np.uint8)
+   data = data.reshape(data.size)
+   data = np.array(data,dtype=np.str_)
+   data = data.reshape(data.size)
+   return [data,result]
+
+
 def write_data_csv(fname, frames, preproc):
    """Write data to csv file"""
    fdata = open(fname, "w")
-   dwriter = csv.writer(fdata)
-   counter = 0
-   result = []
-   for lst in frames:
-       data = []
-       for path in lst:
-           f = dicom.read_file(path)
-           img = preproc(f.pixel_array.astype(float) / np.max(f.pixel_array))
-           dst_path = path.rsplit(".", 1)[0] + ".64x64.jpg"
-           scipy.misc.imsave(dst_path, img)
-           result.append(dst_path)
-           data.append(img)
-       data = np.array(data, dtype=np.uint8)
-       data = data.reshape(data.size)
-       dwriter.writerow(data)
-       counter += 1
-       if counter % 100 == 0:
-           print("%d slices processed" % counter)
-   print("All finished, %d slices in total" % counter)
+   dr=Parallel()(delayed(get_data)(lst) for lst in frames)
+   data,result=zip(*dr)
+   for entry in data:
+      fdata.write(','.join(entry)+'\r\n')
+   print("All finished, %d slices in total" % len(data))
    fdata.close()
+   result=np.ravel(result)
    return result
 
 


### PR DESCRIPTION
This parallelizes loading, cropping, and resizing images, and it eliminates use of the csvwriter library in that section of code, which seems to be very slow (at least in python 2).  On four cores, this sped up preprocessing time by about 5x - from 45 minutes to 9 minutes for me.  Output is identical to pre-change.  

Added dependencies: 
joblib for parallelization
dill for pickling lambda function

The program no longer prints to screen every hundredth task.