### PR TITLE
[Torch] 1 lua_State per Operator instance to fix GC issues

### DIFF
--- a/plugin/torch/torch_base.cc
+++ b/plugin/torch/torch_base.cc
@@ -7,25 +7,29 @@
 #include "./torch_base.h"
 
 namespace mxnet {
-lua_State* TorchState::LuaState() {
-  thread_local lua_State* state = NULL;
-  if (!state) {
-    state = luaL_newstate();
-    luaL_openlibs(state);
-    luaL_loadstring(state,
-                    "require 'torch'\n"
-                    "require 'nn'\n"
+TorchState::TorchState() {
+  this->L = luaL_newstate();
+
+  luaL_openlibs(L);
+  luaL_loadstring(L,
+                  "require 'torch'\n"
+                  "require 'nn'\n"
 #if MXNET_USE_CUDA
-                    "require 'cutorch'\n"
-                    "require 'cunn'\n"
+                  "require 'cutorch'\n"
+                  "require 'cunn'\n"
 #if MXNET_USE_CUDNN
-                    "require 'cudnn'\n"
+                  "require 'cudnn'\n"
 #endif  // MXNET_USE_CUDNN
 #endif  // MXNET_USE_CUDA
-                    "local ss = require 'threads.sharedserialize'\n"
-                    "Serialize, Deserialize = ss.save, ss.load\n");
-    int err = lua_pcall(state, 0, 0, 0);
-    CHECK_EQ(err, 0) << lua_tostring(state, -1);
+                  ); // NOLINT(*)
+  int err = lua_pcall(L, 0, 0, 0);
+  CHECK_EQ(err, 0) << lua_tostring(L, -1);
+}
+
+TorchState* TorchState::ThreadSharedLuaState() {
+  thread_local TorchState* state = nullptr;
+  if (!state) {
+    state = new TorchState();
   }
   return state;
 }
@@ -38,7 +42,7 @@ void TorchState::SetStream(mshadow::Stream<mshadow::cpu>* s) {
 #if MXNET_USE_CUDA
 template<>
 void TorchState::SetStream(mshadow::Stream<mshadow::gpu>* s) {
-  TorchState::CudaState()->currentStream = mshadow::Stream<gpu>::GetStream(s);
+  CudaState()->currentStream = mshadow::Stream<gpu>::GetStream(s);
 }
 #endif  // MXNET_USE_CUDA
 }  // namespace mxnet

--- a/plugin/torch/torch_base.h
+++ b/plugin/torch/torch_base.h
@@ -30,11 +30,12 @@ namespace mxnet {
 
 class TorchState {
  public:
-  static lua_State* LuaState();
+  lua_State* L;
+  TorchState();
+  static TorchState* ThreadSharedLuaState();
 
 #if MXNET_USE_CUDA
-  static THCState* CudaState() {
-    lua_State* L = TorchState::LuaState();
+  THCState* CudaState() {
     lua_getglobal(L, "cutorch");
     CHECK(!lua_isnil(L, -1));
     lua_getfield(L, -1, "_state");
@@ -46,34 +47,9 @@ class TorchState {
 #endif  // MXNET_USE_CUDA
 
   template<typename xpu>
-  static void SetStream(mshadow::Stream<xpu>* s);
+  void SetStream(mshadow::Stream<xpu>* s);
 
-  static int Deserialize(THCharStorage* chunk) {  // read only to the chunk
-    CHECK_NE(chunk, NULL);
-    lua_State* L = LuaState();
-    lua_getglobal(L, "Deserialize");
-    luaT_pushudata(L, chunk, "torch.CharStorage");
-    THCharStorage_retain(chunk);  // keep it because read only
-    int err = lua_pcall(L, 1, 1, 0);
-    CHECK_EQ(err, 0);
-    return 1;
-  }
-
-  static int Serialize(THCharStorage** chunk) {
-    lua_State* L = LuaState();
-    lua_getglobal(L, "Serialize");
-    lua_pushvalue(L, -2);
-    int err = lua_pcall(L, 1, 1, 0);
-    CHECK_EQ(err, 0) << "Serialize failed " << lua_tostring(L, -1);
-    THCharStorage_free(*chunk);  // free the original
-    *chunk = reinterpret_cast<THCharStorage*>(luaT_toudata(L, -1, "torch.CharStorage"));
-    THCharStorage_retain(*chunk);  // keep the chunk even when lua side deletes
-    lua_pop(L, 2);
-    return 0;
-  }
-
-  static void PrintState() {
-    lua_State* L = LuaState();
+  void PrintState() {
     int i;
     int top = lua_gettop(L);
     LOG(INFO) << "Stack height: " << top;
@@ -94,6 +70,28 @@ class TorchState {
           break;
       }
     }
+  }
+
+  int Deserialize(THCharStorage* chunk) {  // read only to the chunk
+    CHECK_NE(chunk, NULL);
+    lua_getglobal(L, "Deserialize");
+    luaT_pushudata(L, chunk, "torch.CharStorage");
+    THCharStorage_retain(chunk);  // keep it because read only
+    int err = lua_pcall(L, 1, 1, 0);
+    CHECK_EQ(err, 0);
+    return 1;
+  }
+
+  int Serialize(THCharStorage** chunk) {
+    lua_getglobal(L, "Serialize");
+    lua_pushvalue(L, -2);
+    int err = lua_pcall(L, 1, 1, 0);
+    CHECK_EQ(err, 0) << "Serialize failed " << lua_tostring(L, -1);
+    THCharStorage_free(*chunk);  // free the original
+    *chunk = reinterpret_cast<THCharStorage*>(luaT_toudata(L, -1, "torch.CharStorage"));
+    THCharStorage_retain(*chunk);  // keep the chunk even when lua side deletes
+    lua_pop(L, 2);
+    return 0;
   }
 };
 
@@ -134,7 +132,7 @@ class TorchTensor {
     return TensorType(data.dev_mask_);
   }
 
-  static THGeneralTensor TBlobToTHTensor(TBlob data) {
+  static THGeneralTensor TBlobToTHTensor(TorchState* torchState, TBlob data) {
     size_t size = data.Size();
     THGeneralTensor tensor = NULL;
     THLongStorage* thshape = THLongStorage_newWithSize(data.ndim());
@@ -153,7 +151,7 @@ class TorchTensor {
       }
 #if MXNET_USE_CUDA
       case gpu::kDevMask: {
-        THCState* state = TorchState::CudaState();
+        THCState* state = torchState->CudaState();
         THCudaStorage* storage = THCudaStorage_newWithData(state, static_cast<real_t*>(data.dptr_),
                                                            size);
         // a bug in cutorch
@@ -171,7 +169,7 @@ class TorchTensor {
     return tensor;
   }
 
-  static void FreeInternal(THGeneralTensor tensor, int dev_mask) {
+  static void FreeInternal(TorchState* torchState, THGeneralTensor tensor, int dev_mask) {
     switch (dev_mask) {
       case cpu::kDevMask: {
         THFloatStorage* original = static_cast<THFloatTensor*>(tensor)->storage;
@@ -180,7 +178,7 @@ class TorchTensor {
       }
 #if MXNET_USE_CUDA
       case gpu::kDevMask: {
-        THCState* state = TorchState::CudaState();
+        THCState* state = torchState->CudaState();
         THCudaStorage* original = static_cast<THCudaTensor*>(tensor)->storage;
         THCudaStorage_free(state, original);
         break;
@@ -191,7 +189,7 @@ class TorchTensor {
     }
   }
 
-  static void SetInternal(THGeneralTensor tensor, const TBlob& blob) {
+  static void SetInternal(TorchState* torchState, THGeneralTensor tensor, const TBlob& blob) {
     size_t size = blob.Size();
     switch (blob.dev_mask_) {
       case cpu::kDevMask: {
@@ -205,7 +203,7 @@ class TorchTensor {
       }
 #if MXNET_USE_CUDA
       case gpu::kDevMask: {
-        THCState* state = TorchState::CudaState();
+        THCState* state = torchState->CudaState();
         THCudaStorage* storage = THCudaStorage_newWithData(state,
                                                            static_cast<real_t*>(blob.dptr_),
                                                            size);
@@ -223,16 +221,17 @@ class TorchTensor {
   }
 
   static std::vector<THGeneralTensor> TBlobVectorAsTable(
+    TorchState* torchState,
     const std::vector<TBlob>::const_iterator begin,
     const std::vector<TBlob>::const_iterator end) {
-    lua_State* L = TorchState::LuaState();
+    lua_State* L = torchState->L;
     std::vector<THGeneralTensor> res;
     int num = end - begin;
     if (num > 1) {
       lua_createtable(L, num, 0);
       int index = 1;
       for (std::vector<TBlob>::const_iterator it = begin; it != end; ++it) {
-        THGeneralTensor th = TorchTensor::TBlobToTHTensor(*it);
+        THGeneralTensor th = TorchTensor::TBlobToTHTensor(torchState, *it);
         res.push_back(th);
         luaT_pushudata(L, th, TorchTensor::TensorType(*it));
         lua_rawseti(L, -2, index++);
@@ -240,15 +239,15 @@ class TorchTensor {
     } else if (num == 0) {
       lua_pushnil(L);
     } else {
-      THGeneralTensor th = TorchTensor::TBlobToTHTensor(*begin);
+      THGeneralTensor th = TorchTensor::TBlobToTHTensor(torchState, *begin);
       res.push_back(th);
       luaT_pushudata(L, th, TorchTensor::TensorType(*begin));
     }
     return res;
   }
 
-  static void CopyIfDifferent(TBlob dst, THGeneralTensor th_dst) {
-    lua_State* L = TorchState::LuaState();
+  static void CopyIfDifferent(TorchState* torchState, TBlob dst, THGeneralTensor th_dst) {
+    lua_State* L = torchState->L;
     if (luaT_isudata(L, -1, TorchTensor::TensorType(cpu::kDevMask))) {
       CHECK_EQ(dst.dev_mask_, cpu::kDevMask) << "Device type mismatch.";
       THFloatTensor* src = static_cast<THFloatTensor*>(
@@ -262,7 +261,7 @@ class TorchTensor {
       THCudaTensor* src = static_cast<THCudaTensor*>(
         luaT_toudata(L, -1, TorchTensor::TensorType(gpu::kDevMask)));
       if (src->storage != static_cast<THCudaTensor*>(th_dst)->storage) {
-        THCudaTensor_copy(TorchState::CudaState(), static_cast<THCudaTensor*>(th_dst), src);
+        THCudaTensor_copy(torchState->CudaState(), static_cast<THCudaTensor*>(th_dst), src);
       }
 #endif  // MXNET_USE_CUDA
     } else {
@@ -270,22 +269,23 @@ class TorchTensor {
     }
   }
 
-  static void CheckOutput(std::vector<TBlob>::const_iterator begin,
+  static void CheckOutput(TorchState* torchState,
+                          std::vector<TBlob>::const_iterator begin,
                           std::vector<TBlob>::const_iterator end,
                           std::vector<THGeneralTensor>::const_iterator th_begin,
                           std::vector<THGeneralTensor>::const_iterator th_end) {
-    lua_State* L = TorchState::LuaState();
+    lua_State* L = torchState->L;
     int num = end - begin;
     CHECK_EQ(th_end - th_begin, num);
     if (num == 0) {
     } else if (num == 1) {
-      CopyIfDifferent(*begin, *th_begin);
+      CopyIfDifferent(torchState, *begin, *th_begin);
     } else {
       CHECK(lua_istable(L, -1));
       lua_pushnil(L);
       for (; begin != end; ++begin, ++th_begin) {
         CHECK(lua_next(L, -2));
-        CopyIfDifferent(*begin, *th_begin);
+        CopyIfDifferent(torchState, *begin, *th_begin);
         lua_pop(L, 1);
       }
       lua_pop(L, 1);

--- a/plugin/torch/torch_module-inl.h
+++ b/plugin/torch/torch_module-inl.h
@@ -46,14 +46,13 @@ template<typename xpu>
 class TorchModuleOp : public Operator {
  private:
   TorchModuleParam param_;
-
- protected:
-  THCharStorage* chunk_;
+  TorchState* torchState_;
+  int lua_reference_;
 
  public:
-  explicit TorchModuleOp(TorchModuleParam p) : chunk_(NULL) {
+  explicit TorchModuleOp(TorchModuleParam p, TorchState* torchState) : torchState_(torchState) {
     this->param_ = p;
-    lua_State* L = TorchState::LuaState();
+    lua_State* L = torchState_->L;
     CHECK_EQ(lua_gettop(L), 0);
     std::string exec = std::string("return ") + p.lua_string
       + TorchTensor::ModuleType(xpu::kDevMask);
@@ -85,29 +84,33 @@ class TorchModuleOp : public Operator {
       while (lua_next(L, -2)) {
         CHECK(luaT_isudata(L, -1, TorchTensor::TensorType(xpu::kDevMask)));
         void* udata = luaT_toudata(L, -1, TorchTensor::TensorType(xpu::kDevMask));
-        TorchTensor::FreeInternal(static_cast<THGeneralTensor>(udata), xpu::kDevMask);
+        TorchTensor::FreeInternal(torchState_, static_cast<THGeneralTensor>(udata), xpu::kDevMask);
         lua_pop(L, 1);
       }
       lua_pop(L, 1);  // pop the parameter table
     }
-    // serialize
-    TorchState::Serialize(&chunk_);
+    this->lua_reference_ = luaL_ref(L, LUA_REGISTRYINDEX);
   }
+
   virtual void Forward(const OpContext &ctx,
                        const std::vector<TBlob> &in_data,
                        const std::vector<OpReqType> &req,
                        const std::vector<TBlob> &out_data,
                        const std::vector<TBlob> &aux_args) {
-    lua_State* L = TorchState::LuaState();
+    lua_State* L = torchState_->L;
+
     CHECK_EQ(lua_gettop(L), 0);
     CHECK_EQ(in_data.size(), param_.num_params + param_.num_data);
     CHECK_EQ(out_data.size(), param_.num_outputs);
     mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-    TorchState::SetStream(s);
+    torchState_->SetStream(s);
     // Deserialize self table
-    TorchState::Deserialize(chunk_);
+
+    lua_rawgeti(L, LUA_REGISTRYINDEX, lua_reference_);
+
     std::vector<THGeneralTensor> th_output =
-      TorchTensor::TBlobVectorAsTable(out_data.begin(), out_data.begin() + param_.num_outputs);
+      TorchTensor::TBlobVectorAsTable(torchState_, out_data.begin(),
+                                      out_data.begin() + param_.num_outputs);
     // set the output field
     lua_setfield(L, -2, "output");
     // set the parameters
@@ -123,7 +126,7 @@ class TorchModuleOp : public Operator {
       while (lua_next(L, -2)) {
         CHECK(luaT_isudata(L, -1, TorchTensor::TensorType(*it)));
         void* udata = luaT_toudata(L, -1, TorchTensor::TensorType(*it));
-        TorchTensor::SetInternal(static_cast<THGeneralTensor>(udata), *(it));
+        TorchTensor::SetInternal(torchState_, static_cast<THGeneralTensor>(udata), *(it));
         it++;
         lua_pop(L, 1);
       }
@@ -135,14 +138,14 @@ class TorchModuleOp : public Operator {
     // | self | updateOutput
     lua_pushvalue(L, -2);
     // | self | updateOutput | self
-    TorchTensor::TBlobVectorAsTable(in_data.begin(), in_data.begin() + param_.num_data);
+    TorchTensor::TBlobVectorAsTable(torchState_, in_data.begin(),
+                                    in_data.begin() + param_.num_data);
     // | self | updateOutput | self | inputs
     int err = lua_pcall(L, 2, 1, 0);  // doesn't need the output
     CHECK_EQ(err, 0) << lua_tostring(L, -1);
-    TorchTensor::CheckOutput(out_data.begin(), out_data.begin() + param_.num_outputs,
+    TorchTensor::CheckOutput(torchState_, out_data.begin(), out_data.begin() + param_.num_outputs,
                              th_output.begin(), th_output.end());
-    lua_pop(L, 1);
-    TorchState::Serialize(&chunk_);
+    lua_pop(L, 2);
     CHECK_EQ(lua_gettop(L), 0);
   }
 
@@ -153,19 +156,20 @@ class TorchModuleOp : public Operator {
                         const std::vector<OpReqType> &req,
                         const std::vector<TBlob> &in_grad,
                         const std::vector<TBlob> &aux_args) {
-    lua_State* L = TorchState::LuaState();
+    lua_State* L = torchState_->L;
     CHECK_EQ(lua_gettop(L), 0);
     CHECK_EQ(in_data.size(), param_.num_params + param_.num_data);
     CHECK_EQ(out_data.size(), param_.num_outputs);
     CHECK_EQ(out_grad.size(), param_.num_outputs);
     CHECK_EQ(in_grad.size(), param_.num_params + param_.num_data);
     mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-    TorchState::SetStream(s);
-    TorchState::Deserialize(chunk_);
-    TorchTensor::TBlobVectorAsTable(out_data.begin(), out_data.end());
+    torchState_->SetStream(s);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, lua_reference_);
+    TorchTensor::TBlobVectorAsTable(torchState_, out_data.begin(), out_data.end());
     lua_setfield(L, -2, "output");
     std::vector<THGeneralTensor> th_grad =
-      TorchTensor::TBlobVectorAsTable(in_grad.begin(), in_grad.begin() + param_.num_data);
+      TorchTensor::TBlobVectorAsTable(torchState_, in_grad.begin(),
+                                      in_grad.begin() + param_.num_data);
     lua_setfield(L, -2, "gradInput");
     if (param_.num_params != 0) {
       // get the parameters into the stack
@@ -178,6 +182,7 @@ class TorchModuleOp : public Operator {
       std::vector<TBlob>::const_iterator it = in_data.begin() + param_.num_data;
       while (lua_next(L, -3)) {
         TorchTensor::SetInternal(
+          torchState_,
           static_cast<THGeneralTensor>(luaT_toudata(L, -1, TorchTensor::TensorType(*it))),
           *it);
         it++;
@@ -188,6 +193,7 @@ class TorchModuleOp : public Operator {
       it = in_grad.begin() + param_.num_data;;
       while (lua_next(L, -2)) {
         TorchTensor::SetInternal(
+          torchState_,
           static_cast<THGeneralTensor>(luaT_toudata(L, -1, TorchTensor::TensorType(*it))),
           *it);
         it++;
@@ -198,8 +204,9 @@ class TorchModuleOp : public Operator {
     lua_getfield(L, -1, "zeroGradParameters");
     lua_pushvalue(L, -2);
     CHECK_EQ(lua_pcall(L, 1, 0, 0), 0);
-    TorchTensor::TBlobVectorAsTable(in_data.begin(), in_data.begin() + param_.num_data);
-    TorchTensor::TBlobVectorAsTable(out_grad.begin(), out_grad.end());
+    TorchTensor::TBlobVectorAsTable(torchState_, in_data.begin(),
+                                    in_data.begin() + param_.num_data);
+    TorchTensor::TBlobVectorAsTable(torchState_, out_grad.begin(), out_grad.end());
     // call
     lua_getfield(L, -3, "accGradParameters");
     lua_pushvalue(L, -4);
@@ -214,26 +221,27 @@ class TorchModuleOp : public Operator {
     lua_pushvalue(L, -4);
     err = lua_pcall(L, 3, 1, 0);  // doesn't need the output
     CHECK_EQ(err, 0) << lua_tostring(L, -1);
-    TorchTensor::CheckOutput(in_grad.begin(), in_grad.begin() + param_.num_data,
+    TorchTensor::CheckOutput(torchState_, in_grad.begin(), in_grad.begin() + param_.num_data,
                              th_grad.begin(), th_grad.end());
-    lua_pop(L, 3);
-    TorchState::Serialize(&chunk_);
+    lua_pop(L, 4);
     CHECK_EQ(lua_gettop(L), 0);
   }
 };  // class TorchModuleOp
 
-// Decalre Factory function, used for dispatch specialization
+// Declare Factory function, used for dispatch specialization
 template<typename xpu>
-Operator* CreateOp(TorchModuleParam type);
+Operator* CreateOp(TorchModuleParam type, TorchState* torchState);
 
 #if DMLC_USE_CXX11
 class TorchModuleProp : public OperatorProperty {
  protected:
-  mutable THCharStorage* chunk_;
   mutable std::vector<std::string> arguments_;
+  mutable TorchState* torchState_;
+  mutable int lua_reference_;
 
-  void InitChunk_() const {
-    lua_State* L = TorchState::LuaState();
+  void InitTorchState() const {
+    this->torchState_ = new TorchState();
+    lua_State* L = torchState_->L;
     std::string exec = std::string("return ") + param_.lua_string;
     CHECK_EQ(luaL_loadstring(L, exec.c_str()), 0);
     int err = lua_pcall(L, 0, LUA_MULTRET, 0);
@@ -243,17 +251,23 @@ class TorchModuleProp : public OperatorProperty {
     lua_pushvalue(L, -2);
     err = lua_pcall(L, 1, 1, 0);
     CHECK_EQ(err, 0);
-    TorchState::Serialize(&chunk_);
+    lua_reference_ = lua_ref(L, LUA_REGISTRYINDEX);
     lua_pop(L, 1);
+
     CHECK_EQ(lua_gettop(L), 0);
   }
 
  public:
+  TorchModuleProp() : OperatorProperty(), torchState_(NULL), lua_reference_(-1) {
+  }
+
   std::vector<std::string> ListArguments() const override {
+    if (!torchState_) {
+      InitTorchState();
+    }
+    lua_State* L = torchState_->L;
+
     if (arguments_.size() == 0) {
-      if (!chunk_) {
-        InitChunk_();
-      }
       for (uint32_t i = 0; i < param_.num_data; ++i) {
         std::string data = "data_" + std::to_string(i);
         arguments_.push_back(data);
@@ -279,11 +293,10 @@ class TorchModuleProp : public OperatorProperty {
           "          end\n"
           "          return ret\n"
           "end\n";
-      lua_State* L = TorchState::LuaState();
       luaL_loadstring(L, lua_code.c_str());
       int err = lua_pcall(L, 0, 1, 0);  // return the function
       CHECK_EQ(err, 0) << lua_tostring(L, -1);
-      TorchState::Deserialize(chunk_);
+      lua_rawgeti(L, LUA_REGISTRYINDEX, lua_reference_);
       err = lua_pcall(L, 1, 1, 0);  // call the function
       CHECK_EQ(err, 0) << lua_tostring(L, -1);
       lua_pushnil(L);
@@ -314,12 +327,13 @@ class TorchModuleProp : public OperatorProperty {
   bool InferShape(std::vector<TShape> *in_shape,
                   std::vector<TShape> *out_shape,
                   std::vector<TShape> *aux_shape) const override {
-    if (chunk_ == nullptr) {
-      this->InitChunk_();
+    if (torchState_ == nullptr) {
+      this->InitTorchState();
     }
-    lua_State* L = TorchState::LuaState();
+    lua_State* L = torchState_->L;
+
     CHECK_EQ(lua_gettop(L), 0);
-    TorchState::Deserialize(chunk_);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, lua_reference_);
     CHECK_EQ(in_shape->size(), param_.num_data + param_.num_params);
     CHECK_EQ(out_shape->size(), param_.num_outputs);
     CHECK_EQ(aux_shape->size(), 0);

--- a/plugin/torch/torch_module.cc
+++ b/plugin/torch/torch_module.cc
@@ -10,13 +10,13 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator *CreateOp<cpu>(TorchModuleParam param) {
-  return new TorchModuleOp<cpu>(param);
+Operator *CreateOp<cpu>(TorchModuleParam param, TorchState* torchState) {
+  return new TorchModuleOp<cpu>(param, torchState);
 }
 
 // DO_BIND_DISPATCH comes from operator_common.h
 Operator *TorchModuleProp::CreateOperator(Context ctx) const {
-  DO_BIND_DISPATCH(CreateOp, param_);
+  DO_BIND_DISPATCH(CreateOp, param_, torchState_);
 }
 
 DMLC_REGISTER_PARAMETER(TorchModuleParam);

--- a/plugin/torch/torch_module.cu
+++ b/plugin/torch/torch_module.cu
@@ -10,8 +10,8 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator *CreateOp<gpu>(TorchModuleParam param) {
-  return new TorchModuleOp<gpu>(param);
+Operator *CreateOp<gpu>(TorchModuleParam param, TorchState* torchState) {
+  return new TorchModuleOp<gpu>(param, torchState);
 }
 
 }  // namespace op


### PR DESCRIPTION
This PR is a potential resolution to #1413.
The original issue is due to the serialization improperly managing references causing memory issues when certain objects get garbage collected. This PR removes the serialization in favour of lua references and dedicated lua_State per operator. This should hopefully make things more transparent as well.

I have tested this with the code in #1413 (with my hack to torch to introduce more GC calls), my original net that was having issues, and examples/torch/*.py.

There is one potential race that could occur with this implementation that I don't think is possible but I want to note it down somewhere anyhow:
Certain torch nn modules store data computed in the forward pass for use in the backward pass on them. These make the assumption that the calls to `forward` and `backward` will be alternating and never called concurrently. I am not sure if I should put in a mutex to ensure this condition is upheld. If backward and forward are called concurrently in this implementation a `CHECK_EQ(lua_gettop(L), 0);`  will most likely fail.