### PR TITLE
add use_global_stats option in batch norm layer

### DIFF
--- a/src/operator/batch_norm-inl.h
+++ b/src/operator/batch_norm-inl.h
@@ -39,7 +39,7 @@ struct BatchNormParam : public dmlc::Parameter<BatchNormParam> {
     .describe("Momentum for moving average");
     DMLC_DECLARE_FIELD(fix_gamma).set_default(true)
     .describe("Fix gamma while training");
-    DMLC_DECLARE_FIELD(use_gloabal_stats).set_default(false)
+    DMLC_DECLARE_FIELD(use_global_stats).set_default(false)
     .describe("Use global mean and variance for training");
   }
 };


### PR DESCRIPTION
Hi, I added the "use_global_stats" option in the batch norm layer to use the global mean and variance during the training instead of using the statistics within the batch. It is pretty useful when the batch is small and we want to finetune a pre-trained model. 