### PR TITLE
try to keep memory region alive untill julia handled it.

### DIFF
--- a/src/operator/ndarray_op.cc
+++ b/src/operator/ndarray_op.cc
@@ -42,32 +42,35 @@ void NDArrayOp<xpu>::Forward(const OpContext &ctx,
                    const std::vector<TBlob> &aux_args) {
   using namespace mshadow;
   Context ndctx = get_ctx();
-  std::vector<void*> ptrs;
+  std::vector<void*> *ptrs = new std::vector<void*>;
   std::vector<Engine::VarHandle> ndvar;
-  std::vector<int> tags;
+  std::vector<int> *tags = new std::vector<int>;
   for (auto& i : req) CHECK_NE(i, kAddTo);
 
   for (auto& blob : in_data) {
-    ptrs.push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
-    tags.push_back(0);
+    ptrs->push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
+    tags->push_back(0);
   }
   for (auto& blob : out_data) {
     NDArray* nd = new NDArray(blob, ndctx.dev_id);
-    ptrs.push_back(reinterpret_cast<void*>(nd));
+    ptrs->push_back(reinterpret_cast<void*>(nd));
     ndvar.push_back(nd->var());
-    tags.push_back(1);
+    tags->push_back(1);
   }
   std::sort(ndvar.begin(), ndvar.end());
   ndvar.resize(std::unique(ndvar.begin(), ndvar.end()) - ndvar.begin());
 
   std::vector<NDArray> ndcpy;
-  for (auto& i : ptrs) {
+  for (auto& i : *ptrs) {
     ndcpy.push_back(*reinterpret_cast<NDArray*>(i));
   }
 
-  CHECK(param_.pinfo->forward(ptrs.size(), ptrs.data(), tags.data(), param_.pinfo->p_forward));
-  Engine::Get()->PushSync([ndcpy, ctx](RunContext rctx) {ctx.async_on_complete(); },
-                          ndctx, ndvar, {});
+  CHECK(param_.pinfo->forward(ptrs->size(), ptrs->data(), tags->data(), param_.pinfo->p_forward));
+  Engine::Get()->PushSync([ptrs, tags, ndcpy, ctx](RunContext rctx) {
+      ctx.async_on_complete();
+      delete ptrs;
+      delete tags;
+    }, ndctx, ndvar, {});
 }
 
 template<typename xpu>
@@ -80,40 +83,43 @@ void NDArrayOp<xpu>::Backward(const OpContext &ctx,
                     const std::vector<TBlob> &aux_args) {
   using namespace mshadow;
   Context ndctx = get_ctx();
-  std::vector<void*> ptrs;
+  std::vector<void*> *ptrs = new std::vector<void*>;
   std::vector<Engine::VarHandle> ndvar;
-  std::vector<int> tags;
+  std::vector<int> *tags = new std::vector<int>;
   for (auto& i : req) CHECK_NE(i, kAddTo);
 
   for (auto& blob : in_data) {
-    ptrs.push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
-    tags.push_back(0);
+    ptrs->push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
+    tags->push_back(0);
   }
   for (auto& blob : out_data) {
-    ptrs.push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
-    tags.push_back(1);
+    ptrs->push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
+    tags->push_back(1);
   }
   for (auto& blob : in_grad) {
     NDArray* nd = new NDArray(blob, ndctx.dev_id);
-    ptrs.push_back(reinterpret_cast<void*>(nd));
+    ptrs->push_back(reinterpret_cast<void*>(nd));
     ndvar.push_back(nd->var());
-    tags.push_back(2);
+    tags->push_back(2);
   }
   std::sort(ndvar.begin(), ndvar.end());
   ndvar.resize(std::unique(ndvar.begin(), ndvar.end()) - ndvar.begin());
   for (auto& blob : out_grad) {
-    ptrs.push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
-    tags.push_back(3);
+    ptrs->push_back(reinterpret_cast<void*>(new NDArray(blob, ndctx.dev_id)));
+    tags->push_back(3);
   }
 
   std::vector<NDArray> ndcpy;
-  for (auto& i : ptrs) {
+  for (auto& i : *ptrs) {
     ndcpy.push_back(*reinterpret_cast<NDArray*>(i));
   }
 
-  CHECK(param_.pinfo->backward(ptrs.size(), ptrs.data(), tags.data(), param_.pinfo->p_backward));
-  Engine::Get()->PushSync([ndcpy, ctx](RunContext rctx){ ctx.async_on_complete(); },
-                          ndctx, ndvar, {});
+  CHECK(param_.pinfo->backward(ptrs->size(), ptrs->data(), tags->data(), param_.pinfo->p_backward));
+  Engine::Get()->PushSync([ptrs, tags, ndcpy, ctx](RunContext rctx){
+      ctx.async_on_complete();
+      delete ptrs;
+      delete tags;
+    }, ndctx, ndvar, {});
 }
 
 Operator* NDArrayOpProp::CreateOperator(Context ctx) const {


### PR DESCRIPTION
@piiswrong @pluskid I started addressing native operators in Julia again and I have run into the issue that the memory areas passed to Julia for tags and arrays went out of scope and contained garbage, before Julia got to them. 

This PR is my attempt at fixing this, but it still doesn't work. What would be the best way of waiting till the async operation has finished to then `delete` the pointers?