### PR TITLE
[WIP] Torch operator and NDArray function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,10 @@ endif
 
 all: lib/libmxnet.a lib/libmxnet.so $(BIN)
 
-SRC = $(wildcard src/*.cc src/*/*.cc)
-OBJ = $(patsubst src/%.cc, build/%.o, $(SRC))
-CUSRC = $(wildcard src/*/*.cu)
-CUOBJ = $(patsubst src/%.cu, build/%_gpu.o, $(CUSRC))
+SRC = $(wildcard src/*.cc src/*/*.cc src/*/*/*.cc)
+OBJ = $(patsubst %.cc, build/%.o, $(SRC))
+CUSRC = $(wildcard src/*/*.cu src/*/*/*.cu)
+CUOBJ = $(patsubst %.cu, build/%_gpu.o, $(CUSRC))
 
 ifneq ($(EXTRA_OPERATORS),)
 	EXTRA_SRC = $(wildcard $(EXTRA_OPERATORS)/*.cc $(EXTRA_OPERATORS)/*/*.cc)
@@ -110,10 +110,23 @@ else
 	EXTRA_CUOBJ =
 endif
 
+# plugin
+ifeq ($(USE_TORCH), 1)
+	CFLAGS += -I$(TORCH_PATH)/install/include -I$(TORCH_PATH)/install/include/TH -I$(TORCH_PATH)/install/include/THC -DMXNET_USE_TORCH=1
+	LDFLAGS += -Wl,-export-dynamic -L$(TORCH_PATH)/install/lib -L$(TORCH_PATH)/install/lib/lua/5.1 -lluajit -lluaT -lTH -lTHC -lpaths -ltorch -lcutorch -lnn -lcunn
+	
+	TORCH_SRC = $(wildcard plugin/torch/*.cc)
+	PLUGIN_OBJ += $(patsubst %.cc, build/%.o, $(TORCH_SRC))
+	TORCH_CUSRC = $(wildcard plugin/torch/*.cu)
+	PLUGIN_CUOBJ += $(patsubst %.cu, build/%_gpu.o, $(TORCH_CUSRC))
+else
+	CFLAGS += -DMXNET_USE_TORCH=0
+endif
+
 LIB_DEP += $(DMLC_CORE)/libdmlc.a
-ALL_DEP = $(OBJ) $(EXTRA_OBJ) $(LIB_DEP)
+ALL_DEP = $(OBJ) $(EXTRA_OBJ) $(PLUGIN_OBJ) $(LIB_DEP)
 ifeq ($(USE_CUDA), 1)
-	ALL_DEP += $(CUOBJ) $(EXTRA_CUOBJ)
+	ALL_DEP += $(CUOBJ) $(EXTRA_CUOBJ) $(PLUGIN_CUOBJ)
 	LDFLAGS += -lcuda
 endif
 
@@ -125,15 +138,26 @@ else
 endif
 
 
-build/%.o: src/%.cc
+build/src/%.o: src/%.cc
 	@mkdir -p $(@D)
-	$(CXX) -std=c++0x $(CFLAGS) -MM -MT build/$*.o $< >build/$*.d
+	$(CXX) -std=c++0x $(CFLAGS) -MM -MT build/src/$*.o $< >build/src/$*.d
 	$(CXX) -std=c++0x -c $(CFLAGS) -c $< -o $@
 
-build/%_gpu.o: src/%.cu
+build/src/%_gpu.o: src/%.cu
 	@mkdir -p $(@D)
-	$(NVCC) $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" -M -MT build/$*_gpu.o $< >build/$*_gpu.d
+	$(NVCC) $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" -M -MT build/src/$*_gpu.o $< >build/src/$*_gpu.d
 	$(NVCC) -c -o $@ $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" $<
+
+build/plugin/%.o: plugin/%.cc
+	@mkdir -p $(@D)
+	$(CXX) -std=c++0x $(CFLAGS) -MM -MT build/plugin/$*.o $< >build/plugin/$*.d
+	$(CXX) -std=c++0x -c $(CFLAGS) -c $< -o $@
+
+build/plugin/%_gpu.o: plugin/%.cu
+	@mkdir -p $(@D)
+	$(NVCC) $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" -M -MT build/plugin/$*_gpu.o $< >build/plugin/$*_gpu.d
+	$(NVCC) -c -o $@ $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" $<
+
 
 $(EXTRA_OPERATORS)/build/%.o: $(EXTRA_OPERATORS)/%.cc
 	@mkdir -p $(@D)
@@ -173,7 +197,7 @@ include tests/cpp/unittest.mk
 test: $(TEST)
 
 lint: rcpplint
-	python2 dmlc-core/scripts/lint.py mxnet ${LINT_LANG} include src scripts python predict/python
+	python2 dmlc-core/scripts/lint.py mxnet ${LINT_LANG} include src plugin scripts python predict/python 
 
 doc: doxygen
 

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,9 @@ endif
 
 all: lib/libmxnet.a lib/libmxnet.so $(BIN)
 
-SRC = $(wildcard src/*.cc src/*/*.cc src/*/*/*.cc)
+SRC = $(wildcard src/*.cc src/*/*.cc)
 OBJ = $(patsubst %.cc, build/%.o, $(SRC))
-CUSRC = $(wildcard src/*/*.cu src/*/*/*.cu)
+CUSRC = $(wildcard src/*/*.cu)
 CUOBJ = $(patsubst %.cu, build/%_gpu.o, $(CUSRC))
 
 ifneq ($(EXTRA_OPERATORS),)
@@ -113,7 +113,10 @@ endif
 # plugin
 ifeq ($(USE_TORCH), 1)
 	CFLAGS += -I$(TORCH_PATH)/install/include -I$(TORCH_PATH)/install/include/TH -I$(TORCH_PATH)/install/include/THC -DMXNET_USE_TORCH=1
