### PR TITLE
enable setting return type for operators in registry

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,3 +96,4 @@ List of Contributors
 * [Ruixiang Zhang](https://github.com/sodabeta7)
 * [Lodewic van Twillert](https://github.com/Lodewic)
 * [Aditya Kumar](https://github.com/hiraditya)
+* [Dan Becker](https://github.com/dansbecker)

--- a/R-package/src/ndarray.cc
+++ b/R-package/src/ndarray.cc
@@ -326,7 +326,7 @@ NDArrayFunction::NDArrayFunction(FunctionHandle handle)
     const char *ret_type;
     MX_CALL(MXFuncGetInfo(handle, &name, &description, &num_args,
                           &arg_names, &arg_type_infos, &arg_descriptions,
-		          &ret_type));
+                          &ret_type));
     if (name[0] == '_') {
       name_ = std::string("mx.nd.internal.") + (name + 1);
     } else {
@@ -460,7 +460,7 @@ FunctionHandle NDArrayFunction::FindHandle(const std::string& hname) {
     const char *ret_type;
     MX_CALL(MXFuncGetInfo(handle, &name, &description, &num_args,
                           &arg_names, &arg_type_infos, &arg_descriptions,
-			  &ret_type));
+                          &ret_type));
     if (name == hname) return handle;
   }
   RLOG_FATAL << "FindHandle: cannot find function " << hname;

--- a/R-package/src/ndarray.cc
+++ b/R-package/src/ndarray.cc
@@ -323,8 +323,10 @@ NDArrayFunction::NDArrayFunction(FunctionHandle handle)
     const char **arg_names;
     const char **arg_type_infos;
     const char **arg_descriptions;
+    const char *ret_type;
     MX_CALL(MXFuncGetInfo(handle, &name, &description, &num_args,
-                          &arg_names, &arg_type_infos, &arg_descriptions));
+                          &arg_names, &arg_type_infos, &arg_descriptions,
+		          &ret_type));
     if (name[0] == '_') {
       name_ = std::string("mx.nd.internal.") + (name + 1);
     } else {
@@ -455,8 +457,10 @@ FunctionHandle NDArrayFunction::FindHandle(const std::string& hname) {
     const char **arg_names;
     const char **arg_type_infos;
     const char **arg_descriptions;
+    const char *ret_type;
     MX_CALL(MXFuncGetInfo(handle, &name, &description, &num_args,
-                          &arg_names, &arg_type_infos, &arg_descriptions));
+                          &arg_names, &arg_type_infos, &arg_descriptions,
+			  &ret_type));
     if (name == hname) return handle;
   }
   RLOG_FATAL << "FindHandle: cannot find function " << hname;

--- a/R-package/src/symbol.cc
+++ b/R-package/src/symbol.cc
@@ -222,11 +222,12 @@ SymbolFunction::SymbolFunction(AtomicSymbolCreator handle)
   const char **arg_type_infos;
   const char **arg_descriptions;
   const char *key_var_num_args;
