### PR TITLE
workaround bug in VS2013. 

### DIFF
--- a/src/symbol/graph_memory_allocator.h
+++ b/src/symbol/graph_memory_allocator.h
@@ -49,8 +49,7 @@ class GraphStorageAllocator {
   explicit GraphStorageAllocator(
       StaticGraph *graph,
       const std::vector<uint32_t>& topo_order,
-      std::shared_ptr<GraphStoragePool> shared_mem
-        = std::make_shared<GraphStoragePool>()) noexcept(false);
+      std::shared_ptr<GraphStoragePool> shared_mem) noexcept(false);
   /*!
    * \brief Request a memory.
    * \param ctx the context of the graph


### PR DESCRIPTION
VS2013 is not able to deduce the type of the parameter passed to make_shared in this case