-	LDFLAGS += -Wl,-export-dynamic -L$(TORCH_PATH)/install/lib -L$(TORCH_PATH)/install/lib/lua/5.1 -lluajit -lluaT -lTH -lTHC -lpaths -ltorch -lcutorch -lnn -lcunn
+	LDFLAGS += -L$(TORCH_PATH)/install/lib -L$(TORCH_PATH)/install/lib/lua/5.1 -lluajit -lluaT -lTH -lTHC -lpaths -ltorch -lnn
+	ifeq ($(USE_CUDA), 1)
+		LDFLAGS += -lcutorch -lcunn
+	endif
 	
 	TORCH_SRC = $(wildcard plugin/torch/*.cc)
 	PLUGIN_OBJ += $(patsubst %.cc, build/%.o, $(TORCH_SRC))
@@ -240,6 +243,7 @@ clean_all: clean
 
 -include build/*.d
 -include build/*/*.d
+-include build/*/*/*.d
 ifneq ($(EXTRA_OPERATORS),)
 	-include $(EXTRA_OPERATORS)/build/*.d
 endif

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ endif
 # plugin
 ifeq ($(USE_TORCH), 1)
 	CFLAGS += -I$(TORCH_PATH)/install/include -I$(TORCH_PATH)/install/include/TH -I$(TORCH_PATH)/install/include/THC -DMXNET_USE_TORCH=1
-	LDFLAGS += -L$(TORCH_PATH)/install/lib -L$(TORCH_PATH)/install/lib/lua/5.1 -lluajit -lluaT -lTH -lTHC -lpaths -ltorch -lnn
+	LDFLAGS += -L$(TORCH_PATH)/install/lib -lluajit -lluaT -lTH -lTHC -L$(TORCH_PATH)/install/lib/lua/5.1 -lpaths -ltorch -lnn
 	ifeq ($(USE_CUDA), 1)
 		LDFLAGS += -lcutorch -lcunn
 	endif
@@ -156,11 +156,11 @@ build/plugin/%.o: plugin/%.cc
 	$(CXX) -std=c++0x $(CFLAGS) -MM -MT build/plugin/$*.o $< >build/plugin/$*.d
 	$(CXX) -std=c++0x -c $(CFLAGS) -c $< -o $@
 
+# A nvcc bug cause this to generate "generic/xxx.h" dependencies from torch headers.
+# $(NVCC) $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" -M -MT build/plugin/$*_gpu.o $< >build/plugin/$*_gpu.d
 build/plugin/%_gpu.o: plugin/%.cu
 	@mkdir -p $(@D)
-	$(NVCC) $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" -M -MT build/plugin/$*_gpu.o $< >build/plugin/$*_gpu.d
 	$(NVCC) -c -o $@ $(NVCCFLAGS) -Xcompiler "$(CFLAGS)" $<
-
 
 $(EXTRA_OPERATORS)/build/%.o: $(EXTRA_OPERATORS)/%.cc
 	@mkdir -p $(@D)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ deep learning system, and interesting insights of DL systems for hackers.
 
 What's New
 ----------
+* [Embedding Torch layers and functions in MXNet](https://mxnet.readthedocs.org/en/latest/tutorial/torch_howto.html)
 * [MXNet.js: Javascript Package for Deep Learning in Browser (without server)
 ](https://github.com/dmlc/mxnet.js/)
 * [Design Note: Design Efficient Deep Learning Data Loading Module](http://mxnet.readthedocs.org/en/latest/developer-guide/note_data_loading.html)

--- a/doc/tutorial/torch_howto.md
+++ b/doc/tutorial/torch_howto.md
@@ -46,7 +46,14 @@ mlp = mx.symbol.SoftmaxOutput(data=fc3, name='softmax')
 ```
 Let's break it down. First `data = mx.symbol.Variable('data')` defines a Variable as placeholder for input.
 Then it's fed through Torch's nn modules with `fc1 = mx.symbol.TorchModule(data_0=data, lua_string='nn.Linear(784, 128)', num_data=1, num_params=2, num_outputs=1, name='fc1')`.
-Note that we used `mx.symbol.SoftmaxOutput` instead of Torch module because torch implement loss layers in separate class torch.Critirion and it's not supported yet.
+We can also replace the last line with:
+```Python
+logsoftmax = mx.symbol.TorchModule(data_0=fc3, lua_string='nn.LogSoftMax()', num_data=1, num_params=0, num_outputs=1, name='logsoftmax')
+# Torch's label starts from 1
+label = mx.symbol.Variable('softmax_label') + 1
+mlp = mx.symbol.TorchCriterion(data=logsoftmax, label=label, lua_string='nn.ClassNLLCriterion()', name='softmax')
+```
+to use Torch's criterion as loss functions.
 The input to nn module is named as data_i for i = 0 ... num_data-1. `lua_string` is a single Lua statement that creates the module object.
 For Torch's built-in module this is simply `nn.module_name(arguments)`.
 If you are using custom module, place it in a .lua script file and load it with `require 'module_file.lua'` if your script returns an torch.nn object, or `(require 'module_file.lua')()` if your script returns a torch.nn class.

--- a/doc/tutorial/torch_howto.md
+++ b/doc/tutorial/torch_howto.md
@@ -1,0 +1,53 @@
+# How to use MXNet as a (almost) full function Torch front-end
+
+This tutorial demonstrates how to use MXNet as front-end to two of Torch's major functionalities:
+
+* 1) Compile MXNet with Torch support.
+
+* 2) Call Torch's tensor mathematical functions with MXNet.NDArray.
+
+* 3) Embed Torch's neural network modules (layers) into MXNet's symbolic graph.
+
+## Compile with Torch
+* First install Torch following [official guide](http://torch.ch/docs/getting-started.html).
+* Then, in `config.mk` (if you haven't already, copy `make/config.mk` (Linux) or `make/osx.mk` (Mac) into MXNet root folder as `config.mk`) set `USE_TORCH = 1`
+and `TORCH_PATH = /path/to/torch`. By default Torch should be installed in your home folder (so `TORCH_PATH = $(HOME)/torch`).
+* Run `make clean && make` to build with torch support.
+
+## Tensor Mathematics
+mxnet.th module supports calling Torch's tensor mathematical functions with mxnet.nd.NDArray. For example ([full code](https://github.com/dmlc/mxnet/blob/master/example/torch/torch_function.py)):
+```Python
+import mxnet as mx
+x = mx.th.randn(2, 2, ctx=mx.cpu(0))
+print x.asnumpy()
+y = mx.th.abs(x)
+print y.asnumpy()
+
+x = mx.th.randn(2, 2, ctx=mx.cpu(0))
+print x.asnumpy()
+mx.th.abs(x, x) # in-place
+print x.asnumpy()
+```
+Help can be found with `help(mx.th)`. 
+We already added support for most common functions listed on [Torch's doc page](https://github.com/torch/torch7/blob/master/doc/maths.md). 
+If you find that the function you need is not supported, you can easily register it in `mxnet_root/plugin/torch/torch_function.cc` following existing registrations.
+
+## Torch Modules (Layers)
+Torch's neural network modules is also supported by MXNet through `mxnet.symbol.TorchModule` symbol.
+For example, the following code defines a 3 layer DNN for classifying MNIST digits ([full code](https://github.com/dmlc/mxnet/blob/master/example/torch/torch_module.py)):
+```Python
+data = mx.symbol.Variable('data')
+fc1 = mx.symbol.TorchModule(data_0=data, lua_string='nn.Linear(784, 128)', num_data=1, num_params=2, num_outputs=1, name='fc1')
+act1 = mx.symbol.TorchModule(data_0=fc1, lua_string='nn.ReLU(false)', num_data=1, num_params=0, num_outputs=1, name='relu1')
+fc2 = mx.symbol.TorchModule(data_0=act1, lua_string='nn.Linear(128, 64)', num_data=1, num_params=2, num_outputs=1, name='fc2')
+act2 = mx.symbol.TorchModule(data_0=fc2, lua_string='nn.ReLU(false)', num_data=1, num_params=0, num_outputs=1, name='relu2')
+fc3 = mx.symbol.TorchModule(data_0=act2, lua_string='nn.Linear(64, 10)', num_data=1, num_params=2, num_outputs=1, name='fc3')
+mlp = mx.symbol.SoftmaxOutput(data=fc3, name='softmax')
+```
+Let's break it down. First `data = mx.symbol.Variable('data')` defines a Variable as placeholder for input.
+Then it's fed through Torch's nn modules with `fc1 = mx.symbol.TorchModule(data_0=data, lua_string='nn.Linear(784, 128)', num_data=1, num_params=2, num_outputs=1, name='fc1')`.
+Note that we used `mx.symbol.SoftmaxOutput` instead of Torch module because torch implement loss layers in separate class torch.Critirion and it's not supported yet.
+The input to nn module is named as data_i for i = 0 ... num_data-1. `lua_string` is a single Lua statement that creates the module object.
+For Torch's built-in module this is simply `nn.module_name(arguments)`.
+If you are using custom module, place it in a .lua script file and load it with `require 'module_file.lua'` if your script returns an torch.nn object, or `(require 'module_file.lua')()` if your script returns a torch.nn class.
+

--- a/example/torch/data.py
+++ b/example/torch/data.py
@@ -1,0 +1,32 @@
+# pylint: skip-file
+""" data iterator for mnist """
+import sys
+import os
+# code to automatically download dataset
+curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+sys.path.append(os.path.join(curr_path, "../../tests/python/common"))
+import get_data
+import mxnet as mx
+
+def mnist_iterator(batch_size, input_shape):
+    """return train and val iterators for mnist"""
+    # download data
+    get_data.GetMNIST_ubyte()
+    flat = False if len(input_shape) == 3 else True
+
+    train_dataiter = mx.io.MNISTIter(
+        image="data/train-images-idx3-ubyte",
+        label="data/train-labels-idx1-ubyte",
+        input_shape=input_shape,
+        batch_size=batch_size,
+        shuffle=True,
+        flat=flat)
+
+    val_dataiter = mx.io.MNISTIter(
+        image="data/t10k-images-idx3-ubyte",
+        label="data/t10k-labels-idx1-ubyte",
+        input_shape=input_shape,
+        batch_size=batch_size,
+        flat=flat)
+
+    return (train_dataiter, val_dataiter)

--- a/example/torch/torch_function.py
+++ b/example/torch/torch_function.py
@@ -1,0 +1,10 @@
+import mxnet as mx
+x = mx.th.randn(2, 2, ctx=mx.cpu(0))
+print x.asnumpy()
+y = mx.th.abs(x)
+print y.asnumpy()
+
+x = mx.th.randn(2, 2, ctx=mx.cpu(0))
+print x.asnumpy()
+mx.th.abs(x, x) # in-place
+print x.asnumpy()

--- a/example/torch/torch_function.py
+++ b/example/torch/torch_function.py
@@ -8,3 +8,7 @@ x = mx.th.randn(2, 2, ctx=mx.cpu(0))
 print x.asnumpy()
 mx.th.abs(x, x) # in-place
 print x.asnumpy()
+
+x = mx.th.ones(2, 2, ctx=mx.cpu(0))
+y = mx.th.ones(2, 2, ctx=mx.cpu(0))*2
+print mx.th.cdiv(x,y).asnumpy()

--- a/example/torch/torch_module.py
+++ b/example/torch/torch_module.py
@@ -13,6 +13,15 @@ fc2 = mx.symbol.TorchModule(data_0=act1, lua_string='nn.Linear(128, 64)', num_da
 act2 = mx.symbol.TorchModule(data_0=fc2, lua_string='nn.ReLU(false)', num_data=1, num_params=0, num_outputs=1, name='relu2')
 fc3 = mx.symbol.TorchModule(data_0=act2, lua_string='nn.Linear(64, 10)', num_data=1, num_params=2, num_outputs=1, name='fc3')
 mlp = mx.symbol.SoftmaxOutput(data=fc3, name='softmax')
+# logsoftmax = mx.symbol.TorchModule(data_0=fc3, lua_string='nn.LogSoftMax()', num_data=1, num_params=0, num_outputs=1, name='logsoftmax')
+# label = mx.symbol.Variable('softmax_label') + 1
+# mlp = mx.symbol.TorchCriterion(data=logsoftmax, label=label, lua_string='nn.ClassNLLCriterion()', name='softmax')
+
+# exe = mlp.simple_bind(mx.cpu(0), 'write', {'data': np.float32}, data=(128,784))
+# exe.forward(is_train=True)
+# exe.backward()
+
+# exit(0)
 
 # data
 
@@ -22,9 +31,14 @@ train, val = mnist_iterator(batch_size=100, input_shape = (784,))
 
 logging.basicConfig(level=logging.DEBUG)
 
+mon = mx.monitor.Monitor(1, None, pattern='.*', sort=True)
+
 model = mx.model.FeedForward(
-    ctx = mx.gpu(0), symbol = mlp, num_epoch = 20,
+    ctx = mx.cpu(0), symbol = mlp, num_epoch = 20,
     learning_rate = 0.1, momentum = 0.9, wd = 0.00001)
 
-model.fit(X=train, eval_data=val)
+model.fit(X=train, eval_data=val,
+    #eval_metric=mx.metric.Torch())
+    monitor = mon,
+    batch_end_callback = [mx.callback.Speedometer(100, 1), mx.callback.log_train_metric(1)])
 

--- a/example/torch/torch_module.py
+++ b/example/torch/torch_module.py
@@ -1,0 +1,30 @@
+# pylint: skip-file
+from data import mnist_iterator
+import mxnet as mx
+import numpy as np
+import logging
+
+# define mlp
+
+data = mx.symbol.Variable('data')
+fc1 = mx.symbol.TorchModule(data_0=data, lua_string='nn.Linear(784, 128)', num_data=1, num_params=2, num_outputs=1, name='fc1')
+act1 = mx.symbol.TorchModule(data_0=fc1, lua_string='nn.ReLU(false)', num_data=1, num_params=0, num_outputs=1, name='relu1')
+fc2 = mx.symbol.TorchModule(data_0=act1, lua_string='nn.Linear(128, 64)', num_data=1, num_params=2, num_outputs=1, name='fc2')
+act2 = mx.symbol.TorchModule(data_0=fc2, lua_string='nn.ReLU(false)', num_data=1, num_params=0, num_outputs=1, name='relu2')
+fc3 = mx.symbol.TorchModule(data_0=act2, lua_string='nn.Linear(64, 10)', num_data=1, num_params=2, num_outputs=1, name='fc3')
+mlp = mx.symbol.SoftmaxOutput(data=fc3, name='softmax')
+
+# data
+
+train, val = mnist_iterator(batch_size=100, input_shape = (784,))
+
+# train
+
+logging.basicConfig(level=logging.DEBUG)
+
+model = mx.model.FeedForward(
+    ctx = mx.gpu(0), symbol = mlp, num_epoch = 20,
+    learning_rate = 0.1, momentum = 0.9, wd = 0.00001)
+
+model.fit(X=train, eval_data=val)
+

--- a/example/torch/torch_module.py
+++ b/example/torch/torch_module.py
@@ -6,22 +6,22 @@ import logging
 
 # define mlp
 
+use_torch_criterion = False
+
 data = mx.symbol.Variable('data')
 fc1 = mx.symbol.TorchModule(data_0=data, lua_string='nn.Linear(784, 128)', num_data=1, num_params=2, num_outputs=1, name='fc1')
 act1 = mx.symbol.TorchModule(data_0=fc1, lua_string='nn.ReLU(false)', num_data=1, num_params=0, num_outputs=1, name='relu1')
 fc2 = mx.symbol.TorchModule(data_0=act1, lua_string='nn.Linear(128, 64)', num_data=1, num_params=2, num_outputs=1, name='fc2')
 act2 = mx.symbol.TorchModule(data_0=fc2, lua_string='nn.ReLU(false)', num_data=1, num_params=0, num_outputs=1, name='relu2')
 fc3 = mx.symbol.TorchModule(data_0=act2, lua_string='nn.Linear(64, 10)', num_data=1, num_params=2, num_outputs=1, name='fc3')
-mlp = mx.symbol.SoftmaxOutput(data=fc3, name='softmax')
-# logsoftmax = mx.symbol.TorchModule(data_0=fc3, lua_string='nn.LogSoftMax()', num_data=1, num_params=0, num_outputs=1, name='logsoftmax')
-# label = mx.symbol.Variable('softmax_label') + 1
-# mlp = mx.symbol.TorchCriterion(data=logsoftmax, label=label, lua_string='nn.ClassNLLCriterion()', name='softmax')
 
-# exe = mlp.simple_bind(mx.cpu(0), 'write', {'data': np.float32}, data=(128,784))
-# exe.forward(is_train=True)
-# exe.backward()
-
-# exit(0)
+if use_torch_criterion:
+    logsoftmax = mx.symbol.TorchModule(data_0=fc3, lua_string='nn.LogSoftMax()', num_data=1, num_params=0, num_outputs=1, name='logsoftmax')
+    # Torch's label starts from 1
+    label = mx.symbol.Variable('softmax_label') + 1
+    mlp = mx.symbol.TorchCriterion(data=logsoftmax, label=label, lua_string='nn.ClassNLLCriterion()', name='softmax')
+else:
+    mlp = mx.symbol.SoftmaxOutput(data=fc3, name='softmax')
 
 # data
 
@@ -31,14 +31,11 @@ train, val = mnist_iterator(batch_size=100, input_shape = (784,))
 
 logging.basicConfig(level=logging.DEBUG)
 
-mon = mx.monitor.Monitor(1, None, pattern='.*', sort=True)
-
 model = mx.model.FeedForward(
     ctx = mx.cpu(0), symbol = mlp, num_epoch = 20,
     learning_rate = 0.1, momentum = 0.9, wd = 0.00001)
 
-model.fit(X=train, eval_data=val,
-    #eval_metric=mx.metric.Torch())
-    monitor = mon,
-    batch_end_callback = [mx.callback.Speedometer(100, 1), mx.callback.log_train_metric(1)])
-
+if use_torch_criterion:
+    model.fit(X=train, eval_data=val, eval_metric=mx.metric.Torch())
+else:
+    model.fit(X=train, eval_data=val)

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -382,7 +382,10 @@ MXNET_DLL int MXFuncDescribe(FunctionHandle fun,
 MXNET_DLL int MXFuncInvoke(FunctionHandle fun,
                            NDArrayHandle *use_vars,
                            mx_float *scalar_args,
-                           NDArrayHandle *mutate_vars);
+                           NDArrayHandle *mutate_vars,
+                           int num_params,
+                           char **param_keys,
+                           char **param_vals);
 
 //--------------------------------------------
 // Part 3: symbolic configuration generation

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -382,11 +382,27 @@ MXNET_DLL int MXFuncDescribe(FunctionHandle fun,
 MXNET_DLL int MXFuncInvoke(FunctionHandle fun,
                            NDArrayHandle *use_vars,
                            mx_float *scalar_args,
-                           NDArrayHandle *mutate_vars,
-                           int num_params,
-                           char **param_keys,
-                           char **param_vals);
-
+                           NDArrayHandle *mutate_vars);
+/*!
+ * \brief invoke a function, the array size of passed in arguments
+ *   must match the values in the
+ * \param fun the function
+ * \param use_vars the normal arguments passed to function
+ * \param scalar_args the scalar qarguments
+ * \param mutate_vars the mutate arguments
+ * \param num_params number of keyword parameters
+ * \param param_keys keys for keyword parameters
+ * \param param_vals values for keyword parameters
+ * \return 0 when success, -1 when failure happens
+ * \sa MXFuncDescribeArgs
+ */
+MXNET_DLL int MXFuncInvokeEx(FunctionHandle fun,
+                             NDArrayHandle *use_vars,
+                             mx_float *scalar_args,
+                             NDArrayHandle *mutate_vars,
+                             int num_params,
+                             char **param_keys,
+                             char **param_vals);
 //--------------------------------------------
 // Part 3: symbolic configuration generation
 //--------------------------------------------

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -561,7 +561,7 @@ struct NDArrayFunctionReg
   /*!
    * \brief set the function body to a unary NDArray function
    *  this will also auto set the parameters correctly
-   * \param funary function body to set
+   * \param fgeneric function body to set
    * \return ref to the registered entry, used to set properties
    */
   inline NDArrayFunctionReg &set_function(

--- a/make/config.mk
+++ b/make/config.mk
@@ -105,3 +105,12 @@ USE_S3 = 0
 
 # path to folders containing projects specific operators that you don't want to put in src/operators
 EXTRA_OPERATORS =
+
+
+#----------------------------
+# plugins
+#----------------------------
+
+# whether to use torch integration. This requires installing torch.
+USE_TORCH = 0
+TORCH_PATH = $(HOME)/torch

--- a/make/osx.mk
+++ b/make/osx.mk
@@ -92,3 +92,12 @@ USE_S3 = 0
 
 # path to folders containing projects specific operators that you don't want to put in src/operators
 EXTRA_OPERATORS =
+
+
+#----------------------------
+# plugins
+#----------------------------
+
+# whether to use torch integration. This requires installing torch.
+USE_TORCH = 0
+TORCH_PATH = $(HOME)/torch

--- a/plugin/torch/torch_base.cc
+++ b/plugin/torch/torch_base.cc
@@ -1,0 +1,44 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file torch_base.cc
+ * \brief torch_state
+ * \author Junyuan Xie
+*/
+#include "./torch_base.h"
+
+namespace mxnet {
+lua_State* TorchState::LuaState() {
+  thread_local lua_State* state = NULL;
+  if (!state) {
+    state = luaL_newstate();
+    luaL_openlibs(state);
+    luaL_loadstring(state,
+                    "require 'torch'\n"
+                    "require 'nn'\n"
+#if MXNET_USE_CUDA
+                    "require 'cutorch'\n"
+                    "require 'cunn'\n"
+#if MXNET_USE_CUDNN
+                    "require 'cudnn'\n"
+#endif  // MXNET_USE_CUDNN
+#endif  // MXNET_USE_CUDA
+                    "local ss = require 'threads.sharedserialize'\n"
+                    "Serialize, Deserialize = ss.save, ss.load\n");
+    int err = lua_pcall(state, 0, 0, 0);
+    CHECK_EQ(err, 0) << lua_tostring(state, -1);
+  }
+  return state;
+}
+
+template<>
+void TorchState::SetStream(mshadow::Stream<mshadow::cpu>* s) {
+  return;
+}
+
+#if MXNET_USE_CUDA
+template<>
+void TorchState::SetStream(mshadow::Stream<mshadow::gpu>* s) {
+  TorchState::CudaState()->currentStream = mshadow::Stream<gpu>::GetStream(s);
+}
+#endif  // MXNET_USE_CUDA
+}  // namespace mxnet

--- a/plugin/torch/torch_base.h
+++ b/plugin/torch/torch_base.h
@@ -1,0 +1,223 @@
+/*!
+ *  Copyright (c) 2015 by Contributors
+ * \file torch_base.h
+ * \brief Torch interface.
+ * \author Junyuan Xie
+ */
+#ifndef PLUGIN_TORCH_TORCH_BASE_H_
+#define PLUGIN_TORCH_TORCH_BASE_H_
+#include <mxnet/base.h>
+#include <vector>
+
+extern "C" {
+#include "lua.h"
+#include "luaT.h"
+#include "lualib.h"
+#include "THStorage.h"
+#include "THTensor.h"
+}
+
+#if MXNET_USE_CUDA
+extern "C" {
+#include "THCStorage.h"
+#include "THCTensor.h"
+}
+#endif  // MXNET_USE_CUDA
+
+namespace mxnet {
+
+class TorchState {
+ public:
+  static lua_State* LuaState();
+
+#if MXNET_USE_CUDA
+  static THCState* CudaState() {
+    lua_State* L = TorchState::LuaState();
+    lua_getglobal(L, "cutorch");
+    CHECK(!lua_isnil(L, -1));
+    lua_getfield(L, -1, "_state");
+    CHECK(!lua_isnil(L, -1));
+    THCState* state = reinterpret_cast<THCState*>(lua_touserdata(L, -1));
+    lua_pop(L, 2);
+    return state;
+  }
+#endif  // MXNET_USE_CUDA
+
+  template<typename xpu>
+  static void SetStream(mshadow::Stream<xpu>* s);
+
+  static int Deserialize(THCharStorage* chunk) {  // read only to the chunk
+    CHECK_NE(chunk, NULL);
+    lua_State* L = LuaState();
+    lua_getglobal(L, "Deserialize");
+    luaT_pushudata(L, chunk, "torch.CharStorage");
+    THCharStorage_retain(chunk);  // keep it because read only
+    int err = lua_pcall(L, 1, 1, 0);
+    CHECK_EQ(err, 0);
+    return 1;
+  }
+
+  static int Serialize(THCharStorage** chunk) {
+    lua_State* L = LuaState();
+    lua_getglobal(L, "Serialize");
+    lua_pushvalue(L, -2);
+    int err = lua_pcall(L, 1, 1, 0);
+    CHECK_EQ(err, 0) << "Serialize failed " << lua_tostring(L, -1);
+    THCharStorage_free(*chunk);  // free the original
+    *chunk = reinterpret_cast<THCharStorage*>(luaT_toudata(L, -1, "torch.CharStorage"));
+    THCharStorage_retain(*chunk);  // keep the chunk even when lua side deletes
+    lua_pop(L, 2);
+    return 0;
+  }
+
+  static void PrintState() {
+    lua_State* L = LuaState();
+    int i;
+    int top = lua_gettop(L);
+    LOG(INFO) << "Stack height: " << top;
+    for (i = 1; i <= top; i++) {  /* repeat for each level */
+      int t = lua_type(L, i);
+      switch (t) {
+        case LUA_TSTRING:  /* strings */
+          LOG(INFO) << i << ": '" << lua_tostring(L, i) << "'";
+          break;
+        case LUA_TBOOLEAN:  /* booleans */
+          LOG(INFO) << i << ": " << (lua_toboolean(L, i) ? "true" : "false");
+          break;
+        case LUA_TNUMBER:  /* numbers */
+          LOG(INFO) << i << ": " << lua_tonumber(L, i);
+          break;
+        default:  /* other values */
+          LOG(INFO) << i << ": " << lua_typename(L, t);
+          break;
+      }
+    }
+  }
+};
+
+typedef void* THGeneralTensor;
+typedef void* THGeneralStorage;
+
+class TorchTensor {
+ public:
+  static const char* TensorType(int dev_mask) {
+    switch (dev_mask) {
+      case cpu::kDevMask:
+        return "torch.FloatTensor";
+      case gpu::kDevMask:
+        return "torch.CudaTensor";
+      default:
+        LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+        return NULL;
+    }
+  }
+
+  static const char* ModuleType(int dev_mask) {
+    switch (dev_mask) {
+      case cpu::kDevMask:
+        return ":float()";
+      case gpu::kDevMask:
+        return ":cuda()";
+      default:
+        LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+        return NULL;
+    }
+  }
+
+  static const char* TensorType(TBlob data) {
+    return TensorType(data.dev_mask_);
+  }
+
+  static const char* ModuleType(TBlob data) {
+    return TensorType(data.dev_mask_);
+  }
+
+  static THGeneralTensor TBlobToTHTensor(TBlob data) {
+    size_t size = data.Size();
+    THGeneralTensor tensor = NULL;
+    THLongStorage* thshape = THLongStorage_newWithSize(data.ndim());
+    for (int i = 0; i < data.ndim(); ++i) {
+      THLongStorage_set(thshape, i, data.shape_[i]);
+    }
+    CHECK_EQ(data.type_flag_, mshadow::kFloat32) << "Torch Interface only support float32";
+    switch (data.dev_mask_) {
+      case cpu::kDevMask: {
+        THFloatStorage* storage = THFloatStorage_newWithData(static_cast<real_t*>(data.dptr_),
+                                                             size);
+        THFloatStorage_clearFlag(storage, TH_STORAGE_FREEMEM);
+        tensor = (THGeneralTensor)THFloatTensor_newWithStorage(storage, 0, thshape, NULL);
+        THFloatStorage_free(storage);
+        break;
+      }
+#if MXNET_USE_CUDA
+      case gpu::kDevMask: {
+        THCState* state = TorchState::CudaState();
+        THCudaStorage* storage = THCudaStorage_newWithData(state, static_cast<real_t*>(data.dptr_),
+                                                           size);
+        // a bug in cutorch
+        THFloatStorage_clearFlag(reinterpret_cast<THFloatStorage*>(storage), TH_STORAGE_FREEMEM);
+        tensor = (THGeneralTensor)THCudaTensor_newWithStorage(state, storage, 0, thshape, NULL);
+        THCudaStorage_free(state, storage);
+        break;
+      }
+#endif
+      default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    }
+    THLongStorage_free(thshape);
+
+    return tensor;
+  }
+
+  static void SetInternal(THGeneralTensor tensor, const TBlob& blob) {
+    size_t size = blob.Size();
+    switch (blob.dev_mask_) {
+      case cpu::kDevMask: {
+        THFloatStorage* storage = THFloatStorage_newWithData(static_cast<real_t*>(blob.dptr_),
+                                                             size);
+        THFloatStorage_clearFlag(storage, TH_STORAGE_FREEMEM);
+        THFloatStorage* original = static_cast<THFloatTensor*>(tensor)->storage;
+        static_cast<THFloatTensor*>(tensor)->storage = storage;
+        THFloatStorage_free(original);
+      }
+      case gpu::kDevMask: {
+#if MXNET_USE_CUDA
+        THCState* state = TorchState::CudaState();
+        THCudaStorage* storage = THCudaStorage_newWithData(state,
+                                                           static_cast<real_t*>(blob.dptr_),
+                                                           size);
+        // TODO(min): torch bug Cuda version not implemented
+        THFloatStorage_clearFlag(reinterpret_cast<THFloatStorage*>(storage), TH_STORAGE_FREEMEM);
+        THCudaStorage* original = static_cast<THCudaTensor*>(tensor)->storage;
+        static_cast<THCudaTensor*>(tensor)->storage = storage;
+        THCudaStorage_free(state, original);
+#else
+        LOG(FATAL) << "GPU is not enabled";
+#endif
+      }
+      default:
+        LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    }
+  }
+
+  static void TBlobVectorAsTable(const std::vector<TBlob>::const_iterator begin,
+                         const std::vector<TBlob>::const_iterator end) {
+    lua_State* L = TorchState::LuaState();
+    int num = end - begin;
+    if (num > 1) {
+      lua_createtable(L, num, 0);
+      int index = 1;
+      for (std::vector<TBlob>::const_iterator it = begin; it != end; ++it) {
+        THGeneralTensor th = TorchTensor::TBlobToTHTensor(*it);
+        luaT_pushudata(L, th, TorchTensor::TensorType(*it));
+        lua_rawseti(L, -2, index++);
+      }
+    } else if (num == 0) {
+      lua_pushnil(L);
+    } else {
+      luaT_pushudata(L, TorchTensor::TBlobToTHTensor(*begin), TorchTensor::TensorType(*begin));
+    }
+  }
+};
+
+}  // namespace mxnet
+#endif  // PLUGIN_TORCH_TORCH_BASE_H_

--- a/plugin/torch/torch_base.h
+++ b/plugin/torch/torch_base.h
@@ -161,7 +161,8 @@ class TorchTensor {
         break;
       }
 #endif
-      default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+      default:
+        LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
     }
     THLongStorage_free(thshape);
 
@@ -178,9 +179,10 @@ class TorchTensor {
         THFloatStorage* original = static_cast<THFloatTensor*>(tensor)->storage;
         static_cast<THFloatTensor*>(tensor)->storage = storage;
         THFloatStorage_free(original);
+        break;
       }
-      case gpu::kDevMask: {
 #if MXNET_USE_CUDA
+      case gpu::kDevMask: {
         THCState* state = TorchState::CudaState();
         THCudaStorage* storage = THCudaStorage_newWithData(state,
                                                            static_cast<real_t*>(blob.dptr_),
@@ -190,12 +192,11 @@ class TorchTensor {
         THCudaStorage* original = static_cast<THCudaTensor*>(tensor)->storage;
         static_cast<THCudaTensor*>(tensor)->storage = storage;
         THCudaStorage_free(state, original);
-#else
-        LOG(FATAL) << "GPU is not enabled";
-#endif
+        break;
       }
+#endif
       default:
-        LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+        LOG(FATAL) << "Unknown device type " << blob.dev_mask_;
     }
   }
 

--- a/plugin/torch/torch_base.h
+++ b/plugin/torch/torch_base.h
@@ -169,57 +169,6 @@ class TorchTensor {
     return tensor;
   }
 
-  static TBlob THTensorToTBlob(THGeneralTensor* handle) {
-    using namespace mshadow;
-    lua_State* L = TorchState::LuaState();
-    TBlob res;
-    lua_getfield(L, -1, "contiguous");
-    lua_pushvalue(L, -2);
-    int err = lua_pcall(L, 1, 1, 0);
-    CHECK_EQ(err, 0);
-    if (luaT_isudata(L, -1, TorchTensor::TensorType(cpu::kDevMask))) {
-      THFloatTensor* tensor = static_cast<THFloatTensor*>(luaT_toudata(L, -1,
-        TorchTensor::TensorType(cpu::kDevMask)));
-      *handle = static_cast<THGeneralTensor>(tensor);
-      THFloatStorage* storage = tensor->storage;
-      TShape shape(tensor->size, tensor->size + tensor->nDimension);
-      res = TBlob(storage->data, shape, cpu::kDevMask);
-#if MXNET_USE_CUDA
-    } else if (luaT_isudata(L, -1, TorchTensor::TensorType(gpu::kDevMask))) {
-      THCudaTensor* tensor = static_cast<THCudaTensor*>(luaT_toudata(L, -1,
-        TorchTensor::TensorType(gpu::kDevMask)));
-      *handle = static_cast<THGeneralTensor>(tensor);
-      THCudaStorage* storage = tensor->storage;
-      TShape shape(tensor->size, tensor->size + tensor->nDimension);
-      res = TBlob(storage->data, shape, gpu::kDevMask);
-#endif
-    } else {
-      LOG(FATAL) << "Unsupported Torch Tensor type " << luaT_typename(L, -1);
-    }
-    lua_pop(L, 2);
-    return res;
-  }
-
-  static void THTensorFree(THGeneralTensor handle, int dev_mask) {
-    switch (dev_mask) {
-      case cpu::kDevMask: {
-        THFloatTensor* original = static_cast<THFloatTensor*>(handle);
-        THFloatTensor_free(original);
-        break;
-      }
-#if MXNET_USE_CUDA
-      case gpu::kDevMask: {
-        THCState* state = TorchState::CudaState();
-        THCudaTensor* original = static_cast<THCudaTensor*>(handle);
-        THCudaTensor_free(state, original);
-        break;
-      }
-#endif
-      default:
-        LOG(FATAL) << "Unknown device type " << dev_mask;
-    }
-  }
-
   static void FreeInternal(THGeneralTensor tensor, int dev_mask) {
     switch (dev_mask) {
       case cpu::kDevMask: {

--- a/plugin/torch/torch_criterion-inl.h
+++ b/plugin/torch/torch_criterion-inl.h
@@ -1,0 +1,209 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file torch_module-inl.h
+ * \brief torch module operator
+ * \author Min Lin
+*/
+#ifndef PLUGIN_TORCH_TORCH_CRITERION_INL_H_
+#define PLUGIN_TORCH_TORCH_CRITERION_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <stdio.h>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+#include <utility>
+#include "../../src/operator/operator_common.h"
+#include "./torch_base.h"
+
+namespace mxnet {
+namespace op {
+struct TorchCriterionParam : public dmlc::Parameter<TorchCriterionParam> {
+  std::string lua_string;
+  TShape label_shape;
+  float grad_scale;
+  DMLC_DECLARE_PARAMETER(TorchCriterionParam) {
+    DMLC_DECLARE_FIELD(lua_string)
+    .describe("lua string that is called to generate the torch criterion object");
+    DMLC_DECLARE_FIELD(label_shape)
+    .set_default(TShape())
+    .enforce_nonzero()
+    .describe("Shape of label (without batch size).");
+    DMLC_DECLARE_FIELD(grad_scale)
+    .set_default(1.0f)
+    .describe("Scale the gradient by a float factor (a.k.a weight of this loss).");
+  }
+};
+
+/**
+ * \brief This is the implementation of activation operator.
+ * \tparam xpu The device that the op will be executed on.
+ */
+template<typename xpu>
+class TorchCriterionOp : public Operator {
+ private:
+  TorchCriterionParam param_;
+
+ protected:
+  THCharStorage* chunk_;
+
+ public:
+  explicit TorchCriterionOp(TorchCriterionParam p) : chunk_(NULL) {
+    this->param_ = p;
+    lua_State* L = TorchState::LuaState();
+    CHECK_EQ(lua_gettop(L), 0);
+    std::string exec = std::string("return ") + p.lua_string
+      + TorchTensor::ModuleType(xpu::kDevMask);
+    CHECK_EQ(luaL_loadstring(L, exec.c_str()), 0);
+    int err = lua_pcall(L, 0, 1, 0);
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    // serialize
+    TorchState::Serialize(&chunk_);
+  }
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    lua_State* L = TorchState::LuaState();
+    CHECK_EQ(lua_gettop(L), 0);
+    CHECK_EQ(in_data.size(), 2);
+    CHECK_EQ(out_data.size(), 1);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    TorchState::SetStream(s);
+    // Deserialize self table
+    TorchState::Deserialize(chunk_);
+    // call forward
+    // | self
+    lua_getfield(L, -1, "forward");
+    // | self | forward
+    lua_pushvalue(L, -2);
+    // | self | forward | self
+    for (index_t i = 0; i < in_data.size(); ++i) {
+      THGeneralTensor th = TorchTensor::TBlobToTHTensor(in_data[i]);
+      luaT_pushudata(L, th, TorchTensor::TensorType(in_data[i]));
+    }
+    // | self | forward | self | pred | label
+    int err = lua_pcall(L, 3, 1, 0);
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    CHECK(lua_isnumber(L, -1)) << "Criterion must return a number";
+    real_t loss = static_cast<real_t>(lua_tonumber(L, -1));
+    lua_pop(L, 1);
+    Tensor<xpu, 2> out = out_data[0].FlatTo2D<xpu, real_t>(s);
+    Assign(out, req[0], loss*param_.grad_scale);
+    TorchState::Serialize(&chunk_);
+    CHECK_EQ(lua_gettop(L), 0);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    lua_State* L = TorchState::LuaState();
+    CHECK_EQ(lua_gettop(L), 0);
+    CHECK_EQ(in_data.size(), 2);
+    CHECK_EQ(out_data.size(), 1);
+    CHECK_EQ(req[0], kWriteTo) << "Torch Criterion only supports write to in_grad";
+    CHECK_EQ(req[1], kNullOp) << "Torch Criterion cannot back prop to label";
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    TorchState::SetStream(s);
+    TorchState::Deserialize(chunk_);
+    THGeneralTensor th = TorchTensor::TBlobToTHTensor(in_grad[0]);
+    luaT_pushudata(L, th, TorchTensor::TensorType(in_grad[0]));
+    lua_setfield(L, -2, "gradInput");
+    lua_getfield(L, -1, "backward");
+    // | self | backward
+    lua_pushvalue(L, -2);
+    // | self | backward | self
+    for (index_t i = 0; i < in_data.size(); ++i) {
+      th = TorchTensor::TBlobToTHTensor(in_data[i]);
+      luaT_pushudata(L, th, TorchTensor::TensorType(in_data[i]));
+    }
+    // | self | forward | self | pred | label
+    int err = lua_pcall(L, 3, 0, 0);
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    Tensor<xpu, 2> grad = in_grad[0].FlatTo2D<xpu, real_t>(s);
+    grad *= param_.grad_scale * in_grad[0].shape_[0];
+    TorchState::Serialize(&chunk_);
+    CHECK_EQ(lua_gettop(L), 0);
+  }
+};  // class TorchCriterionOp
+
+// Decalre Factory function, used for dispatch specialization
+template<typename xpu>
+Operator* CreateOp(TorchCriterionParam type);
+
+#if DMLC_USE_CXX11
+class TorchCriterionProp : public OperatorProperty {
+ public:
+  std::vector<std::string> ListArguments() const override {
+    return {"data", "label"};
+  }
+
+  virtual std::vector<std::string> ListOutputs() const {
+    return {"output"};
+  }
+
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    CHECK_EQ(in_shape->size(), 2);
+    const TShape &dshape = in_shape->at(0);
+    if (dshape.ndim() == 0) return false;
+    std::vector<index_t> lshape;
+    lshape.push_back(dshape[0]);
+    lshape.insert(lshape.end(), param_.label_shape.data(),
+      param_.label_shape.data() +  param_.label_shape.ndim());
+    TShape shape(lshape.begin(), lshape.end());
+    SHAPE_ASSIGN_CHECK(*in_shape, 1, shape);
+    out_shape->clear();
+    out_shape->push_back(Shape1(dshape[0]));
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new TorchCriterionProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "TorchCriterion";
+  }
+
+  // decalre dependency and inplace optimization options
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    std::vector<int> dep;
+    dep.insert(dep.end(), in_data.begin(), in_data.end());
+    return dep;
+  }
+
+  Operator* CreateOperator(Context ctx) const override;
+
+ private:
+  TorchCriterionParam param_;
+};
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+#endif  // PLUGIN_TORCH_TORCH_CRITERION_INL_H_

--- a/plugin/torch/torch_criterion.cc
+++ b/plugin/torch/torch_criterion.cc
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file activation.cc
+ * \brief activation op
+ * \author Junyuan Xie
+*/
+#include "./torch_criterion-inl.h"
+#include "../../src/operator/mshadow_op.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<cpu>(TorchCriterionParam param) {
+  return new TorchCriterionOp<cpu>(param);
+}
+
+// DO_BIND_DISPATCH comes from operator_common.h
+Operator *TorchCriterionProp::CreateOperator(Context ctx) const {
+  DO_BIND_DISPATCH(CreateOp, param_);
+}
+
+DMLC_REGISTER_PARAMETER(TorchCriterionParam);
+
+MXNET_REGISTER_OP_PROPERTY(TorchCriterion, TorchCriterionProp)
+.describe("Criterions from torch.")
+.add_arguments(TorchCriterionParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/plugin/torch/torch_criterion.cu
+++ b/plugin/torch/torch_criterion.cu
@@ -4,14 +4,14 @@
  * \brief activation op
  * \author Bing Xu
 */
-#include "./torch_module-inl.h"
+#include "./torch_criterion-inl.h"
 #include "../../src/operator/mshadow_op.h"
 
 namespace mxnet {
 namespace op {
 template<>
-Operator *CreateOp<gpu>(TorchModuleParam param) {
-  return new TorchModuleOp<gpu>(param);
+Operator *CreateOp<gpu>(TorchCriterionParam param) {
+  return new TorchCriterionOp<gpu>(param);
 }
 
 }  // namespace op

--- a/plugin/torch/torch_function.cc
+++ b/plugin/torch/torch_function.cc
@@ -8,6 +8,16 @@
 
 namespace mxnet {
 
+// Construction or extraction functions
+MXNET_REGISTER_TORCH_CONSTRUCTOR_FUN(_th_eye, eye);
+MXNET_REGISTER_TORCH_CONSTRUCTOR_FUN(_th_ones, ones);
+MXNET_REGISTER_TORCH_CONSTRUCTOR_FUN(_th_rand, rand);
+MXNET_REGISTER_TORCH_CONSTRUCTOR_FUN(_th_randn, randn);
+MXNET_REGISTER_TORCH_CONSTRUCTOR_FUN(_th_randperm, randperm);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_tril, tril);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_triu, triu);
+MXNET_REGISTER_TORCH_CONSTRUCTOR_FUN(_th_zeros, zeros);
+
 // Element-wise Mathematical Operations
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_abs, abs);
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_sign, sign);
@@ -21,7 +31,9 @@ MXNET_REGISTER_TORCH_UNARY_FUN(_th_exp, exp);
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_floor, floor);
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_log, log);
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_log1p, log1p);
-MXNET_REGISTER_TORCH_UNARY_FUN(_th_pow, pow);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_pow, pow)
+.add_argument("n", "float", "pow(x, n) returns x^n, element-wise. "
+  "pow(n, x) returns n^x, element-wise.");
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_round, round);
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_sin, sin);
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_sinh, sinh);
@@ -30,7 +42,96 @@ MXNET_REGISTER_TORCH_UNARY_FUN(_th_tan, tan);
 MXNET_REGISTER_TORCH_UNARY_FUN(_th_tanh, tanh);
 
 // Basic operations