+  const char *ret_type;
 
   MX_CALL(MXSymbolGetAtomicSymbolInfo(
       handle_, &name, &description, &num_args,
       &arg_names, &arg_type_infos, &arg_descriptions,
-      &key_var_num_args));
+      &key_var_num_args, &ret_type));
   if (key_var_num_args != nullptr) {
     key_var_num_args_ = key_var_num_args;
   }

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -345,6 +345,7 @@ MXNET_DLL int MXGetFunction(const char *name,
  * \param arg_names Name of the arguments.
  * \param arg_type_infos Type informations about the arguments.
  * \param arg_descriptions Description information about the arguments.
+ * \param return_type Return type of the function.
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXFuncGetInfo(FunctionHandle fun,
@@ -353,7 +354,8 @@ MXNET_DLL int MXFuncGetInfo(FunctionHandle fun,
                             mx_uint *num_args,
                             const char ***arg_names,
                             const char ***arg_type_infos,
-                            const char ***arg_descriptions);
+                            const char ***arg_descriptions,
+                            const char **return_type);
 /*!
  * \brief get the argument requirements of the function
  * \param fun input function handle
@@ -428,6 +430,7 @@ MXNET_DLL int MXSymbolListAtomicSymbolCreators(mx_uint *out_size,
  *            of positional arguments, and will need the caller to pass it in in
  *            MXSymbolCreateAtomicSymbol,
  *            With key = key_var_num_args, and value = number of positional arguments.
+ * \param return_type Return type of the function, can be Symbol or Symbol[]
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
@@ -437,7 +440,8 @@ MXNET_DLL int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
                                           const char ***arg_names,
                                           const char ***arg_type_infos,
                                           const char ***arg_descriptions,
-                                          const char **key_var_num_args);
+                                          const char **key_var_num_args,
+                                          const char **return_type = NULL);
 /*!
  * \brief Create an AtomicSymbol.
  * \param creator the AtomicSymbolCreator

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -355,7 +355,7 @@ MXNET_DLL int MXFuncGetInfo(FunctionHandle fun,
                             const char ***arg_names,
                             const char ***arg_type_infos,
                             const char ***arg_descriptions,
-                            const char **return_type);
+                            const char **return_type = NULL);
 /*!
  * \brief get the argument requirements of the function
  * \param fun input function handle

--- a/include/mxnet/operator.h
+++ b/include/mxnet/operator.h
@@ -517,6 +517,7 @@ struct OperatorPropertyReg
 #define MXNET_REGISTER_OP_PROPERTY(name, OperatorPropertyType)          \
   DMLC_REGISTRY_REGISTER(::mxnet::OperatorPropertyReg, OperatorPropertyReg, name) \
   .set_body([]() { return new OperatorPropertyType(); })                \
+  .set_return_type("Symbol") \
   .check_name()
 
 #endif  // DMLC_USE_CXX11

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -653,7 +653,7 @@ def _make_ndarray_function(handle):
         ctypes.byref(arg_names),
         ctypes.byref(arg_types),
         ctypes.byref(arg_descs),
-	ctypes.byref(ret_type)))
+        ctypes.byref(ret_type)))
     func_name = py_str(name.value)
     param_str = ctypes2docstring(num_args, arg_names, arg_types, arg_descs)
     doc_str = ('%s\n\n' +

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -645,13 +645,15 @@ def _make_ndarray_function(handle):
     arg_names = ctypes.POINTER(ctypes.c_char_p)()
     arg_types = ctypes.POINTER(ctypes.c_char_p)()
     arg_descs = ctypes.POINTER(ctypes.c_char_p)()
+    ret_type = ctypes.c_char_p()
 
     check_call(_LIB.MXFuncGetInfo(
         handle, ctypes.byref(name), ctypes.byref(desc),
         ctypes.byref(num_args),
         ctypes.byref(arg_names),
         ctypes.byref(arg_types),
-        ctypes.byref(arg_descs)))
+        ctypes.byref(arg_descs),
+	ctypes.byref(ret_type)))
     func_name = py_str(name.value)
     param_str = ctypes2docstring(num_args, arg_names, arg_types, arg_descs)
     doc_str = ('%s\n\n' +

--- a/python/mxnet/symbol.py
+++ b/python/mxnet/symbol.py
@@ -907,7 +907,7 @@ def _make_atomic_symbol_function(handle):
         ctypes.byref(arg_types),
         ctypes.byref(arg_descs),
         ctypes.byref(key_var_num_args),
-	ctypes.byref(ret_type)))
+        ctypes.byref(ret_type)))
     param_str = ctypes2docstring(num_args, arg_names, arg_types, arg_descs)
     key_var_num_args = py_str(key_var_num_args.value)
     func_name = py_str(name.value)

--- a/python/mxnet/symbol.py
+++ b/python/mxnet/symbol.py
@@ -898,6 +898,7 @@ def _make_atomic_symbol_function(handle):
     arg_names = ctypes.POINTER(ctypes.c_char_p)()
     arg_types = ctypes.POINTER(ctypes.c_char_p)()
     arg_descs = ctypes.POINTER(ctypes.c_char_p)()
+    ret_type = ctypes.c_char_p()
 
     check_call(_LIB.MXSymbolGetAtomicSymbolInfo(
         handle, ctypes.byref(name), ctypes.byref(desc),
@@ -905,7 +906,8 @@ def _make_atomic_symbol_function(handle):
         ctypes.byref(arg_names),
         ctypes.byref(arg_types),
         ctypes.byref(arg_descs),
-        ctypes.byref(key_var_num_args)))
+        ctypes.byref(key_var_num_args),
+	ctypes.byref(ret_type)))
     param_str = ctypes2docstring(num_args, arg_names, arg_types, arg_descs)
     key_var_num_args = py_str(key_var_num_args.value)
     func_name = py_str(name.value)

--- a/python/mxnet/torch.py
+++ b/python/mxnet/torch.py
@@ -50,7 +50,7 @@ def _make_torch_function(handle):
         ctypes.byref(arg_names),
         ctypes.byref(arg_types),
         ctypes.byref(arg_descs),
-	ctypes.byref(ret_type)))
+        ctypes.byref(ret_type)))
     func_name = py_str(name.value)
     if not func_name.startswith('_th_'):
         return None

--- a/python/mxnet/torch.py
+++ b/python/mxnet/torch.py
@@ -42,13 +42,15 @@ def _make_torch_function(handle):
     arg_names = ctypes.POINTER(ctypes.c_char_p)()
     arg_types = ctypes.POINTER(ctypes.c_char_p)()
     arg_descs = ctypes.POINTER(ctypes.c_char_p)()
+    ret_type = ctypes.c_char_p()
 
     check_call(_LIB.MXFuncGetInfo(
         handle, ctypes.byref(name), ctypes.byref(desc),
         ctypes.byref(num_args),
         ctypes.byref(arg_names),
         ctypes.byref(arg_types),
-        ctypes.byref(arg_descs)))
+        ctypes.byref(arg_descs),
+	ctypes.byref(ret_type)))
     func_name = py_str(name.value)
     if not func_name.startswith('_th_'):
         return None

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -955,8 +955,7 @@ int MXDataIterGetIterInfo(DataIterCreator creator,
                           mx_uint *num_args,
                           const char ***arg_names,
                           const char ***arg_type_infos,
-                          const char ***arg_descriptions,
-                          const char **return_type) {
+                          const char ***arg_descriptions) {
   DataIteratorReg *e = static_cast<DataIteratorReg *>(creator);
   return MXAPIGetFunctionRegInfo(e, name, description, num_args,
                                  arg_names, arg_type_infos, arg_descriptions,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -74,13 +74,15 @@ inline int MXAPIGetFunctionRegInfo(const FunRegType *e,
                                    mx_uint *num_args,
                                    const char ***arg_names,
                                    const char ***arg_type_infos,
-                                   const char ***arg_descriptions) {
+                                   const char ***arg_descriptions,
+                                   const char **return_type) {
   MXAPIThreadLocalEntry *ret = MXAPIThreadLocalStore::Get();
 
   API_BEGIN();
   *name = e->name.c_str();
   *description = e->description.c_str();
   *num_args = static_cast<mx_uint>(e->arguments.size());
+  if (return_type) *return_type = e->return_type.c_str();
   ret->ret_vec_charp.clear();
   for (size_t i = 0; i < e->arguments.size(); ++i) {
     ret->ret_vec_charp.push_back(e->arguments[i].name.c_str());
@@ -360,10 +362,12 @@ int MXFuncGetInfo(FunctionHandle fun,
                   mx_uint *num_args,
                   const char ***arg_names,
                   const char ***arg_type_infos,
-                  const char ***arg_descriptions) {
+                  const char ***arg_descriptions,
+                  const char **return_type) {
   return MXAPIGetFunctionRegInfo(static_cast<const NDArrayFunctionReg *>(fun),
                                  name, description, num_args,
-                                 arg_names, arg_type_infos, arg_descriptions);
+                                 arg_names, arg_type_infos, arg_descriptions,
+                                 return_type);
 }
 
 int MXFuncDescribe(FunctionHandle fun,
@@ -441,11 +445,13 @@ int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
                                 const char ***arg_names,
                                 const char ***arg_type_infos,
                                 const char ***arg_descriptions,
-                                const char **key_var_num_args) {
+                                const char **key_var_num_args,
+                                const char **return_type) {
   OperatorPropertyReg *e = static_cast<OperatorPropertyReg *>(creator);
   *key_var_num_args = e->key_var_num_args.c_str();
   return MXAPIGetFunctionRegInfo(e, name, description, num_args,
-                                 arg_names, arg_type_infos, arg_descriptions);
+                                 arg_names, arg_type_infos, arg_descriptions,
+                                 return_type);
 }
 
 int MXSymbolCreateAtomicSymbol(AtomicSymbolCreator creator,
@@ -949,10 +955,12 @@ int MXDataIterGetIterInfo(DataIterCreator creator,
                           mx_uint *num_args,
                           const char ***arg_names,
                           const char ***arg_type_infos,
-                          const char ***arg_descriptions) {
+                          const char ***arg_descriptions,
+                          const char **return_type) {
   DataIteratorReg *e = static_cast<DataIteratorReg *>(creator);
   return MXAPIGetFunctionRegInfo(e, name, description, num_args,
-                                 arg_names, arg_type_infos, arg_descriptions);
+                                 arg_names, arg_type_infos, arg_descriptions,
+                                 NULL);
 }
 
 int MXDataIterCreateIter(DataIterCreator creator,

--- a/src/operator/slice_channel.cc
+++ b/src/operator/slice_channel.cc
@@ -22,6 +22,7 @@ DMLC_REGISTER_PARAMETER(SliceChannelParam);
 
 MXNET_REGISTER_OP_PROPERTY(SliceChannel, SliceChannelProp)
 .describe("Slice channel into many outputs with equally divided channel")
+.set_return_type("Symbol[]")
 .add_arguments(SliceChannelParam::__FIELDS__());
 
 }  // namespace op


### PR DESCRIPTION
Most operators returns one Symbol, but some like slice_channel returns array of Symbols. This patch enables setting return type to "Symbol" or "Symbol[]" in the registry, so that we can get the return type in MXSymbolGetAtomicSymbolInfo()