### PR TITLE
[EXECUTOR] Efficient gradient memory aggregation for RNN

### DIFF
--- a/doc/env_var.md
+++ b/doc/env_var.md
@@ -20,6 +20,9 @@ Usually you do not need to change these settings, but they are listed here for r
   - Maximum number of temp workspace we can allocate to each device.
   - Set this to small number can save GPU memory.
   - It will also likely to decrease level of parallelism, which is usually OK.
+* MXNET_EXEC_INPLACE_GRAD_SUM_CAP (default=8)
+	- When doing gradient accumulation from gradients bigger than this cap, use AddTo logic to save temp gradient memory.
+	- This optimization be helpful to save memory in settings such as RNN.
 * MXNET_ENGINE_TYPE (default=ThreadedEnginePerDevice)
   - The type of underlying execution engine of MXNet.
   - List of choices
@@ -42,4 +45,3 @@ Settings for More GPU Parallelism
 - Set ```MXNET_GPU_WORKER_NTHREADS``` to larger number (e.g. 2)
   - You may want to set ```MXNET_EXEC_NUM_TEMP``` to reduce memory usage.
 - This may not speed things up, especially for image applications, because GPU is usually fully utilized even with serialized jobs.
-

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -121,6 +121,17 @@ inline std::vector<std::pair<T, T> > GraphExecutor::GetInplaceOption(
   // get the node
   const StaticGraph::Node &node = graph_.nodes[node_id];
 
+  // AddTO: always use inplace when addto requirement presents.
+  if (node.addto_index.size() != 0) {
+    std::vector<std::pair<T, T> > remap(node.addto_index.size());
+    const size_t n = node.inputs.size() - node.addto_index.size();
+    for (size_t i = 0; i < node.addto_index.size(); ++i) {
+      remap[i] = std::make_pair(in_data[n + i],
+                                out_data[node.addto_index[i]]);
+    }
+    return remap;
+  }
+
   if (node.is_forward()) {
     std::vector<int> in_data_index(in_data.size());
     for (size_t i = 0; i < in_data.size(); ++i) {
@@ -186,7 +197,10 @@ GraphExecutor::GetOpExecEntry(uint32_t nid) {
   OpNode& op_node = op_nodes_[nid];
   std::vector<OpReqType> req;
   std::vector<NDArray> in_array, out_array, aux_array;
-  in_array.reserve(graph_.nodes[nid].inputs.size());
+  StaticGraph::Node& gnode = graph_.nodes[nid];
+  // AddTO: index is used to store in-place add resources.
+  const size_t ninput = gnode.inputs.size() - gnode.addto_index.size();
+  in_array.reserve(ninput);
   out_array.reserve(op_node.outputs.size());
   req.reserve(op_node.outputs.size());
   aux_array.reserve(op_node.aux_states.size());
@@ -198,13 +212,24 @@ GraphExecutor::GetOpExecEntry(uint32_t nid) {
     exec.mutate_vars.push_back(out.data.var());
     req.push_back(out.op_req);
   }
+
+  // AddTO: check the consistency
+  for (size_t i = 0; i < gnode.addto_index.size(); ++i) {
+    CHECK_EQ(req[gnode.addto_index[i]], kWriteInplace);
+    req[gnode.addto_index[i]] = kAddTo;
+    const StaticGraph::DataEntry& e = graph_.nodes[nid].inputs[i + ninput];
+    const DataEntryInfo &info = op_nodes_[e.source_id].outputs[e.index];
+    CHECK_EQ(info.inplace_op_id, static_cast<int>(nid));
+  }
+
   // aux
   for (const DataEntryInfo& aux : op_node.aux_states) {
     aux_array.push_back(aux.data);
     exec.mutate_vars.push_back(aux.data.var());
   }
   // input
-  for (StaticGraph::DataEntry e : graph_.nodes[nid].inputs) {
+  for (size_t i = 0; i < ninput; ++i) {
+    const StaticGraph::DataEntry& e = graph_.nodes[nid].inputs[i];
     const DataEntryInfo &info = op_nodes_[e.source_id].outputs[e.index];
     in_array.push_back(info.data);
     // skip inplace since they already appear in mutate vars
@@ -612,6 +637,7 @@ void GraphExecutor::InitDataEntryMemory() {
       out_data[i] = &op_nodes_[nid].outputs[i];
       CHECK_NE(out_data[i]->type, kInternalAllocated);
     }
+
     auto inplace = GetInplaceOption(nid, in_data, out_data);
 
     for (std::pair<DataEntryInfo*, DataEntryInfo*> kv : inplace) {

--- a/src/symbol/static_graph.h
+++ b/src/symbol/static_graph.h
@@ -112,6 +112,17 @@ class StaticGraph {
     int32_t backward_source_id;
     /*! \brief additional attributes about the node */
     std::map<std::string, std::string> attr;
+    /*!
+     * \brief Data structure to enable add-to operations in the node.
+     *  Use to enable memory efficient gradient sum aggregation.
+     *  Normally this array is empty.
+     *
+     *  Let n = inputs.size() - addto_index_.size();
+     *    the output of the node is defined as:
+     *  - out[j] = op(input[0:n]) for j not in addto_index_
+     *  - out[addto_index_[i]] = op(input[0:n]) + inputs[n + i]
+     */
+    std::vector<uint32_t> addto_index;
     /*! \brief default constructor */
     Node() : backward_source_id(-1) {}
     /*! \brief copy constructor in favor of serialization. */
@@ -120,7 +131,8 @@ class StaticGraph {
           name(another.name),
           inputs(another.inputs),
           backward_source_id(another.backward_source_id),
-          attr(another.attr) {}
+          attr(another.attr),
+          addto_index(another.addto_index) {}
 
     inline Node& operator=(Node another) {
       op = std::move(another.op);
@@ -128,6 +140,7 @@ class StaticGraph {
       inputs = std::move(another.inputs);
       backward_source_id = std::move(another.backward_source_id);
       attr = std::move(another.attr);
+      addto_index = std::move(another.addto_index);
       return *this;
     }
     /*! \return whether the node is forward op node */
@@ -284,7 +297,7 @@ class StaticGraph {
    * \param grad_source the source of the inputs.
    * \return a created ElementWiseSum node
    */
-  static Node CreateSumNode(const std::vector<DataEntry> &grad_source);
+  Node CreateGradSumNode(const std::vector<DataEntry> &grad_source);
   /*!
    * \brief create a copy node.
    * \param source the Source data


### PR DESCRIPTION
see https://github.com/dmlc/mxnet/issues/722 
The gradient of the embedding need to be summed and previous way of summing so many timestamps was not very efficient. 

- This PR gives a experimental hack to do smarter memory allocation, and use a stream line addition sequence to calculate the gradient
- This can benefit the  RNN with long sequences.

- However, the new optimization relies on the operators to correctly implement AddTo, some of the operators so far are not well tested on AddTo setting, so it is only enabled for summing a lot of gradients.

The environment variable ```MXNET_EXEC_INPLACE_GRAD_SUM_CAP``` (default to 8) is introduced to control between whether use the new optimization.
