### PR TITLE
Modified R-package clip_gradient to use same ctx

### DIFF
--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -43,10 +43,11 @@ mx.opt.sgd <- function(learning.rate,
     grad <- grad * rescale.grad
     if (!is.null(clip_gradient)){
       if(clip_gradient >= 0){
-        grad <- as.array(grad)
-        grad <- pmax(grad, -1 * clip_gradient)
-        grad <- pmin(grad, clip_gradient)
-        grad <- mx.nd.array(grad,ctx(weight))
+          grad_ctx <- ctx(grad)
+          grad <- as.array(grad)
+          grad <- pmax(grad, -1 * clip_gradient)
+          grad <- pmin(grad, clip_gradient)
+          grad <- mx.nd.array(grad, grad_ctx)
       } else {
         stop("Error: clip_gradient should be positive number.")
       }

--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -46,7 +46,7 @@ mx.opt.sgd <- function(learning.rate,
         grad <- as.array(grad)
         grad <- pmax(grad, -1 * clip_gradient)
         grad <- pmin(grad, clip_gradient)
-        grad <- mx.nd.array(grad)
+        grad <- mx.nd.array(grad,ctx(weight))
       } else {
         stop("Error: clip_gradient should be positive number.")
       }


### PR DESCRIPTION
Related to https://github.com/dmlc/mxnet/issues/1323
@thirdwing @Puriney 
Another minor issue is with clip_gradient when ctx in the model is different than mx.ctx.default. This results in an error of the type "Check failed: lhs.ctx() == rhs.ctx() operands context mismatch""
It is due to the redefinition of the grad as an mx.nd.array after the clip:
grad <- mx.nd.array(grad)
this uses the default ctx that can be different to the one used in the model. Setting in your code the default ctx to the same used in the model solves the problem but I don't think this should be a feature.
Changing the nd.array re-definition of grad in optimizer.R to:
grad <- mx.nd.array(grad,ctx(weight))
seems to solve the issue. I don't know if it is possible to avoid doing the conversion of grad back and forth to array and nd.array. 
I've done a PR with this solution.