### PR TITLE
Correct typos.

### DIFF
--- a/make/config.mk
+++ b/make/config.mk
@@ -40,12 +40,12 @@ ADD_CFLAGS =
 # whether use CUDA during compile
 USE_CUDA = 0
 
-# add the path to CUDA libary to link and compile flag
-# if you have already add them to enviroment variable, leave it as NONE
+# add the path to CUDA library to link and compile flag
+# if you have already add them to environment variable, leave it as NONE
 # USE_CUDA_PATH = /usr/local/cuda
 USE_CUDA_PATH = NONE
 
-# whether use CUDNN R3 library
+# whether use CuDNN R3 library
 USE_CUDNN = 0
 
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
@@ -69,11 +69,11 @@ else
 USE_BLAS = atlas
 endif
 
-# add path to intel libary, you may need it for MKL, if you did not add the path
-# to enviroment variable
+# add path to intel library, you may need it for MKL, if you did not add the path
+# to environment variable
 USE_INTEL_PATH = NONE
 
-# If use MKL, choose static link automaticly to allow python wrapper
+# If use MKL, choose static link automatically to allow python wrapper
 ifeq ($(USE_BLAS), mkl)
 USE_STATIC_MKL = 1
 else
@@ -84,7 +84,7 @@ endif
 # distributed computing
 #----------------------------
 
-# whether or not to enable mullti-machine supporting
+# whether or not to enable multi-machine supporting
 USE_DIST_KVSTORE = 0
 
 # whether or not allow to read and write HDFS directly. If yes, then hadoop is

--- a/make/osx.mk
+++ b/make/osx.mk
@@ -40,8 +40,8 @@ ADD_CFLAGS =
 # whether use CUDA during compile
 USE_CUDA = 0
 
-# add the path to CUDA libary to link and compile flag
-# if you have already add them to enviroment variable, leave it as NONE
+# add the path to CUDA library to link and compile flag
+# if you have already add them to environment variable, leave it as NONE
 # USE_CUDA_PATH = /usr/local/cuda
 USE_CUDA_PATH = NONE
 
@@ -63,15 +63,15 @@ USE_OPENMP = 0
 # can be: mkl, blas, atlas, openblas
 USE_BLAS = apple
 
-# add path to intel libary, you may need it for MKL, if you did not add the path
-# to enviroment variable
+# add path to intel library, you may need it for MKL, if you did not add the path
+# to environment variable
 USE_INTEL_PATH = NONE
 
 #----------------------------
 # distributed computing
 #----------------------------
 
-# whether or not to enable mullti-machine supporting
+# whether or not to enable multi-machine supporting
 USE_DIST_KVSTORE = 0
 
 # whether or not allow to read and write HDFS directly. If yes, then hadoop is

--- a/make/readthedocs.mk
+++ b/make/readthedocs.mk
@@ -11,8 +11,8 @@ export NVCC = nvcc
 # whether use CUDA during compile
 USE_CUDA = 0
 
-# add the path to CUDA libary to link and compile flag
-# if you have already add them to enviroment variable, leave it as NONE
+# add the path to CUDA library to link and compile flag
+# if you have already add them to environment variable, leave it as NONE
 USE_CUDA_PATH = NONE
 
 # whether use opencv during compilation
@@ -33,8 +33,8 @@ USE_OPENMP = 0
 USE_STATIC_MKL = NONE
 USE_BLAS = NONE
 #
-# add path to intel libary, you may need it
-# for MKL, if you did not add the path to enviroment variable
+# add path to intel library, you may need it
+# for MKL, if you did not add the path to environment variable
 #
 USE_INTEL_PATH = NONE
 
@@ -45,7 +45,7 @@ ADD_LDFLAGS = -lgomp
 # the additional compile flags you want to add
 ADD_CFLAGS = -DMSHADOW_STAND_ALONE=1
 #
-# If use MKL, choose static link automaticly to fix python wrapper
+# If use MKL, choose static link automatically to fix python wrapper
 #
 ifeq ($(USE_BLAS), mkl)
 	USE_STATIC_MKL = 1


### PR DESCRIPTION
Thank you for your work. I've successfully built `libmxnet.so` on with GCC+OpenBLAS and ICC+MKL separtately. If I may, I wonder why MKL is required to be statically linked into `libmxnet.so`. Dynamic linking of MKL also makes sense.

My arguments are:

* Just like OpenBLAS, MKL provides BLAS implementation. So MKL can be linked dynamically like OpenBLAS. It doesn't bother users that much to add MKL lib path to `LD_LIBRARY` variable.
* So far I haven't seen posts or experienced issues on using Python backed by dynamically-linked MKL.
* Even MKL is statically linked into `libmxnet.so`, other Intel compiler libraries (libiomp5, libimf, libsvml,..) are still required at runtime.

GCC + OpenBLAS:

	$ ldd lib/libmxnet.so | grep openblas
	libopenblas.so.0 => /lustre/usr/openblas/0.2-gcc49/lib/libopenblas.so.0 (0x00002b637da67000)

ICC + MKL

	$ ldd lib/libmxnet.so | grep intel
        libiomp5.so => /lustre/usr/intel_cluster_studio/composer_xe_2015.2.164/compiler/lib/intel64/libiomp5.so (0x00002b04a3705000)
        libimf.so => /lustre/usr/intel_cluster_studio/composer_xe_2015.2.164/compiler/lib/intel64/libimf.so (0x00002b04a406b000)
        libsvml.so => /lustre/usr/intel_cluster_studio/composer_xe_2015.2.164/compiler/lib/intel64/libsvml.so (0x00002b04a4526000)
        libirng.so => /lustre/usr/intel_cluster_studio/composer_xe_2015.2.164/compiler/lib/intel64/libirng.so (0x00002b04a53fa000)
        libintlc.so.5 => /lustre/usr/intel_cluster_studio/composer_xe_2015.2.164/compiler/lib/intel64/libintlc.so.5 (0x00002b04a5b21000)