### PR TITLE
remove print shape form get_output

### DIFF
--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -157,7 +157,6 @@ class Predictor(object):
             ctypes.byref(pdata),
             ctypes.byref(ndim)))
         shape = tuple(pdata[:ndim.value])
-        print shape
         data = np.empty(shape, dtype=np.float32)
         _check_call(_LIB.MXPredGetOutput(
             self.handle, mx_uint(index),


### PR DESCRIPTION
we don't always care shape of output, especially when batch execution.