### PR TITLE
Fix bug with train_mnist.py when data-dir is an S3 URI

### DIFF
--- a/example/image-classification/train_mnist.py
+++ b/example/image-classification/train_mnist.py
@@ -95,7 +95,7 @@ def get_iterator(args, kv):
     data_dir = args.data_dir
     if '://' not in args.data_dir:
         _download(args.data_dir)
-        flat = False if len(data_shape) == 3 else True
+    flat = False if len(data_shape) == 3 else True
 
     train           = mx.io.MNISTIter(
         image       = data_dir + "train-images-idx3-ubyte",


### PR DESCRIPTION
Line 98 in the original code will only execute if the data source is not a URL, so the local variable 'flat' is never set, and the script crashes with an error, as in the following:
```
$ python /mnt/software/mxnet/example/image-classification/train_mnist.py \
--data-dir s3://sandbox-svo/datasets/mnist/data/
2016-01-11 19:00:50,322 Node[0] start with arguments Namespace(batch_size=128, 
   data_dir='s3://sandbox-svo/datasets/mnist/data/',
   gpus=None, kv_store='local', load_epoch=None,
   lr=0.1, lr_factor=1, lr_factor_epoch=1, model_prefix=None,
   network='mlp', num_epochs=10, num_examples=60000)
Traceback (most recent call last):
  File "/mnt/software/mxnet/example/image-classification/train_mnist.py", line 122, in <module>
    train_model.fit(args, net, get_iterator)
  File "/mnt/software/mxnet/example/image-classification/train_model.py", line 44, in fit
    (train, val) = data_loader(args, kv)
  File "/mnt/software/mxnet/example/image-classification/train_mnist.py", line 106, in get_iterator
    flat        = flat,
UnboundLocalError: local variable 'flat' referenced before assignment
```
I simply changed the indent on the relevant line of code and it seems to work fine now.