### PR TITLE
add  arg.params,aux.params parameters in R. close #1543

### DIFF
--- a/R-package/R/model.R
+++ b/R-package/R/model.R
@@ -378,9 +378,14 @@ mx.model.select.layout.predict <- function(X, model) {
 #'     The parameter synchronization scheme in multiple devices.
 #' @param verbose logical (default=TRUE)
 #'     Specifies whether to print information on the iterations during training.     
+#' @param arg.params list, optional
+#'     Model parameter, list of name to NDArray of net's weights.
+#' @param aux.params list, optional
+#'     Model parameter, list of name to NDArray of net's auxiliary states.
 #' @return model A trained mxnet model.
 #'
 #' @export
+
 mx.model.FeedForward.create <-
 function(symbol, X, y=NULL, ctx=NULL,
          num.round=10, optimizer="sgd",
@@ -390,6 +395,7 @@ function(symbol, X, y=NULL, ctx=NULL,
          array.batch.size=128, array.layout="auto",
          kvstore="local",
          verbose=TRUE,
+         arg.params=NULL, aux.params=NULL,
          ...) {
   if (is.array(X) || is.matrix(X)) {
     if (array.layout == "auto") {
@@ -406,6 +412,8 @@ function(symbol, X, y=NULL, ctx=NULL,
   }
   input.shape <- dim((X$value())$data)
   params <- mx.model.init.params(symbol, input.shape, initializer, mx.cpu())
+  if (!is.null(arg.params)) params$arg.params <- arg.params
+  if (!is.null(aux.params)) params$aux.params <- aux.params
   if (is.null(ctx)) ctx <- mx.ctx.default()
   if (is.mx.context(ctx)) {
     ctx <- list(ctx)

--- a/R-package/demo/basic_model.R
+++ b/R-package/demo/basic_model.R
@@ -81,3 +81,34 @@ accuracy <- function(label, pred) {
 print(paste0("Finish prediction... accuracy=", accuracy(label, pred)))
 print(paste0("Finish prediction... accuracy2=", accuracy(label, pred2)))
 
+
+
+# load the model
+model <- mx.model.load("chkpt", 1)
+
+#continue training with some new arguments
+model <- mx.model.FeedForward.create(model$symbol, X=dtrain, eval.data=dtest,
+                                     ctx=devices, num.round=5,
+                                     learning.rate=0.1, momentum=0.9,
+                                     epoch.end.callback=mx.callback.save.checkpoint("reload_chkpt"),
+                                     batch.end.callback=mx.callback.log.train.metric(100),
+                                     arg.params=model$arg.params, aux.params=model$aux.params)
+
+# do prediction
+pred <- predict(model, dtest)
+label <- mx.io.extract(dtest, "label")
+dataX <- mx.io.extract(dtest, "data")
+# Predict with R's array
+pred2 <- predict(model, X=dataX)
+
+accuracy <- function(label, pred) {
+  ypred = max.col(t(as.array(pred)))
+  return(sum((as.array(label) + 1) == ypred) / length(label))
+}
+
+print(paste0("Finish prediction... accuracy=", accuracy(label, pred)))
+print(paste0("Finish prediction... accuracy2=", accuracy(label, pred2)))
+
+
+
+

--- a/R-package/man/mx.model.FeedForward.create.Rd
+++ b/R-package/man/mx.model.FeedForward.create.Rd
@@ -8,7 +8,8 @@ mx.model.FeedForward.create(symbol, X, y = NULL, ctx = NULL,
   num.round = 10, optimizer = "sgd", initializer = mx.init.uniform(0.01),
   eval.data = NULL, eval.metric = NULL, epoch.end.callback = NULL,
   batch.end.callback = NULL, array.batch.size = 128,
-  array.layout = "auto", kvstore = "local", verbose = TRUE, ...)
+  array.layout = "auto", kvstore = "local", verbose = TRUE,
+  arg.params = NULL, aux.params = NULL, ...)
 }
 \arguments{
 \item{symbol}{The symbolic configuration of the neural network.}
@@ -58,6 +59,12 @@ The parameter synchronization scheme in multiple devices.}
 
 \item{verbose}{logical (default=TRUE)
 Specifies whether to print information on the iterations during training.}
+
+\item{arg.params}{list, optional
+Model parameter, list of name to NDArray of net's weights.}
+
+\item{aux.params}{list, optional
+Model parameter, list of name to NDArray of net's auxiliary states.}
 }
 \value{
 model A trained mxnet model.


### PR DESCRIPTION
arg.params,aux.params parameters are added in mx.model.FeedForward.create function. After adding parameters above, people can load the model from a checkpoint and continue learning by passing parameters symbol, arg.params and aux.params of the model.

An example is pushed which is modified by basic_model.R to test to load model and continue training. Part of the code is below:
```R
# load the model
model <- mx.model.load("chkpt", 1)

#continue training with some new arguments
model <- mx.model.FeedForward.create(model$symbol, X=dtrain, eval.data=dtest,
                                     ctx=devices, num.round=5,
                                     learning.rate=0.1, momentum=0.9,
                                     epoch.end.callback=mx.callback.save.checkpoint("reload_chkpt"),
                                     batch.end.callback=mx.callback.log.train.metric(100),
                                     arg.params=model$arg.params, aux.params=model$aux.params)

```