### PR TITLE
Add network fine tuning examples

### DIFF
--- a/example/image-classification/symbol_alexnet.py
+++ b/example/image-classification/symbol_alexnet.py
@@ -6,7 +6,7 @@ Krizhevsky, Alex, Ilya Sutskever, and Geoffrey E. Hinton. "Imagenet classificati
 import find_mxnet
 import mxnet as mx
 
-def get_symbol(num_classes = 1000):
+def get_symbol(num_classes = 1000, fine_tune = False):
     input_data = mx.symbol.Variable(name="data")
     # stage 1
     conv1 = mx.symbol.Convolution(
@@ -42,6 +42,9 @@ def get_symbol(num_classes = 1000):
     relu7 = mx.symbol.Activation(data=fc2, act_type="relu")
     dropout2 = mx.symbol.Dropout(data=relu7, p=0.5)
     # stage 6
-    fc3 = mx.symbol.FullyConnected(data=dropout2, num_hidden=num_classes)
+    if fine_tune:
+        dropout2 = mx.sym.BlockGrad(dropout2)
+    fc3 = mx.symbol.FullyConnected(data=dropout2, num_hidden=num_classes,
+                                   name='fc3_%d_classes' % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc3, name='softmax')
     return softmax

--- a/example/image-classification/symbol_googlenet.py
+++ b/example/image-classification/symbol_googlenet.py
@@ -30,7 +30,7 @@ def InceptionFactory(data, num_1x1, num_3x3red, num_3x3, num_d5x5red, num_d5x5, 
     concat = mx.symbol.Concat(*[c1x1, c3x3, cd5x5, cproj], name='ch_concat_%s_chconcat' % name)
     return concat
 
-def get_symbol(num_classes = 1000):
+def get_symbol(num_classes = 1000, fine_tune = False):
     data = mx.sym.Variable("data")
     conv1 = ConvFactory(data, 64, kernel=(7, 7), stride=(2,2), pad=(3, 3), name="conv1")
     pool1 = mx.sym.Pooling(conv1, kernel=(3, 3), stride=(2, 2), pool_type="max")
@@ -51,6 +51,9 @@ def get_symbol(num_classes = 1000):
     in5b = InceptionFactory(in5a, 384, 192, 384, 48, 128, "max", 128, name="in5b")
     pool6 = mx.sym.Pooling(in5b, kernel=(7, 7), stride=(1,1), pool_type="avg")
     flatten = mx.sym.Flatten(data=pool6)
-    fc1 = mx.sym.FullyConnected(data=flatten, num_hidden=num_classes)
+    if fine_tune:
+        flatten = mx.sym.BlockGrad(flatten)
+    fc1 = mx.sym.FullyConnected(data=flatten, num_hidden=num_classes,
+                                name='fc1_%d_classes' % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc1, name='softmax')
     return softmax

--- a/example/image-classification/symbol_inception-bn-28-small.py
+++ b/example/image-classification/symbol_inception-bn-28-small.py
@@ -32,7 +32,7 @@ def SimpleFactory(data, ch_1x1, ch_3x3):
     concat = mx.symbol.Concat(*[conv1x1, conv3x3])
     return concat
 
-def get_symbol(num_classes = 10):
+def get_symbol(num_classes = 10, fine_tune = False):
     data = mx.symbol.Variable(name="data")
     conv1 = ConvFactory(data=data, kernel=(3,3), pad=(1,1), num_filter=96, act_type="relu")
     in3a = SimpleFactory(conv1, 32, 32)
@@ -47,6 +47,9 @@ def get_symbol(num_classes = 10):
     in5b = SimpleFactory(in5a, 176, 160)
     pool = mx.symbol.Pooling(data=in5b, pool_type="avg", kernel=(7,7), name="global_pool")
     flatten = mx.symbol.Flatten(data=pool, name="flatten1")
-    fc = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes, name="fc1")
+    if fine_tune:
+        flatten = mx.sym.BlockGrad(flatten)
+    fc = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes,
+                                  name="fc1_%d_classes" % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc, name="softmax")
     return softmax

--- a/example/image-classification/symbol_inception-bn-full.py
+++ b/example/image-classification/symbol_inception-bn-full.py
@@ -42,7 +42,7 @@ def InceptionFactoryB(data, num_3x3red, num_3x3, num_d3x3red, num_d3x3, name):
     concat = mx.symbol.Concat(*[c3x3, cd3x3, pooling], name='ch_concat_%s_chconcat' % name)
     return concat
 
-def get_symbol(num_classes = 21841):
+def get_symbol(num_classes = 21841, fine_tune = False):
     # data
     data = mx.symbol.Variable(name="data")
     # stage 1
@@ -69,6 +69,9 @@ def get_symbol(num_classes = 21841):
     avg = mx.symbol.Pooling(data=in5b, kernel=(7, 7), stride=(1, 1), name="global_pool", pool_type='avg')
     # linear classifier
     flatten = mx.symbol.Flatten(data=avg, name='flatten')
-    fc1 = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes, name='fc1')
+    if fine_tune:
+        flatten = mx.sym.BlockGrad(flatten)
+    fc1 = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes,
+                                   name='fc1_%d_classes' % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc1, name='softmax')
     return softmax

--- a/example/image-classification/symbol_inception-bn.py
+++ b/example/image-classification/symbol_inception-bn.py
@@ -50,7 +50,7 @@ def InceptionFactoryB(data, num_3x3red, num_3x3, num_d3x3red, num_d3x3, name):
     concat = mx.symbol.Concat(*[c3x3, cd3x3, pooling], name='ch_concat_%s_chconcat' % name)
     return concat
 
