### PR TITLE
Cross entropy loss and MultiFactorScheduler

### DIFF
--- a/python/mxnet/lr_scheduler.py
+++ b/python/mxnet/lr_scheduler.py
@@ -74,3 +74,52 @@ class FactorScheduler(LRScheduler):
             logging.info("Update[%d]: Change learning rate to %0.5e",
                          num_update, self.base_lr)
         return self.base_lr
+
+class MultiFactorScheduler(LRScheduler):
+    """Reduce learning rate in factor at steps specified in a list
+
+    Assume the weight has been updated by n times, then the learning rate will
+    be
+
+    base_lr * factor^(sum((step/n)<=1)) # step is an array
+
+    Parameters
+    ----------
+    step: list of int
+        schedule learning rate after n updates
+    factor: float
+        the factor for reducing the learning rate
+    """
+    def __init__(self, step, factor=1):
+        super(MultiFactorScheduler, self).__init__()
+        assert isinstance(step, list) and len(step) >= 1
+        for i, _step in enumerate(step):
+            if i != 0 and step[i] <= step[i-1]:
+                raise ValueError("Schedule step must be an increasing integer list")
+            if _step < 1:
+                raise ValueError("Schedule step must be greater or equal than 1 round")
+        if factor >= 1.0:
+            raise ValueError("Factor must be less than 1 to make lr reduce")
+        self.step = step
+        self.cur_step_ind = 0
+        self.factor = factor
+        self.count = 0
+
+    def __call__(self, num_update):
+        """
+        Call to schedule current learning rate
+
+        Parameters
+        ----------
+        num_update: int
+            the maximal number of updates applied to a weight.
+        """
+
+        if self.cur_step_ind <= len(self.step)-1:        
+            if num_update > self.step[self.cur_step_ind]:
+                self.count = self.step[self.cur_step_ind]
+                self.cur_step_ind += 1
+                self.base_lr *= self.factor
+                logging.info("Update[%d]: Change learning rate to %0.5e",
+                             num_update, self.base_lr)
+        return self.base_lr

--- a/python/mxnet/lr_scheduler.py
+++ b/python/mxnet/lr_scheduler.py
@@ -115,7 +115,7 @@ class MultiFactorScheduler(LRScheduler):
             the maximal number of updates applied to a weight.
         """
 
-        if self.cur_step_ind <= len(self.step)-1:        
+        if self.cur_step_ind <= len(self.step)-1:
             if num_update > self.step[self.cur_step_ind]:
                 self.count = self.step[self.cur_step_ind]
                 self.cur_step_ind += 1

--- a/python/mxnet/lr_scheduler.py
+++ b/python/mxnet/lr_scheduler.py
@@ -52,8 +52,8 @@ class FactorScheduler(LRScheduler):
         super(FactorScheduler, self).__init__()
         if step < 1:
             raise ValueError("Schedule step must be greater or equal than 1 round")
-        if factor >= 1.0:
-            raise ValueError("Factor must be less than 1 to make lr reduce")
+        if factor > 1.0:
+            raise ValueError("Factor must be no more than 1 to make lr reduce")
         self.step = step
         self.factor = factor
         self.count = 0
@@ -98,8 +98,8 @@ class MultiFactorScheduler(LRScheduler):
                 raise ValueError("Schedule step must be an increasing integer list")
             if _step < 1:
                 raise ValueError("Schedule step must be greater or equal than 1 round")
-        if factor >= 1.0:
-            raise ValueError("Factor must be less than 1 to make lr reduce")
+        if factor > 1.0:
+            raise ValueError("Factor must be no more than 1 to make lr reduce")
         self.step = step
         self.cur_step_ind = 0
         self.factor = factor

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -185,6 +185,25 @@ class RMSE(EvalMetric):
             self.sum_metric += numpy.sqrt(((label - pred)**2.0).mean())
             self.num_inst += 1
 
+class CrossEntropy(EvalMetric):
+    """Calculate Cross Entropy loss"""
+    def __init__(self):
+        super(CrossEntropy, self).__init__('cross-entropy')
+
+    def update(self, labels, preds):
+        check_label_shapes(labels, preds)
+
+        for label, pred in zip(labels, preds):
+            label = label.asnumpy()
+            pred = pred.asnumpy()
+
+            label = label.ravel()
+            assert label.shape[0] == pred.shape[0]
+
+            prob = pred[numpy.arange(label.shape[0]), numpy.int64(label)]
+            self.sum_metric += (-numpy.log(prob)).sum()
+            self.num_inst += label.shape[0]
+
 class Torch(EvalMetric):
     """Dummy metric for torch criterions"""
     def __init__(self):
@@ -261,7 +280,9 @@ def create(metric):
         'acc' : Accuracy(),
         'rmse' : RMSE(),
         'mae' : MAE(),
-        'mse' : MSE()
+        'mse' : MSE(),
+        'ce' : CrossEntropy(),
+        'cross-entropy' : CrossEntropy()
     }
 
     if callable(metric):


### PR DESCRIPTION
Calculate the cross entropy loss for softmax probability output. 

And also provide the MultiFactorScheduler that is able to set `step` to a list of integers to indicate where to reduce the learning rate. It expands the FactorScheduler, as the latter only accepts for a fixed `step`.