-MXNET_REGISTER_TORCH_UNARY_FUN(_th_add_scalar, add);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_add_scalar, add)
+.add_argument("value", "float", "Add value to all elements in x");
+MXNET_REGISTER_TORCH_BINARY_FUN_WITH_ARG(_th_add, add);
+MXNET_REGISTER_TORCH_BINARY_FUN(_th_add_axpy, add);
 
+// MXNET_REGISTER_TORCH_UNARY_FUN(_th_csub_scalar, csub);
+// MXNET_REGISTER_TORCH_BINARY_FUN_WITH_ARG(_th_csub, csub);
+
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_mul_scalar, mul)
+.add_argument("value", "float", "Multiply value to all elements in x");
+MXNET_REGISTER_TORCH_BINARY_FUN_WITH_ARG(_th_cmul, cmul);
+
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_clamp, clamp);
+MXNET_REGISTER_TORCH_BINARY_FUN_WITH_ARG(_th_cpow, cpow);
+MXNET_REGISTER_TORCH_TENARY_FUN(_th_addcmul, addcmul);
+
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_div_scalar, div)
+.add_argument("value", "float", "Divide all elements in x by value");
+MXNET_REGISTER_TORCH_BINARY_FUN_WITH_ARG(_th_cdiv, cdiv);
+MXNET_REGISTER_TORCH_TENARY_FUN(_th_addcdiv, addcdiv);
+
+MXNET_REGISTER_TORCH_TENARY_FUN(_th_addmv, addmv);
+MXNET_REGISTER_TORCH_TENARY_FUN(_th_addr, addr);
+MXNET_REGISTER_TORCH_TENARY_FUN(_th_addmm, addmm);
+MXNET_REGISTER_TORCH_TENARY_FUN(_th_addbmm, addbmm);
+MXNET_REGISTER_TORCH_TENARY_FUN(_th_baddbmm, baddbmm);
+
+struct TorchMMShape {
+  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+    const std::map<std::string, std::string>& param) {
+    CHECK_EQ(u[0]->shape().ndim(), 2);
+    CHECK_EQ(u[1]->shape().ndim(), 2);
+    CHECK_EQ(u[0]->shape()[1], u[1]->shape()[0]);
+    index_t shape[] = {u[0]->shape()[0], u[1]->shape()[1]};
+    mshadow::TShape tshape(shape, shape+2);
+    return {tshape};
+  }
+  static constexpr const char* fname = "mm";
+  static const int num_inputs = 2;
+  static const int num_outputs = 1;
+};
+MXNET_REGISTER_TORCH_FUN(_th_mm, TorchMMShape);
+
+struct TorchMVShape {
+  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+    const std::map<std::string, std::string>& param) {
+    CHECK_EQ(u[0]->shape().ndim(), 2);
+    CHECK_EQ(u[1]->shape().ndim(), 1);
+    CHECK_EQ(u[0]->shape()[1], u[1]->shape()[0]);
+    index_t shape[] = {u[0]->shape()[0]};
+    mshadow::TShape tshape(shape, shape+1);
+    return {tshape};
+  }
+  static constexpr const char* fname = "mv";
+  static const int num_inputs = 2;
+  static const int num_outputs = 1;
+};
+MXNET_REGISTER_TORCH_FUN(_th_mv, TorchMVShape);
+
+
+struct TorchBMMShape {
+  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+    const std::map<std::string, std::string>& param) {
+    CHECK_EQ(u[0]->shape().ndim(), 3);
+    CHECK_EQ(u[1]->shape().ndim(), 3);
+    CHECK_EQ(u[0]->shape()[0], u[1]->shape()[0]);
+    CHECK_EQ(u[0]->shape()[2], u[1]->shape()[1]);
+    index_t shape[] = {u[0]->shape()[1], u[1]->shape()[2]};
+    mshadow::TShape tshape(shape, shape+2);
+    return {tshape};
+  }
+  static constexpr const char* fname = "bmm";
+  static const int num_inputs = 2;
+  static const int num_outputs = 1;
+};
+MXNET_REGISTER_TORCH_FUN(_th_bmm, TorchBMMShape);
+
+struct TorchGERShape {
+  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+    const std::map<std::string, std::string>& param) {
+    CHECK_EQ(u[0]->shape().ndim(), 1);
+    CHECK_EQ(u[1]->shape().ndim(), 1);
+    index_t shape[] = {u[0]->shape()[0], u[1]->shape()[0]};
+    mshadow::TShape tshape(shape, shape+2);
+    return {tshape};
+  }
+  static constexpr const char* fname = "ger";
+  static const int num_inputs = 2;
+  static const int num_outputs = 1;
+};
+MXNET_REGISTER_TORCH_FUN(_th_ger, TorchGERShape);
 
 }  // namespace mxnet

