### PR TITLE
new DropoutAllchannels operator / layer

### DIFF
--- a/src/operator/dropout_allchannels-inl.h
+++ b/src/operator/dropout_allchannels-inl.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2015,2016 by Contributors
+ * Copyright (c) 2015, 2016 by Contributors
  * \file dropout_allchannels-inl.h
  * \brief
  * \author Bing Xu, Kai Londenberg

--- a/src/operator/dropout_allchannels-inl.h
+++ b/src/operator/dropout_allchannels-inl.h
@@ -1,0 +1,179 @@
+/*!
+ * Copyright (c) 2015,2016 by Contributors
+ * \file dropout_allchannels-inl.h
+ * \brief
+ * \author Bing Xu, Kai Londenberg
+*/
+
+#ifndef MXNET_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
+#define MXNET_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "./operator_common.h"
+#include "./mshadow_op.h"
+#include "mshadow/extension/broadcast_with_axis.h"
+
+
+namespace dropout_allchannels {
+enum DropoutAllchannelsOpInputs {kData};
+enum DropoutAllchannelsOpOutputs {kOut, kMask};
+enum DropoutAllchannelsOpForwardResource {kRandom};
+}  // namespace dropout_allchannels
+
+namespace mxnet {
+namespace op {
+
+struct DropoutAllchannelsParam : public dmlc::Parameter<DropoutAllchannelsParam> {
+  float p;
+  DMLC_DECLARE_PARAMETER(DropoutAllchannelsParam) {
+    DMLC_DECLARE_FIELD(p).set_default(0.5)
+    .set_range(0, 1)
+    .describe("Fraction of the input that gets dropped out at training time");
+  }
+};  // struct DropoutParam
+
+template<typename xpu>
+class DropoutAllchannelsOp : public Operator {
+ public:
+  explicit DropoutAllchannelsOp(DropoutAllchannelsParam param) {
+    this->pkeep_ = 1.0f - param.p;
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_states) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 1);
+    if (ctx.is_train) {
+      CHECK_EQ(out_data.size(), 2);
+    }
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    Tensor<xpu, 4> data = in_data[dropout_allchannels::kData].get<xpu, 4, real_t>(s);
+    Tensor<xpu, 4> out = out_data[dropout_allchannels::kOut].get<xpu, 4, real_t>(s);
+    if (ctx.is_train) {
+      Tensor<xpu, 4> mask = out_data[dropout_allchannels::kMask].get<xpu,4,real_t>(s);
+      Random<xpu> *prnd = ctx.requested[dropout_allchannels::kRandom].get_random<xpu, real_t>(s);
+      Shape<3> subshp = Shape3(mask.shape_[0], mask.shape_[2], mask.shape_[3]);
+      mask = broadcast_with_axis(F<mshadow_op::threshold>(prnd->uniform(subshp), pkeep_) * (1.0f / pkeep_), 0, mask.shape_[1]);
+      Assign(out, req[dropout_allchannels::kOut], data * mask);
+    } else {
+      Assign(out, req[dropout_allchannels::kOut], F<mshadow_op::identity>(data));
+    }
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_states) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(out_grad.size(), 1);
+    CHECK_EQ(in_grad.size(), 1);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    Tensor<xpu, 4> grad = in_data[dropout_allchannels::kOut].get<xpu, 4, real_t>(s);
+    Tensor<xpu, 4> mask = in_data[dropout_allchannels::kMask].get<xpu, 4, real_t>(s);
+    Tensor<xpu, 4> gdata = in_data[dropout_allchannels::kData].get<xpu, 4, real_t>(s);
+    Assign(gdata, req[dropout_allchannels::kData], grad * mask);
+  }
+
+ private:
+  real_t pkeep_;
+};  // class DropoutOp
+
+
+template<typename xpu>
+Operator *CreateOp(DropoutAllchannelsParam param);
+
+#if DMLC_USE_CXX11
+class DropoutAllchannelsProp : public OperatorProperty {
+ public:
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    CHECK_EQ(in_shape->size(), 1);
+    const TShape &dshape = in_shape->at(0);
+    if (dshape.ndim() == 0) return false;
+    out_shape->clear();
+    out_shape->push_back(dshape);
+    out_shape->push_back(dshape);
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new DropoutAllchannelsProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "DropoutAllchannels";
+  }
+
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    return {out_grad[dropout_allchannels::kOut], out_data[dropout_allchannels::kMask]};
+  }
+
+  std::vector<std::pair<int, void*> > BackwardInplaceOption(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data,
+    const std::vector<void*> &in_grad) const override {
+    return {{out_grad[dropout_allchannels::kOut], in_grad[dropout_allchannels::kData]}};
+  }
+
+  std::vector<std::pair<int, void*> > ForwardInplaceOption(
+    const std::vector<int> &in_data,
+    const std::vector<void*> &out_data) const override {
+    return {{in_data[dropout_allchannels::kData], out_data[dropout_allchannels::kOut]}};
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+    const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kRandom};
+  }
+
+  int NumVisibleOutputs() const override {
+    return 1;
+  }
+
+  int NumOutputs() const override {
+    return 2;
+  }
+
+  std::vector<std::string> ListOutputs() const override {
+    return {"output", "mask"};
+  }
+
+  Operator* CreateOperator(Context ctx) const override;
+
+ private:
+  DropoutAllchannelsParam param_;
+};  // class DropoutAllchannelsProp
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
+