-def get_symbol(num_classes=1000):
+def get_symbol(num_classes=1000, fine_tune=False):
     # data
     data = mx.symbol.Variable(name="data")
     # stage 1
@@ -77,6 +77,9 @@ def get_symbol(num_classes=1000):
     avg = mx.symbol.Pooling(data=in5b, kernel=(7, 7), stride=(1, 1), name="global_pool", pool_type='avg')
     # linear classifier
     flatten = mx.symbol.Flatten(data=avg, name='flatten')
-    fc1 = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes, name='fc1')
+    if fine_tune:
+        flatten = mx.sym.BlockGrad(flatten)
+    fc1 = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes,
+                                   name='fc1_%d_classes' % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc1, name='softmax')
     return softmax

--- a/example/image-classification/symbol_inception-v3.py
+++ b/example/image-classification/symbol_inception-v3.py
@@ -109,7 +109,7 @@ def Inception7E(data,
 
 # In[49]:
 
-def get_symbol(num_classes=1000):
+def get_symbol(num_classes=1000, fune_tune=False):
     data = mx.symbol.Variable(name="data")
     # stage 1
     conv = Conv(data, 32, kernel=(3, 3), stride=(2, 2), name="conv")
@@ -168,7 +168,9 @@ def get_symbol(num_classes=1000):
     # pool
     pool = mx.sym.Pooling(data=in5b, kernel=(8, 8), stride=(1, 1), pool_type="avg", name="global_pool")
     flatten = mx.sym.Flatten(data=pool, name="flatten")
-    fc1 = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes, name='fc1')
+    if fine_tune:
+        flatten = mx.sym.BlockGrad(flatten)
+    fc1 = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes, name='fc1_%d_classes' % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc1, name='softmax')
     return softmax
 

--- a/example/image-classification/symbol_resnet-28-small.py
+++ b/example/image-classification/symbol_resnet-28-small.py
@@ -87,13 +87,16 @@ def residual_net(data, n):
      
     return data
 
-def get_symbol(num_classes = 10):
+def get_symbol(num_classes = 10, fine_tune = False):
     conv = conv_factory(data=mx.symbol.Variable(name='data'), num_filter=16, kernel=(3,3), stride=(1,1), pad=(1,1), act_type='relu', conv_type=0)
     n = 3 # set n = 3 means get a model with 3*6+2=20 layers, set n = 9 means 9*6+2=56 layers
     resnet = residual_net(conv, n) # 
     pool = mx.symbol.Pooling(data=resnet, kernel=(7,7), pool_type='avg')
     flatten = mx.symbol.Flatten(data=pool, name='flatten')
-    fc = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes,  name='fc1')
+    if fine_tune:
+        flatten = mx.sym.BlockGrad(flatten)
+    fc = mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes,
+                                  name='fc1_%d_classes' % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc, name='softmax')
     return softmax
 

--- a/example/image-classification/symbol_vgg.py
+++ b/example/image-classification/symbol_vgg.py
@@ -6,7 +6,7 @@ large-scale image recognition." arXiv preprint arXiv:1409.1556 (2014).
 import find_mxnet
 import mxnet as mx
 
-def get_symbol(num_classes = 1000):
+def get_symbol(num_classes = 1000, fine_tune = False):
     ## define alexnet
     data = mx.symbol.Variable(name="data")
     # group 1
@@ -57,6 +57,9 @@ def get_symbol(num_classes = 1000):
     relu7 = mx.symbol.Activation(data=fc7, act_type="relu", name="relu7")
     drop7 = mx.symbol.Dropout(data=relu7, p=0.5, name="drop7")
     # output
-    fc8 = mx.symbol.FullyConnected(data=drop7, num_hidden=num_classes, name="fc8")
+    if fine_tune:
+        drop7 = mx.sym.BlockGrad(drop7)
+    fc8 = mx.symbol.FullyConnected(data=drop7, num_hidden=num_classes,
+                                   name="fc8_%d_classes" % num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc8, name='softmax')
     return softmax

--- a/example/image-classification/train_imagenet.py
+++ b/example/image-classification/train_imagenet.py
@@ -46,11 +46,17 @@ parser.add_argument('--val-dataset', type=str, default="val.rec",
                     help="validation dataset name")
 parser.add_argument('--data-shape', type=int, default=224,
                     help='set image\'s shape')
+parser.add_argument('--fine-tune', action='store_true', default=False,
+                    help='Fine tune a new network with a pre-trained model, default False')
 args = parser.parse_args()
 
 # network
 import importlib
-net = importlib.import_module('symbol_' + args.network).get_symbol(args.num_classes)
+if args.fine_tune:
+    net = importlib.import_module('symbol_' + args.network).get_symbol(
+              args.num_classes, args.fine_tune)
+else:
+    net = importlib.import_module('symbol_' + args.network).get_symbol(args.num_classes)
 
 # data
 def get_iterator(args, kv):

--- a/example/image-classification/train_model.py
+++ b/example/image-classification/train_model.py
@@ -66,6 +66,9 @@ def fit(args, network, data_loader):
             args.gpus is None or len(args.gpus.split(',')) is 1):
         kv = None
 
+    ## Log network definition for post mortem examination
+    logging.info(network.debug_str())
+
     model = mx.model.FeedForward(
         ctx                = devs,
         symbol             = network,


### PR DESCRIPTION
These examples show how to only train the last fully connected layer of a network with all the other parameters loaded from a pre-trained model.

Related issues include https://github.com/dmlc/mxnet/issues/1313, https://github.com/dmlc/mxnet/issues/1340,  https://github.com/dmlc/mxnet/issues/1439, and https://github.com/dmlc/mxnet/pull/1568.