--- a/plugin/torch/torch_function.cc
+++ b/plugin/torch/torch_function.cc
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file torch_base.cc
+ * \brief torch_state
+ * \author Junyuan Xie
+*/
+#include "./torch_function.h"
+
+namespace mxnet {
+
+// Element-wise Mathematical Operations
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_abs, abs);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_sign, sign);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_acos, acos);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_asin, asin);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_atan, atan);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_ceil, ceil);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_cos, cos);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_cosh, cosh);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_exp, exp);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_floor, floor);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_log, log);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_log1p, log1p);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_pow, pow);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_round, round);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_sin, sin);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_sinh, sinh);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_sqrt, sqrt);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_tan, tan);
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_tanh, tanh);
+
+// Basic operations
+MXNET_REGISTER_TORCH_UNARY_FUN(_th_add_scalar, add);
+
+
+}  // namespace mxnet

--- a/plugin/torch/torch_function.h
+++ b/plugin/torch/torch_function.h
@@ -1,0 +1,164 @@
+/*!
+ *  Copyright (c) 2015 by Contributors
+ * \file torch_function.h
+ * \brief Torch interface.
+ * \author Junyuan Xie
+ */
+#ifndef PLUGIN_TORCH_TORCH_FUNCTION_H_
+#define PLUGIN_TORCH_TORCH_FUNCTION_H_
+#include "./torch_base.h"
+#include <mxnet/base.h>
+#include <mxnet/ndarray.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <map>
+#include <algorithm>
+#include <vector>
+
+namespace mxnet {
+
+template<typename xpu, typename OP>
+void TorchRunOp(std::vector<NDArray> arr_in,
+                std::vector<NDArray> arr_out,
+                const std::map<std::string, std::string>& param,
+                RunContext ctx) {
+  lua_State* L = TorchState::LuaState();
+  TorchState::SetStream(ctx.get_stream<xpu>());
+  lua_getglobal(L, "torch");
+  lua_getfield(L, -1, OP::fname);
+  int idx = 0;
+  std::vector<NDArray> arr(arr_out.begin(), arr_out.end());
+  arr.insert(arr.end(), arr_in.begin(), arr_in.end());
+  std::string format = param.at("format");
+  std::istringstream args(param.at("args"));
+  for (size_t i = 0; i < format.size(); ++i) {
+    std::string val;
+    std::getline(args, val, ',');
+    switch (format[i]) {
+      case 'n': {
+        CHECK(idx < arr.size()) << "Too few NDArray arguments for Torch." << OP::fname;
+        luaT_pushudata(L,
+                       TorchTensor::TBlobToTHTensor(arr[idx].data()),
+                       TorchTensor::TensorType(arr[idx].data()));
+        idx++;
+        break;
+      }
+      case 'i':
+        lua_pushinteger(L, std::stoi(val));
+        break;
+      case 'f':
+        lua_pushnumber(L, std::stof(val));
+        break;
+      case 's':
+        lua_pushstring(L, val.c_str());
+        break;
+      case 'b':
+        lua_pushboolean(L, std::stoi(val));
+        break;
+      default:
+        LOG(FATAL) << "Unknown argument type " << format[i] << " for Torch." << OP::fname;
+    }
+  }
+  CHECK_EQ(lua_pcall(L, format.size(), 0, 0), 0) << "Lua Error: " << lua_tostring(L, -1);
+}
+
+template<typename OP>
+void TorchOp(NDArray **u, real_t *s, NDArray **out,
+             const std::map<std::string, std::string>& param) {
+  std::vector<mshadow::TShape> shapes = OP::GetShape(u, param);
+  CHECK_EQ(shapes.size(), OP::num_outputs)
+    << "Too many output shapes for TorchOp " << OP::fname;
+  Context ctx;
+  int type_flag;
+  if (OP::num_inputs) {
+    ctx = u[0]->ctx();
+    type_flag = u[0]->dtype();
+    for (int i = 0; i < OP::num_inputs; ++i) {
+      CHECK_EQ(ctx, u[i]->ctx()) << "Context of all oprands must be the same.";
+      CHECK_EQ(type_flag, u[i]->dtype()) << "Data type of all oprands must be the same.";
+    }
+  } else {
+    CHECK(param.count("ctx")) << "Must provide keyword argument ctx for TorchOp with 0 inputs";
+    std::istringstream str_ctx(param.at("ctx"));
+    std::string dev;
+    int id;
+    char tmp;
+    str_ctx >> dev >> tmp >> id >> tmp;
+    if (dev == "cpu") {
+      ctx = Context::Create(Context::kCPU, id);
+    } else if (dev == "gpu") {
+      ctx = Context::Create(Context::kGPU, id);
+    } else {
+      LOG(FATAL) << "Unknown device type " << dev;
+    }
+
+    if (param.count("dtype")) {
+      std::stringstream str_dtype(param.at("dtype"));
+      str_dtype >> type_flag;
+    } else {
+      type_flag = mshadow::default_type_flag;
+    }
+  }
+  std::vector<NDArray> arr_in, arr_out;
+  std::vector<Engine::VarHandle> var_in, var_out, var_const;
+  for (int i = 0; i < OP::num_inputs; ++i) {
+    arr_in.push_back(*(u[i]));
+    var_in.push_back(u[i]->var());
+  }
+  for (int i = 0; i < OP::num_outputs; ++i) {
+    if (out[i]->is_none()) {
+      *(out[i]) = NDArray(shapes[i], ctx, false, type_flag);
+    }
+    arr_out.push_back(*(out[i]));
+    var_out.push_back(out[i]->var());
+  }
+  std::sort(var_in.begin(), var_in.end());
+  var_in.resize(std::unique(var_in.begin(), var_in.end()) - var_in.begin());
+  std::sort(var_out.begin(), var_out.end());
+  var_out.resize(std::unique(var_out.begin(), var_out.end()) - var_out.begin());
+  std::set_difference(var_in.begin(), var_in.end(), var_out.begin(), var_out.end(),
+                      std::inserter(var_const, var_const.begin()));
+  switch (ctx.dev_mask()) {
+    case mshadow::cpu::kDevMask: {
+      Engine::Get()->PushSync([arr_in, arr_out, param](RunContext rctx) {
+        TorchRunOp<mshadow::cpu, OP>(arr_in, arr_out, param, rctx);
+      }, ctx, var_const, var_out);
+      break;
+    }
+#if MXNET_USE_CUDA
+    case gpu::kDevMask: {
+      Engine::Get()->PushSync([arr_in, arr_out, param](RunContext rctx) {
+        TorchRunOp<mshadow::gpu, OP>(arr_in, arr_out, param, rctx);
+      }, ctx, var_const, var_out);
+      break;
+    }
+#endif
+    default: LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+  }
+}
+
+struct TorchUnaryOpDesc {
+  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+    const std::map<std::string, std::string>& param) {
+    return {u[0]->shape()};
+  }
+  static const int num_inputs = 1;
+  static const int num_outputs = 1;
+};
+
+#define MXNET_REGISTER_TORCH_FUN(name, OP)                \
+  MXNET_REGISTER_NDARRAY_FUN(name)                        \
+  .set_function(TorchOp<OP>)                              \
+  .set_num_use_vars(OP::num_inputs)                       \
+  .set_num_mutate_vars(OP::num_outputs)                   \
+  .set_type_mask(kAcceptEmptyMutateTarget)
+
+#define MXNET_REGISTER_TORCH_UNARY_FUN(name, func)                            \
+  struct TorchUnaryOpDesc_ ## name ## _ ## func : public TorchUnaryOpDesc {   \
+    static constexpr const char* fname = #func;                               \
+  };                                                                          \
+  MXNET_REGISTER_TORCH_FUN(name, TorchUnaryOpDesc_ ## name ## _ ## func);
+
+}  // namespace mxnet
+#endif  // PLUGIN_TORCH_TORCH_FUNCTION_H_

