### PR TITLE
fix bug with zip in mixed initializer

### DIFF
--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -131,7 +131,7 @@ class Mixed(object):
     """
     def __init__(self, patterns, initializers):
         assert len(patterns) == len(initializers)
-        self.map = zip([re.compile(p) for p in patterns], initializers)
+        self.map = list(zip([re.compile(p) for p in patterns], initializers))
 
     def __call__(self, name, arr):
         for prog, init in self.map:


### PR DESCRIPTION
zip returns an iterator with state in python3. 
The for loop will exhaust `self.map` and then cause error.