--- a/src/operator/dropout_allchannels-inl.h
+++ b/src/operator/dropout_allchannels-inl.h
@@ -5,8 +5,8 @@
  * \author Bing Xu, Kai Londenberg
 */
 
-#ifndef MXNET_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
-#define MXNET_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
+#ifndef MXNET_RCPP_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
+#define MXNET_RCPP_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
 #include <dmlc/logging.h>
 #include <dmlc/parameter.h>
 #include <mxnet/operator.h>
@@ -59,10 +59,11 @@ class DropoutAllchannelsOp : public Operator {
     Tensor<xpu, 4> data = in_data[dropout_allchannels::kData].get<xpu, 4, real_t>(s);
     Tensor<xpu, 4> out = out_data[dropout_allchannels::kOut].get<xpu, 4, real_t>(s);
     if (ctx.is_train) {
-      Tensor<xpu, 4> mask = out_data[dropout_allchannels::kMask].get<xpu,4,real_t>(s);
+      Tensor<xpu, 4> mask = out_data[dropout_allchannels::kMask].get<xpu, 4, real_t>(s);
       Random<xpu> *prnd = ctx.requested[dropout_allchannels::kRandom].get_random<xpu, real_t>(s);
       Shape<3> subshp = Shape3(mask.shape_[0], mask.shape_[2], mask.shape_[3]);
-      mask = broadcast_with_axis(F<mshadow_op::threshold>(prnd->uniform(subshp), pkeep_) * (1.0f / pkeep_), 0, mask.shape_[1]);
+      mask = broadcast_with_axis(F<mshadow_op::threshold>(prnd->uniform(subshp), pkeep_)
+                                                       * (1.0f / pkeep_), 0, mask.shape_[1]);
       Assign(out, req[dropout_allchannels::kOut], data * mask);
     } else {
       Assign(out, req[dropout_allchannels::kOut], F<mshadow_op::identity>(data));
@@ -175,5 +176,5 @@ class DropoutAllchannelsProp : public OperatorProperty {
 #endif  // DMLC_USE_CXX11
 }  // namespace op
 }  // namespace mxnet
-#endif  // MXNET_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
+#endif  // MXNET_RCPP_OPERATOR_DROPOUT_ALLCHANNELS_INL_H_
 

--- a/src/operator/dropout_allchannels.cc
+++ b/src/operator/dropout_allchannels.cc
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) 2015, 2016 by Contributors
+ * \file dropout_allchannels.cc
+ * \brief
+ * \author Bing Xu, Kai Londenberg
+*/
+
+#include "./dropout_allchannels-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<cpu>(DropoutAllchannelsParam param) {
+  return new DropoutAllchannelsOp<cpu>(param);
+}
+
+// DO_BIND_DISPATCH comes from operator_common.h
+Operator *DropoutAllchannelsProp::CreateOperator(Context ctx) const {
+  DO_BIND_DISPATCH(CreateOp, param_);
+}
+
+DMLC_REGISTER_PARAMETER(DropoutAllchannelsParam);
+
+MXNET_REGISTER_OP_PROPERTY(DropoutAllchannels, DropoutAllchannelsProp)
+.describe("Apply dropout on a batch of image or image-like inputs, always dropping or keeping all channels of a given pixel.")
+.add_argument("data", "Symbol", "Input data to apply dropout to. Has to be a 4D Tensor with shape (samples, channels, rows, cols)")
+.add_arguments(DropoutAllchannelsParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet
+
+

--- a/src/operator/dropout_allchannels.cc
+++ b/src/operator/dropout_allchannels.cc
@@ -22,8 +22,10 @@ Operator *DropoutAllchannelsProp::CreateOperator(Context ctx) const {
 DMLC_REGISTER_PARAMETER(DropoutAllchannelsParam);
 
 MXNET_REGISTER_OP_PROPERTY(DropoutAllchannels, DropoutAllchannelsProp)
-.describe("Apply dropout on a batch of image or image-like inputs, always dropping or keeping all channels of a given pixel.")
-.add_argument("data", "Symbol", "Input data to apply dropout to. Has to be a 4D Tensor with shape (samples, channels, rows, cols)")
+.describe("Apply dropout on a batch of image or image-like inputs, always dropping or keeping " \
+          "all channels of a given pixel.")
+.add_argument("data", "Symbol", "Input data to apply dropout to. Has to be a 4D Tensor with " \
+                                "shape (samples, channels, rows, cols)")
 .add_arguments(DropoutAllchannelsParam::__FIELDS__());
 
 }  // namespace op

--- a/src/operator/dropout_allchannels.cu
+++ b/src/operator/dropout_allchannels.cu
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) 2015, 2016 by Contributors
+ * \file dropout_allchannels.cc
+ * \brief
+ * \author Bing Xu, Kai Londenberg
+*/
+
+#include "./dropout_allchannels-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<gpu>(DropoutAllchannelsParam param) {
+  return new DropoutAllchannelsOp<gpu>(param);
+}
+}  // namespace op
+}  // namespace mxnet
+
+