--- a/plugin/torch/torch_module-inl.h
+++ b/plugin/torch/torch_module-inl.h
@@ -1,0 +1,395 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file torch_module-inl.h
+ * \brief torch module operator
+ * \author Min Lin
+*/
+#ifndef PLUGIN_TORCH_TORCH_MODULE_INL_H_
+#define PLUGIN_TORCH_TORCH_MODULE_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <stdio.h>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+#include <utility>
+#include "../../src/operator/operator_common.h"
+#include "./torch_base.h"
+
+namespace mxnet {
+namespace op {
+struct TorchModuleParam : public dmlc::Parameter<TorchModuleParam> {
+  std::string lua_string;
+  uint32_t num_data;
+  uint32_t num_params;
+  uint32_t num_outputs;
+  DMLC_DECLARE_PARAMETER(TorchModuleParam) {
+    DMLC_DECLARE_FIELD(lua_string)
+    .describe("lua string that is called to generate the object");
+    DMLC_DECLARE_FIELD(num_data)
+    .describe("the number of input data");
+    DMLC_DECLARE_FIELD(num_params)
+    .describe("the number of parameters");
+    DMLC_DECLARE_FIELD(num_outputs)
+    .describe("the number of outputs");
+  }
+};
+
+/**
+ * \brief This is the implementation of activation operator.
+ * \tparam xpu The device that the op will be executed on.
+ */
+template<typename xpu>
+class TorchModuleOp : public Operator {
+ private:
+  TorchModuleParam param_;
+
+ protected:
+  THCharStorage* chunk_;
+
+ public:
+  explicit TorchModuleOp(TorchModuleParam p) : chunk_(NULL) {
+    this->param_ = p;
+    lua_State* L = TorchState::LuaState();
+    CHECK_EQ(lua_gettop(L), 0);
+    std::string exec = std::string("return ") + p.lua_string
+      + TorchTensor::ModuleType(xpu::kDevMask);
+    CHECK_EQ(luaL_loadstring(L, exec.c_str()), 0);
+    int err = lua_pcall(L, 0, 1, 0);
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    // Get number of parameters
+    uint32_t param_num = 0;
+    lua_getfield(L, -1, "parameters");
+    lua_pushvalue(L, -2);
+    CHECK_EQ(lua_pcall(L, 1, LUA_MULTRET, 0), 0);
+    if (lua_gettop(L) == 1) {
+      param_num = 0;
+    } else {
+      CHECK_EQ(lua_gettop(L), 3);
+      param_num = lua_objlen(L, -2);
+      lua_pop(L, 2);
+    }
+    CHECK_EQ(param_num, param_.num_params);
+    // serialize
+    TorchState::Serialize(&chunk_);
+  }
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    lua_State* L = TorchState::LuaState();
+    CHECK_EQ(lua_gettop(L), 0);
+    CHECK_EQ(in_data.size(), param_.num_params + param_.num_data);
+    CHECK_EQ(out_data.size(), param_.num_outputs);
+    mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+    TorchState::SetStream(s);
+    // Deserialize self table
+    TorchState::Deserialize(chunk_);
+    TorchTensor::TBlobVectorAsTable(out_data.begin(), out_data.begin() + param_.num_outputs);
+    // set the output field
+    lua_setfield(L, -2, "output");
+    // set the parameters
+    if (param_.num_params != 0) {
+      // get the parameters into the stack
+      lua_getfield(L, -1, "parameters");
+      lua_pushvalue(L, -2);
+      int err = lua_pcall(L, 1, 1, 0);
+      CHECK_EQ(err, 0);
+      // iterate the parameters table to put tblobs inside
+      lua_pushnil(L);
+      std::vector<TBlob>::const_iterator it = in_data.begin() + param_.num_data;
+      while (lua_next(L, -2)) {
+        CHECK(luaT_isudata(L, -1, TorchTensor::TensorType(*it)));
+        void* udata = luaT_toudata(L, -1, TorchTensor::TensorType(*it));
+        TorchTensor::SetInternal(static_cast<THGeneralTensor>(udata), *(it));
+        it++;
+        lua_pop(L, 1);
+      }
+      lua_pop(L, 1);  // pop the parameter table
+    }
+    // call updateOutput
+    // | self
+    lua_getfield(L, -1, "updateOutput");
+    // | self | updateOutput
+    lua_pushvalue(L, -2);
+    // | self | updateOutput | self
+    TorchTensor::TBlobVectorAsTable(in_data.begin(), in_data.begin() + param_.num_data);
+    // | self | updateOutput | self | inputs
+    int err = lua_pcall(L, 2, 0, 0);  // doesn't need the output
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    TorchState::Serialize(&chunk_);
+    CHECK_EQ(lua_gettop(L), 0);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    lua_State* L = TorchState::LuaState();
+    CHECK_EQ(lua_gettop(L), 0);
+    CHECK_EQ(in_data.size(), param_.num_params + param_.num_data);
+    CHECK_EQ(out_data.size(), param_.num_outputs);
+    CHECK_EQ(out_grad.size(), param_.num_outputs);
+    CHECK_EQ(in_grad.size(), param_.num_params + param_.num_data);
+    mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+    TorchState::SetStream(s);
+    TorchState::Deserialize(chunk_);
+    TorchTensor::TBlobVectorAsTable(out_data.begin(), out_data.end());
+    lua_setfield(L, -2, "output");
+    TorchTensor::TBlobVectorAsTable(in_grad.begin(), in_grad.begin() + param_.num_data);
+    lua_setfield(L, -2, "gradInput");
+    if (param_.num_params != 0) {
+      // get the parameters into the stack
+      lua_getfield(L, -1, "parameters");
+      lua_pushvalue(L, -2);
+      int err = lua_pcall(L, 1, LUA_MULTRET, 0);
+      CHECK_EQ(err, 0) << lua_tostring(L, -1);
+      // iterate the parameters table to put tblobs inside
+      lua_pushnil(L);
+      std::vector<TBlob>::const_iterator it = in_data.begin() + param_.num_data;
+      while (lua_next(L, -3)) {
+        TorchTensor::SetInternal(
+          static_cast<THGeneralTensor>(luaT_toudata(L, -1, TorchTensor::TensorType(*it))),
+          *it);
+        it++;
+        lua_pop(L, 1);
+      }
+      // iterate the grad of params
+      lua_pushnil(L);
+      it = in_grad.begin() + param_.num_data;;
+      while (lua_next(L, -2)) {
+        TorchTensor::SetInternal(
+          static_cast<THGeneralTensor>(luaT_toudata(L, -1, TorchTensor::TensorType(*it))),
+          *it);
+        it++;
+        lua_pop(L, 1);
+      }
+      lua_pop(L, 2);  // pop the parameters
+    }
+    lua_getfield(L, -1, "zeroGradParameters");
+    lua_pushvalue(L, -2);
+    CHECK_EQ(lua_pcall(L, 1, 0, 0), 0);
+    TorchTensor::TBlobVectorAsTable(in_data.begin(), in_data.begin() + param_.num_data);
+    TorchTensor::TBlobVectorAsTable(out_grad.begin(), out_grad.end());
+    // call
+    lua_getfield(L, -3, "accGradParameters");
+    lua_pushvalue(L, -4);
+    lua_pushvalue(L, -4);
+    lua_pushvalue(L, -4);
+    lua_pushnumber(L, 1);
+    int err = lua_pcall(L, 4, 0, 0);  // doesn't need the output
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    lua_getfield(L, -3, "updateGradInput");
+    lua_pushvalue(L, -4);
+    lua_pushvalue(L, -4);
+    lua_pushvalue(L, -4);
+    err = lua_pcall(L, 3, 0, 0);  // doesn't need the output
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    lua_pop(L, 2);
+    TorchState::Serialize(&chunk_);
+    CHECK_EQ(lua_gettop(L), 0);
+  }
+};  // class TorchModuleOp
+
+// Decalre Factory function, used for dispatch specialization
+template<typename xpu>
+Operator* CreateOp(TorchModuleParam type);
+
+#if DMLC_USE_CXX11
+class TorchModuleProp : public OperatorProperty {
+ protected:
+  mutable THCharStorage* chunk_;
+  void InitChunk_() const {
+    lua_State* L = TorchState::LuaState();
+    std::string exec = std::string("return ") + param_.lua_string;
+    CHECK_EQ(luaL_loadstring(L, exec.c_str()), 0);
+    int err = lua_pcall(L, 0, LUA_MULTRET, 0);
+    CHECK_EQ(lua_gettop(L), 1);
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    lua_getfield(L, -1, "float");
+    lua_pushvalue(L, -2);
+    err = lua_pcall(L, 1, 1, 0);
+    CHECK_EQ(err, 0);
+    TorchState::Serialize(&chunk_);
+    lua_pop(L, 1);
+    CHECK_EQ(lua_gettop(L), 0);
+  }
+
+ public:
+  std::vector<std::string> ListArguments() const override {
+    std::vector<std::string> ret;
+    if (!chunk_) {
+      InitChunk_();
+    }
+    std::string data = "data";
+    for (uint32_t i = 0; i < param_.num_data; ++i) {
+      ret.push_back(data + "_" + std::to_string(i));
+    }
+    std::string lua_code =
+        "return function(module)\n"
+        "          local params = module:parameters()\n"
+        "          local dict = {}\n"
+        "          if params == nil then\n"
+        "             return {}\n"
+        "          end\n"
+        "          for id, p in ipairs(params) do\n"
+        "             dict[p] = string.format('param_%d', id)\n"
+        "          end\n"
+        "          for key, value in pairs(module) do\n"
+        "             if dict[value] then\n"
+        "                dict[value] = key\n"
+        "             end\n"
+        "          end\n"
+        "          local ret = {}\n"
+        "          for _, p in ipairs(params) do\n"
+        "             table.insert(ret, dict[p])\n"
+        "          end\n"
+        "          return ret\n"
+        "end\n";
+    lua_State* L = TorchState::LuaState();
+    luaL_loadstring(L, lua_code.c_str());
+    int err = lua_pcall(L, 0, 1, 0);  // return the function
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    TorchState::Deserialize(chunk_);
+    err = lua_pcall(L, 1, 1, 0);  // call the function
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    lua_pushnil(L);
+    while (lua_next(L, -2)) {
+      ret.push_back(lua_tostring(L, -1));
+      lua_pop(L, 1);
+    }
+    lua_pop(L, 1);
+    return ret;
+  }
+
+  virtual std::vector<std::string> ListOutputs() const {
+    std::vector<std::string> ret;
+    std::string output = "output";
+    for (uint32_t i = 0; i < param_.num_outputs; ++i) {
+      ret.push_back(output + "_" + std::to_string(i));
+    }
+    return ret;
+  }
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    if (chunk_ == nullptr) {
+      this->InitChunk_();
+    }
+    lua_State* L = TorchState::LuaState();
+    CHECK_EQ(lua_gettop(L), 0);
+    TorchState::Deserialize(chunk_);
+    CHECK_EQ(in_shape->size(), param_.num_data + param_.num_params);
+    CHECK_EQ(out_shape->size(), param_.num_outputs);
+    CHECK_EQ(aux_shape->size(), 0);
+    lua_getfield(L, -1, "updateOutput");
+    lua_pushvalue(L, -2);  // self
+    if (param_.num_data == 1) {
+      THLongStorage* thshape = THLongStorage_newWithSize((*in_shape)[0].ndim());
+      for (uint32_t i = 0; i < (*in_shape)[0].ndim(); ++i) {
+        THLongStorage_set(thshape, i, (*in_shape)[0][i]);
+      }
+      THFloatTensor* in_data = THFloatTensor_newWithSize(thshape, NULL);
+      THLongStorage_free(thshape);
+      luaT_pushudata(L, in_data, TorchTensor::TensorType(mshadow::cpu::kDevMask));
+    } else if (param_.num_data > 1) {
+      lua_createtable(L, param_.num_data, 0);
+      for (uint32_t data_index = 0; data_index < param_.num_data; ++data_index) {
+        THLongStorage* thshape = THLongStorage_newWithSize((*in_shape)[data_index].ndim());
+        for (uint32_t i = 0; i < (*in_shape)[data_index].ndim(); ++i) {
+          THLongStorage_set(thshape, i, (*in_shape)[data_index][i]);
+        }
+        THFloatTensor* in_data = THFloatTensor_newWithSize(thshape, NULL);
+        THLongStorage_free(thshape);
+        luaT_pushudata(L, in_data, TorchTensor::TensorType(mshadow::cpu::kDevMask));
+        lua_rawseti(L, -2, data_index);
+      }
+    }
+    int err = lua_pcall(L, 2, 0, 0);
+    CHECK_EQ(err, 0) << lua_tostring(L, -1);
+    if (param_.num_params != 0) {
+      lua_getfield(L, -1, "parameters");
+      lua_pushvalue(L, -2);
+      int err = lua_pcall(L, 1, LUA_MULTRET, 0);
+      CHECK_EQ(err, 0);
+      CHECK_EQ(lua_gettop(L), 3);
+      lua_pushnil(L);
+      int index = param_.num_data;
+      while (lua_next(L, -3)) {
+        THFloatTensor* param = reinterpret_cast<THFloatTensor*>(luaT_toudata(L, -1,
+          TorchTensor::TensorType(mshadow::cpu::kDevMask)));
+        size_t* size = param->size;
+        (*in_shape)[index++] = TShape(size, size + THFloatTensor_nDimension(param));
+        lua_pop(L, 1);
+      }
+      lua_pop(L, 2);
+    }
+    lua_getfield(L, -1, "output");
+    if (param_.num_outputs == 0) {
+    } else if (param_.num_outputs == 1) {
+      THFloatTensor* output = reinterpret_cast<THFloatTensor*>(luaT_toudata(L, -1,
+        TorchTensor::TensorType(mshadow::cpu::kDevMask)));
+      size_t* size = output->size;
+      (*out_shape)[0] = TShape(size, size + THFloatTensor_nDimension(output));
+    } else {
+      for (uint32_t data_index = 0; data_index < param_.num_outputs; ++data_index) {
+        lua_pushnil(L);
+        int index = 0;
+        while (lua_next(L, -2)) {
+          THFloatTensor* out = reinterpret_cast<THFloatTensor*>(luaT_toudata(L, -1,
+            TorchTensor::TensorType(mshadow::cpu::kDevMask)));
+          size_t* size = out->size;
+          (*out_shape)[index++] = TShape(size, size + THFloatTensor_nDimension(out));
+        }
+      }
+    }
+    lua_pop(L, 2);
+    CHECK_EQ(lua_gettop(L), 0);
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new TorchModuleProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "TorchModule";
+  }
+
+  // decalre dependency and inplace optimization options
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    std::vector<int> dep;
+    dep.insert(dep.end(), out_grad.begin(), out_grad.end());
+    dep.insert(dep.end(), out_data.begin(), out_data.end());
+    dep.insert(dep.end(), in_data.begin(), in_data.end());
+    return dep;
+  }
+
+  Operator* CreateOperator(Context ctx) const override;
+
+ private:
+  TorchModuleParam param_;
+};
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+#endif  // PLUGIN_TORCH_TORCH_MODULE_INL_H_

