### PR TITLE
Fix metric error for MAE, MSE, RMSE

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -146,8 +146,8 @@ class MAE(EvalMetric):
             if len(label.shape) == 1:
                 label = label.reshape(label.shape[0], 1)
 
-            self.sum_metric += numpy.abs(label - pred).sum()
-            self.num_inst += numpy.prod(label.shape)
+            self.sum_metric += numpy.abs(label - pred).mean()
+            self.num_inst += 1 # numpy.prod(label.shape)
 
 class MSE(EvalMetric):
     """Calculate Mean Squared Error loss"""
@@ -165,7 +165,7 @@ class MSE(EvalMetric):
                 label = label.reshape(label.shape[0], 1)
 
             self.sum_metric += ((label - pred)**2.0).mean()
-            self.num_inst += numpy.prod(label.shape)
+            self.num_inst += 1 # numpy.prod(label.shape)
 
 class RMSE(EvalMetric):
     """Calculate Root Mean Squred Error loss"""
@@ -183,7 +183,7 @@ class RMSE(EvalMetric):
                 label = label.reshape(label.shape[0], 1)
 
             self.sum_metric += numpy.sqrt(((label - pred)**2.0).mean())
-        self.num_inst += 1
+            self.num_inst += 1
 
 class Torch(EvalMetric):
     """Dummy metric for torch criterions"""

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -272,6 +272,8 @@ def create(metric):
 
     if callable(metric):
         return CustomMetric(metric)
+    elif isinstance(metric, EvalMetric):
+        return metric
     try:
         return metrics[metric.lower()]
     except:

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -146,8 +146,6 @@ class MAE(EvalMetric):
             if len(label.shape) == 1:
                 label = label.reshape(label.shape[0], 1)
 
-            check_label_shapes(label, pred, shape=1)
-
             self.sum_metric += numpy.abs(label - pred).sum()
             self.num_inst += numpy.prod(label.shape)
 
@@ -166,8 +164,6 @@ class MSE(EvalMetric):
             if len(label.shape) == 1:
                 label = label.reshape(label.shape[0], 1)
 
-            check_label_shapes(label, pred, shape=1)
-
             self.sum_metric += ((label - pred)**2.0).mean()
             self.num_inst += numpy.prod(label.shape)
 
@@ -185,8 +181,6 @@ class RMSE(EvalMetric):
 
             if len(label.shape) == 1:
                 label = label.reshape(label.shape[0], 1)
-
-            check_label_shapes(label, pred, shape=1)
 
             self.sum_metric += numpy.sqrt(((label - pred)**2.0).mean())
         self.num_inst += 1


### PR DESCRIPTION
**shape error:**

If eval_metric='mse', there will be a error message like:

```
ValueError: Shape of labels (128, 1) does not match shape of predictions (128, 10)
```

The reason is that the following lines in `metric.py` for MAE, MSE, RMSE fucntions:

```
check_label_shapes(label, pred, shape=1)
```

force label and pred have exactly the same shapes. While in this case, label is (128,1), pred is (128,10), it is broadcastable. Hence these checks should be removed.

Whether two ndarray's are broadcastable can be automatically checked by numpy, hence we do not need to add extra codes.

PS: This pull request also allows directly use eval_metrix=mx.metric.Accuracy() for model.fit().

**MAE, MSE, RMSE are not calculated correctly:**

The loss scales should not change with different batch sizes. The original implementation is not calculated correctly. The losses are increasing as the batch sizes decrease! And this bug has been fixed.