--- a/tests/python/unittest/test_dropout_allchannels.py
+++ b/tests/python/unittest/test_dropout_allchannels.py
@@ -7,18 +7,18 @@ def same(a, b):
 
 def check_with_device(device):
     with mx.Context(device):
-	shape = (10,10, 10, 10)
-	a = mx.nd.ones(shape, dtype=np.float32)
-	c = mx.symbol.Variable('input')
-	e = mx.symbol.DropoutAllchannels(data=c)
-	be = e.bind(device, { 'input' : a })
-	be.forward(True)
-	ret = be.outputs[0].asnumpy()
-	for i in range(shape[0]):
-		for j in range(shape[1]-1):
-		    # Making sure all channels have been dropped out the same way
- 	  	    assert(same(ret[i,j,:,:], ret[i,j+1,:,:]))
-	
+        shape = (10,10, 10, 10)
+        a = mx.nd.ones(shape, dtype=np.float32)
+        c = mx.symbol.Variable('input')
+        e = mx.symbol.DropoutAllchannels(data=c)
+        be = e.bind(device, { 'input' : a })
+        be.forward(True)
+        ret = be.outputs[0].asnumpy()
+        for i in range(shape[0]):
+          for j in range(shape[1]-1):
+            # Making sure all channels have been dropped out the same way
+            assert(same(ret[i,j,:,:], ret[i,j+1,:,:]))
+
 def test_dropout_allchannels():
     check_with_device(mx.cpu())
 

--- a/tests/python/unittest/test_dropout_allchannels.py
+++ b/tests/python/unittest/test_dropout_allchannels.py
@@ -7,7 +7,7 @@ def same(a, b):
 
 def check_with_device(device):
     with mx.Context(device):
-	shape = (3,10, 10, 10)
+	shape = (10,10, 10, 10)
 	a = mx.nd.ones(shape, dtype=np.float32)
 	c = mx.symbol.Variable('input')
 	e = mx.symbol.DropoutAllchannels(data=c)
@@ -18,7 +18,6 @@ def check_with_device(device):
 		for j in range(shape[1]-1):
 		    # Making sure all channels have been dropped out the same way
  	  	    assert(same(ret[i,j,:,:], ret[i,j+1,:,:]))
-	print "OK"
 	
 def test_dropout_allchannels():
     check_with_device(mx.cpu())

--- a/tests/python/unittest/test_dropout_allchannels.py
+++ b/tests/python/unittest/test_dropout_allchannels.py
@@ -1,0 +1,28 @@
+import os
+import mxnet as mx
+import numpy as np
+
+def same(a, b):
+    return np.all(a == b)
+
+def check_with_device(device):
+    with mx.Context(device):
+	shape = (3,10, 10, 10)
+	a = mx.nd.ones(shape, dtype=np.float32)
+	c = mx.symbol.Variable('input')
+	e = mx.symbol.DropoutAllchannels(data=c)
+	be = e.bind(device, { 'input' : a })
+	be.forward(True)
+	ret = be.outputs[0].asnumpy()
+	for i in range(shape[0]):
+		for j in range(shape[1]-1):
+		    # Making sure all channels have been dropped out the same way
+ 	  	    assert(same(ret[i,j,:,:], ret[i,j+1,:,:]))
+	print "OK"
+	
+def test_dropout_allchannels():
+    check_with_device(mx.cpu())
+
+if __name__ == '__main__':
+    test_dropout_allchannels()
+


### PR DESCRIPTION
This pull request adds a new "DropoutAllchannels" operator, which is intended to work on batches of image or image-like inputs such as the output of convolution operations.

The DropoutAllchannels layer drops or keeps all channels of given pixels, everything else behaves just as usual.  The code is a slight modification of the Dropout operator. It is tested on CPU so far, and seems to work fine. 

NOTE: Yes, this operator could be emulated given existing operators, but that would be rather messy.