--- a/plugin/torch/torch_module-inl.h
+++ b/plugin/torch/torch_module-inl.h
@@ -332,7 +332,7 @@ class TorchModuleProp : public OperatorProperty {
       while (lua_next(L, -3)) {
         THFloatTensor* param = reinterpret_cast<THFloatTensor*>(luaT_toudata(L, -1,
           TorchTensor::TensorType(mshadow::cpu::kDevMask)));
-        size_t* size = param->size;
+        long int* size = param->size;  // NOLINT(*)
         (*in_shape)[index++] = TShape(size, size + THFloatTensor_nDimension(param));
         lua_pop(L, 1);
       }
@@ -343,7 +343,7 @@ class TorchModuleProp : public OperatorProperty {
     } else if (param_.num_outputs == 1) {
       THFloatTensor* output = reinterpret_cast<THFloatTensor*>(luaT_toudata(L, -1,
         TorchTensor::TensorType(mshadow::cpu::kDevMask)));
-      size_t* size = output->size;
+      long int* size = output->size;  // NOLINT(*)
       (*out_shape)[0] = TShape(size, size + THFloatTensor_nDimension(output));
     } else {
       for (uint32_t data_index = 0; data_index < param_.num_outputs; ++data_index) {
@@ -352,7 +352,7 @@ class TorchModuleProp : public OperatorProperty {
         while (lua_next(L, -2)) {
           THFloatTensor* out = reinterpret_cast<THFloatTensor*>(luaT_toudata(L, -1,
             TorchTensor::TensorType(mshadow::cpu::kDevMask)));
-          size_t* size = out->size;
+          long int* size = out->size;  // NOLINT(*)
           (*out_shape)[index++] = TShape(size, size + THFloatTensor_nDimension(out));
         }
       }

--- a/plugin/torch/torch_module-inl.h
+++ b/plugin/torch/torch_module-inl.h
@@ -28,7 +28,7 @@ struct TorchModuleParam : public dmlc::Parameter<TorchModuleParam> {
   uint32_t num_outputs;
   DMLC_DECLARE_PARAMETER(TorchModuleParam) {
     DMLC_DECLARE_FIELD(lua_string)
-    .describe("lua string that is called to generate the object");
+    .describe("lua string that is called to generate the torch module object");
     DMLC_DECLARE_FIELD(num_data)
     .describe("the number of input data");
     DMLC_DECLARE_FIELD(num_params)
@@ -73,6 +73,23 @@ class TorchModuleOp : public Operator {
       lua_pop(L, 2);
     }
     CHECK_EQ(param_num, param_.num_params);
+    // // Free the parameters allocated by torch so it doesn't take up memory.
+    // if (param_.num_params != 0) {
+    //   // get the parameters into the stack
+    //   lua_getfield(L, -1, "parameters");
+    //   lua_pushvalue(L, -2);
+    //   int err = lua_pcall(L, 1, 1, 0);
+    //   CHECK_EQ(err, 0);
+    //   // iterate the parameters table to put tblobs inside
+    //   lua_pushnil(L);
+    //   while (lua_next(L, -2)) {
+    //     CHECK(luaT_isudata(L, -1, TorchTensor::TensorType(xpu::kDevMask)));
+    //     void* udata = luaT_toudata(L, -1, TorchTensor::TensorType(xpu::kDevMask));
+    //     TorchTensor::FreeInternal(static_cast<THGeneralTensor>(udata), xpu::kDevMask);
+    //     lua_pop(L, 1);
+    //   }
+    //   lua_pop(L, 1);  // pop the parameter table
+    // }
     // serialize
     TorchState::Serialize(&chunk_);
   }

--- a/plugin/torch/torch_module.cc
+++ b/plugin/torch/torch_module.cc
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file activation.cc
+ * \brief activation op
+ * \author Bing Xu
+*/
+#include "./torch_module-inl.h"
+#include "../../src/operator/mshadow_op.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<cpu>(TorchModuleParam param) {
+  return new TorchModuleOp<cpu>(param);
+}
+
+// DO_BIND_DISPATCH comes from operator_common.h
+Operator *TorchModuleProp::CreateOperator(Context ctx) const {
+  DO_BIND_DISPATCH(CreateOp, param_);
+}
+
+DMLC_REGISTER_PARAMETER(TorchModuleParam);
+
+MXNET_REGISTER_OP_PROPERTY(TorchModule, TorchModuleProp)
+.describe("Modules from torch.")
+.add_arguments(TorchModuleParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/plugin/torch/torch_module.cu
+++ b/plugin/torch/torch_module.cu
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file activation.cc
+ * \brief activation op
+ * \author Bing Xu
+*/
+#include "./torch_module-inl.h"
+#include "../../src/operator/mshadow_op.h"
+extern "C" {
+#include "THCTensor.h"
+}
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<gpu>(TorchModuleParam param) {
+  return new TorchModuleOp<gpu>(param);
+}
+
+}  // namespace op
+}  // namespace mxnet

--- a/python/mxnet/__init__.py
+++ b/python/mxnet/__init__.py
@@ -41,4 +41,7 @@ from .attribute import AttrScope
 from . import monitor
 from . import monitor as mon
 
+from . import torch
+from . import torch as th
+
 __version__ = base.__version__

--- a/python/mxnet/executor.py
+++ b/python/mxnet/executor.py
@@ -353,7 +353,7 @@ class DataParallelExecutorManager(object):
         self.train_execs = []
         for i in range(len(ctx)):
             data_shapes = {k: tuple([slices[i].stop-slices[i].start] + list(v[1:]))
-                           for k, v in train_data.provide_data}
+                           for k, v in train_data.provide_data + train_data.provide_label}
             train_exec = symbol.simple_bind(ctx[i], 'write', **data_shapes)
             self.train_execs.append(train_exec)
 

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -83,6 +83,17 @@ class RMSE(EvalMetric):
             self.sum_metric += numpy.sqrt(numpy.mean((label.asnumpy() - pred.asnumpy())**2))
         self.num_inst += 1
 
+class Torch(EvalMetric):
+    """Dummy metric for torch criterions"""
+    def __init__(self):
+        super(Torch, self).__init__('torch')
+
+    def update(self, labels, preds):
+        self.reset()
+        for p in preds:
+            self.sum_metric += p.asnumpy().mean()
+        self.num_inst += 1
+
 class CustomMetric(EvalMetric):
     """Custom evaluation metric that takes a NDArray function.
 

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -88,10 +88,9 @@ class Torch(EvalMetric):
     def __init__(self):
         super(Torch, self).__init__('torch')
 
-    def update(self, labels, preds):
-        self.reset()
-        for p in preds:
-            self.sum_metric += p.asnumpy().mean()
+    def update(self, _, preds):
+        for pred in preds:
+            self.sum_metric += pred.asnumpy().mean()
         self.num_inst += 1
 
 class CustomMetric(EvalMetric):

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -680,7 +680,10 @@ def _make_ndarray_function(handle):
         check_call(_LIB.MXFuncInvoke(handle,
                                      c_array(NDArrayHandle, (lhs.handle, rhs.handle)),
                                      c_array(mx_float, ()),
-                                     c_array(NDArrayHandle, (out.handle,))))
+                                     c_array(NDArrayHandle, (out.handle,)),
+                                     ctypes.c_int(0),
+                                     c_array(ctypes.c_char_p, []),
+                                     c_array(ctypes.c_char_p, [])))
         return out
 
     def unary_ndarray_function(src, out=None):
@@ -698,7 +701,10 @@ def _make_ndarray_function(handle):
                 handle, \
                 c_array(NDArrayHandle, (src.handle,)), \
                 c_array(mx_float, ()), \
-                c_array(NDArrayHandle, (out.handle,))))
+                c_array(NDArrayHandle, (out.handle,)), \
+                ctypes.c_int(0), \
+                c_array(ctypes.c_char_p, []), \
+                c_array(ctypes.c_char_p, [])))
         return out
 
     def generic_ndarray_function(*args, **kwargs):
@@ -732,7 +738,10 @@ def _make_ndarray_function(handle):
                 handle, \
                 c_array(NDArrayHandle, [args[i].handle for i in use_vars_range]), \
                 c_array(mx_float, [args[i] for i in scalar_range]), \
-                c_array(NDArrayHandle, [v.handle for v in mutate_vars])))
+                c_array(NDArrayHandle, [v.handle for v in mutate_vars]), \
+                ctypes.c_int(0), \
+                c_array(ctypes.c_char_p, []), \
+                c_array(ctypes.c_char_p, [])))
         if n_mutate_vars == 1:
             return mutate_vars[0]
         else:

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -677,13 +677,13 @@ def _make_ndarray_function(handle):
             if not accept_empty_mutate:
                 raise TypeError('argument out is required to call %s' % func_name)
             out = NDArray(_new_empty_handle())
-        check_call(_LIB.MXFuncInvoke(handle,
-                                     c_array(NDArrayHandle, (lhs.handle, rhs.handle)),
-                                     c_array(mx_float, ()),
-                                     c_array(NDArrayHandle, (out.handle,)),
-                                     ctypes.c_int(0),
-                                     c_array(ctypes.c_char_p, []),
-                                     c_array(ctypes.c_char_p, [])))
+        check_call(_LIB.MXFuncInvokeEx(handle,
+                                       c_array(NDArrayHandle, (lhs.handle, rhs.handle)),
+                                       c_array(mx_float, ()),
+                                       c_array(NDArrayHandle, (out.handle,)),
+                                       ctypes.c_int(0),
+                                       c_array(ctypes.c_char_p, []),
+                                       c_array(ctypes.c_char_p, [])))
         return out
 
     def unary_ndarray_function(src, out=None):
@@ -697,7 +697,7 @@ def _make_ndarray_function(handle):
             if not accept_empty_mutate:
                 raise TypeError('argument out is required to call %s' % func_name)
             out = NDArray(_new_empty_handle())
-        check_call(_LIB.MXFuncInvoke( \
+        check_call(_LIB.MXFuncInvokeEx( \
                 handle, \
                 c_array(NDArrayHandle, (src.handle,)), \
                 c_array(mx_float, ()), \
@@ -734,7 +734,7 @@ def _make_ndarray_function(handle):
                     NDArray(_new_empty_handle()) for i in range(n_mutate_vars))
             else:
                 raise TypeError('argument out is required to call %s' % func_name)
-        check_call(_LIB.MXFuncInvoke( \
+        check_call(_LIB.MXFuncInvokeEx( \
                 handle, \
                 c_array(NDArrayHandle, [args[i].handle for i in use_vars_range]), \
                 c_array(mx_float, [args[i] for i in scalar_range]), \

--- a/python/mxnet/symbol.py
+++ b/python/mxnet/symbol.py
@@ -595,6 +595,10 @@ class Symbol(object):
             Input type dictionary, name->dtype
         kwargs : dict of str->shape
             Input shape dictionary, name->shape
+        type_dict  : dict of str->numpy.dtype
+            Input type dictionary, name->dtype
+        kwargs : dict of str->shape
+            Input shape dictionary, name->shape
 
         Returns
         -------

--- a/python/mxnet/torch.py
+++ b/python/mxnet/torch.py
@@ -1,0 +1,143 @@
+# coding: utf-8
+"""Interface for NDArray functions executed by torch backend.
+Install torch and Compile with USE_TORCH=1 to use this module"""
+from __future__ import absolute_import
+
+import ctypes
+import sys
+from .base import _LIB
+from .base import c_array, py_str
+from .base import mx_uint, mx_float, NDArrayHandle, FunctionHandle
+from .base import check_call
+from .ndarray import NDArray, _new_empty_handle
+
+# pylint: disable=too-many-locals, invalid-name
+def _make_torch_function(handle):
+    """Create a Torch function from the FunctionHandle."""
+    # Get the property of function
+    n_used_vars = mx_uint()
+    n_scalars = mx_uint()
+    n_mutate_vars = mx_uint()
+    type_mask = ctypes.c_int()
+    check_call(_LIB.MXFuncDescribe(
+        handle,
+        ctypes.byref(n_used_vars),
+        ctypes.byref(n_scalars),
+        ctypes.byref(n_mutate_vars),
+        ctypes.byref(type_mask)))
+    n_mutate_vars = n_mutate_vars.value
+    n_used_vars = n_used_vars.value
+    n_scalars = n_scalars.value
+    type_mask = type_mask.value
+
+    # Get the information from the function
+    name = ctypes.c_char_p()
+    desc = ctypes.c_char_p()
+    num_args = mx_uint()
+    arg_names = ctypes.POINTER(ctypes.c_char_p)()
+    arg_types = ctypes.POINTER(ctypes.c_char_p)()
+    arg_descs = ctypes.POINTER(ctypes.c_char_p)()
+
+    check_call(_LIB.MXFuncGetInfo(
+        handle, ctypes.byref(name), ctypes.byref(desc),
+        ctypes.byref(num_args),
+        ctypes.byref(arg_names),
+        ctypes.byref(arg_types),
+        ctypes.byref(arg_descs)))
+    func_name = py_str(name.value)
+    if not func_name.startswith('_th_'):
+        return None
+
+    doc_str = (('Interface for Torch function {name}.\n' +
+                'Invoke with\nres = mxnet.th.{name}(...)\nor\n'+
+                'mxnet.th.{name}(res, ...).\n\n' +
+                'detailed help can be found at ' +
+                'https://github.com/torch/torch7/blob/master/doc/maths.md\n').format(
+                    name=func_name[4:]))
+
+    def generic_torch_function(*args, **kwargs):
+        """Invoke this function by passing in parameters
+
+        Parameters
+        ----------
+        *args
+            Positional arguments of input scalars and NDArray
+
+        Returns
+        -------
+        out : NDArray
+            The result NDArray(tuple) of result of computation.
+        """
+        ndargs = []
+        arg_format = ''
+        value = ''
+        for arg in args:
+            if isinstance(arg, NDArray):
+                ndargs.append(arg)
+                arg_format += 'n'
+                value += ','
+            elif isinstance(arg, int):
+                arg_format += 'i'
+                value += str(arg) + ','
+            elif isinstance(arg, str):
+                arg_format += 's'
+                value += str(arg) + ','
+            elif isinstance(arg, float):
+                arg_format += 'f'
+                value += str(arg) + ','
+            elif isinstance(arg, bool):
+                arg_format += 'b'
+                value += str(arg) + ','
+        value = value[:-1]
+        if len(ndargs) == n_used_vars:
+            ndargs = [NDArray(_new_empty_handle()) for _ in range(n_mutate_vars)] + ndargs
+            arg_format = 'n'*n_mutate_vars + arg_format
+            value = ','*n_mutate_vars + value
+        elif len(ndargs) == n_mutate_vars + n_used_vars:
+            pass
+        else:
+            raise AssertionError(('Incorrect number of input NDArrays. ' +
+                                  'Need to be either %d (inputs) or %d ' +
+                                  '(output buffer) + %d (input)') %
+                                 (n_used_vars, n_mutate_vars, n_used_vars))
+
+        kwargs['format'] = arg_format
+        kwargs['args'] = value
+
+        check_call(_LIB.MXFuncInvoke( \
+                handle, \
+                c_array(NDArrayHandle, [x.handle for x in ndargs[n_mutate_vars:]]), \
+                c_array(mx_float, []), \
+                c_array(NDArrayHandle, [x.handle for x in ndargs[:n_mutate_vars]]),
+                ctypes.c_int(len(kwargs)),
+                c_array(ctypes.c_char_p, kwargs.keys()),
+                c_array(ctypes.c_char_p, kwargs.values()),))
+        if n_mutate_vars == 1:
+            return ndargs[0]
+        else:
+            return ndargs[:n_mutate_vars]
+    # End of function declaration
+    ret_function = generic_torch_function
+    ret_function.__name__ = func_name[4:]
+    ret_function.__doc__ = doc_str
+    return ret_function
+
+# pylint: enable=too-many-locals, invalid-name
+
+def _init_torch_module():
+    """List and add all the torch backed ndarray functions to current module."""
+    plist = ctypes.POINTER(FunctionHandle)()
+    size = ctypes.c_uint()
+    check_call(_LIB.MXListFunctions(ctypes.byref(size),
+                                    ctypes.byref(plist)))
+
+    module_obj = sys.modules[__name__]
+    for i in range(size.value):
+        hdl = FunctionHandle(plist[i])
+        function = _make_torch_function(hdl)
+        # if function name starts with underscore, register as static method of NDArray
+        if function is not None:
+            setattr(module_obj, function.__name__, function)
+
+# Initialize the NDArray module
+_init_torch_module()

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -383,12 +383,18 @@ int MXFuncDescribe(FunctionHandle fun,
 int MXFuncInvoke(FunctionHandle fun,
                  NDArrayHandle *use_vars,
                  mx_float *scalar_args,
-                 NDArrayHandle *mutate_vars) {
+                 NDArrayHandle *mutate_vars,
+                 int num_params,
+                 char **param_keys,
+                 char **param_vals) {
   API_BEGIN();
   auto *f = static_cast<const NDArrayFunctionReg*>(fun);
   f->body((NDArray**)(use_vars),  //  NOLINT(*)
           scalar_args,
-          (NDArray**)(mutate_vars));  //  NOLINT(*)
+          (NDArray**)(mutate_vars),  //  NOLINT(*)
+          num_params,
+          param_keys,
+          param_vals);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -383,6 +383,21 @@ int MXFuncDescribe(FunctionHandle fun,
 int MXFuncInvoke(FunctionHandle fun,
                  NDArrayHandle *use_vars,
                  mx_float *scalar_args,
+                 NDArrayHandle *mutate_vars) {
+  API_BEGIN();
+  auto *f = static_cast<const NDArrayFunctionReg*>(fun);
+  f->body((NDArray**)(use_vars),  //  NOLINT(*)
+          scalar_args,
+          (NDArray**)(mutate_vars),  //  NOLINT(*)
+          0,
+          NULL,
+          NULL);
+  API_END();
+}
+
+int MXFuncInvokeEx(FunctionHandle fun,
+                 NDArrayHandle *use_vars,
+                 mx_float *scalar_args,
                  NDArrayHandle *mutate_vars,
                  int num_params,
                  char **param_keys,

--- a/src/common/tblob_op_registry.cc
+++ b/src/common/tblob_op_registry.cc
@@ -272,7 +272,10 @@ void TBlobOpRegEntryImpl::RegisterUnary() {
   // The body to be registered
   auto body = [this] (NDArray **used_vars,
                       real_t *s,
-                      NDArray **mutate_vars) {
+                      NDArray **mutate_vars,
+                      int num_params,
+                      char **param_keys,
+                      char **param_vals) {
     NDArray src = *used_vars[0];
     NDArray *out = mutate_vars[0];
     TShape dshape = src.shape();

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -631,14 +631,16 @@ MXNET_REGISTER_NDARRAY_FUN(_copyto)
 
 // register random number generators
 MXNET_REGISTER_NDARRAY_FUN(_random_uniform)
-.set_body([](NDArray **u, real_t *s, NDArray **out) {
+.set_body([](NDArray **u, real_t *s, NDArray **out,
+             int num_params, char **param_keys, char **param_vals) {
     SampleUniform(s[0], s[1], out[0]);
   })
 .set_num_scalars(2)
 .set_num_mutate_vars(1);
 
 MXNET_REGISTER_NDARRAY_FUN(_random_gaussian)
-.set_body([](NDArray **u, real_t *s, NDArray **out) {
+.set_body([](NDArray **u, real_t *s, NDArray **out,
+             int num_params, char **param_keys, char **param_vals) {
     SampleGaussian(s[0], s[1], out[0]);
   })
 .set_num_scalars(2)
@@ -646,7 +648,8 @@ MXNET_REGISTER_NDARRAY_FUN(_random_gaussian)
 
 MXNET_REGISTER_NDARRAY_FUN(clip)
 .set_type_mask(kNDArrayArgBeforeScalar | kAcceptEmptyMutateTarget)
-.set_body([](NDArray **u, real_t *s, NDArray **out) {
+.set_body([](NDArray **u, real_t *s, NDArray **out,
+             int num_params, char **param_keys, char **param_vals) {
     ClipOp(*u[0], s[0], s[1], out[0]);
   })
 .set_num_use_vars(1)

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -33,6 +33,7 @@ def check_with_uniform(uf, arg_shapes, dim=None, npuf=None, rmin=-10, type_list=
             out2 = uf(*numpy_arg).astype(dtype)
         else:
             out2 = npuf(*numpy_arg).astype(dtype)
+            
         assert out1.shape == out2.shape
         if isinstance(out1, mx.nd.NDArray):
             out1 = out1.asnumpy()


### PR DESCRIPTION
this is currently working and can be tested with 
```Python
import ctypes
lualib = ctypes.CDLL("libluajit.so", mode=ctypes.RTLD_GLOBAL)
import mxnet as mx
import numpy as np
from mxnet.base import FunctionHandle, mx_uint, check_call, _LIB, py_str, c_array, NDArrayHandle, mx_float
# data = mx.symbol.Variable('data')
# f32data = mx.symbol.Cast(data=data, dtype='float32')
# fc1  = mx.symbol.FullyConnected(data = f32data, name='fc1', num_hidden=128)
# mlp  = mx.symbol.SoftmaxOutput(data = fc1, name = 'softmax')

# print mlp.infer_shape(data=(128,77))
# print mlp.infer_type(data=np.float16)

# exe = mlp.simple_bind(mx.gpu(0), 'write', {'data': np.float32}, data=(128,77))
# exe.forward(is_train=True)
# exe.backward()

# print exe.grad_arrays
# for arr in exe.grad_arrays:
#     if arr:
#         arr.wait_to_read()

plist = ctypes.POINTER(FunctionHandle)()
size = ctypes.c_uint()
check_call(_LIB.MXListFunctions(ctypes.byref(size),
                                ctypes.byref(plist)))
for i in range(size.value):
    hdl = FunctionHandle(plist[i])
    n_used_vars = mx_uint()
    n_scalars = mx_uint()
    n_mutate_vars = mx_uint()
    type_mask = ctypes.c_int()
    check_call(_LIB.MXFuncDescribe(
        hdl,
        ctypes.byref(n_used_vars),
        ctypes.byref(n_scalars),
        ctypes.byref(n_mutate_vars),
        ctypes.byref(type_mask)))
    n_mutate_vars = n_mutate_vars.value
    n_used_vars = n_used_vars.value
    n_scalars = n_scalars.value
    type_mask = type_mask.value

    name = ctypes.c_char_p()
    desc = ctypes.c_char_p()
    num_args = mx_uint()
    arg_names = ctypes.POINTER(ctypes.c_char_p)()
    arg_types = ctypes.POINTER(ctypes.c_char_p)()
    arg_descs = ctypes.POINTER(ctypes.c_char_p)()

    check_call(_LIB.MXFuncGetInfo(
        hdl, ctypes.byref(name), ctypes.byref(desc),
        ctypes.byref(num_args),
        ctypes.byref(arg_names),
        ctypes.byref(arg_types),
        ctypes.byref(arg_descs)))
    func_name = py_str(name.value)

    if func_name == '_torch_add':
        break
print func_name

x = mx.nd.zeros((10,10), ctx=mx.gpu(2))
x[:] = -3
x.wait_to_read()
print x.asnumpy()
check_call(_LIB.MXFuncInvoke( \
            hdl, \
            c_array(NDArrayHandle, [arg.handle for arg in [x]]), \
            c_array(mx_float, []), \
            c_array(NDArrayHandle, [v.handle for v in [x]]),
            ctypes.c_int(2),
            c_array(ctypes.c_char_p, ['format', 'args']),
            c_array(ctypes.c_char_p, ['nnf', ',,2']),
            ))

print x.asnumpy()
print x.context
```
Still need to work on python side interface.