### PR TITLE
Add LD_LIBRARY_PATH into search paths for libmxnet.so.

### DIFF
--- a/python/mxnet/libinfo.py
+++ b/python/mxnet/libinfo.py
@@ -23,6 +23,8 @@ def find_lib_path():
         else:
             dll_path.append(os.path.join(curr_path, '../../build', vs_configuration))
             dll_path.append(os.path.join(curr_path, '../../windows', vs_configuration))
+    elif os.name == "posix" and os.environ['LD_LIBRARY_PATH']:
+        dll_path.extend([p.strip() for p in os.environ['LD_LIBRARY_PATH'].split(":")])
     if os.name == 'nt':
         dll_path = [os.path.join(p, 'libmxnet.dll') for p in dll_path]
     else:


### PR DESCRIPTION
By convention, dynamic objects like `libmxnet.so` are searched in `LD_LIBRARY_PATH` on POSIX platforms. Python seems to ignore this convention, which requires extra hack on the user side, such copying `libmxnet.so` file for each training project. 

I add `LD_LIBRARY_PATH` into search paths, making `libmxnet.so` act more like a standard library.