### PR TITLE
update build.md with intel-mkl 2016.1.30.450722

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -131,7 +131,7 @@ various distributed filesystem such as HDFS/Amazon S3/...
   any local modification will be ignored by git, then modify the according flags.
 
 #### Building with Intel MKL Support
-First, `source /path/to/intel/bin/compilervars.sh` to automatically set environment variables. Then, edit [make/config.mk](../make/config.mk), let `USE_BLAS = mkl`. `USE_INTEL_PATH = NONE` is usually not necessary to be modified.
+First, `source path/to/intel/pkg_bin/compilervars.sh -arch intel64 -platform linux` to automatically set environment variables where `-arch` and `-platform` should be modified according to your own needs. Then, edit [make/config.mk](../make/config.mk), let `USE_BLAS = mkl`. `USE_INTEL_PATH = NONE` is usually not necessary to be modified.
 
 
 ## Python Package Installation

--- a/doc/build.md
+++ b/doc/build.md
@@ -131,8 +131,9 @@ various distributed filesystem such as HDFS/Amazon S3/...
   any local modification will be ignored by git, then modify the according flags.
 
 #### Building with Intel MKL Support
-First, `source path/to/intel/pkg_bin/compilervars.sh -arch intel64 -platform linux` to automatically set environment variables where `-arch` and `-platform` should be modified according to your own needs. Then, edit [make/config.mk](../make/config.mk), let `USE_BLAS = mkl`. `USE_INTEL_PATH = NONE` is usually not necessary to be modified.
+First, `source /path/to/intel/bin/compilervars.sh` to automatically set environment variables. Then, edit [make/config.mk](../make/config.mk), let `USE_BLAS = mkl`. `USE_INTEL_PATH = NONE` is usually not necessary to be modified.
 
+ - NOTICE: For `intel-mkl` version later than `parallel_studio_xe_2016.2.062`, you should use `source /path/to/intel/pkg_bin/compilervars.sh -arch intel64` instead where `-arch` must be specified according to your own architecture.
 
 ## Python Package Installation
 


### PR DESCRIPTION
In `intel-mkl 2016.1.30.450722` (archlinux), the compilervars.sh now resides in pkg_bin folder. This script now has two vars, `-arch` is mandatory which must be specified and `-platform` is optional.

tested in my archlinux. where `uname -a` is
```
Linux by 4.4.2-1-lqx #1 ZEN SMP PREEMPT Sun Feb 21 08:58:28 UTC 2016 x86_64 GNU/Linux
```