### PR TITLE
[op] fix

### DIFF
--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -88,7 +88,7 @@ struct elu {
 struct elu_grad {
   template<typename DType>
   MSHADOW_XINLINE static DType Map(DType x, DType a) {
-    return DType(x > 0.0f ? 1.0f : a * expf(x));
+    return DType(x > 0.0f ? 1.0f : a + x);
   }
 };
 


### PR DESCRIPTION
@vchuravy for x < 0, forward: outdata = a ( exp(x) - 1), in backward we are calling grad(outdata). As d outdata/dx = a * exp(x), so grad(outdata) should be: outdata + a 