### PR TITLE
Fix potential macro expansion problem on Visual Studio

### DIFF
--- a/src/operator/cudnn_deconvolution-inl.h
+++ b/src/operator/cudnn_deconvolution-inl.h
@@ -61,10 +61,6 @@ class CuDNNDeconvolutionOp : public Operator {
       float beta = 0.0f;
       #if CUDNN_MAJOR <= 4
       CHECK_EQ(cudnnConvolutionBackwardData_v3(s->dnn_handle_,
-      #endif
-      #if CUDNN_MAJOR == 5
-      CHECK_EQ(cudnnConvolutionBackwardData(s->dnn_handle_,
-      #endif
                &alpha,
                filter_desc_,
                wmat.dptr_ + weight_offset_ * g,
@@ -77,6 +73,21 @@ class CuDNNDeconvolutionOp : public Operator {
                &beta,
                out_desc_,
                out.dptr_ + out_offset_ * g), CUDNN_STATUS_SUCCESS);
+      #elif CUDNN_MAJOR == 5
+      CHECK_EQ(cudnnConvolutionBackwardData(s->dnn_handle_,
+               &alpha,
+               filter_desc_,
+               wmat.dptr_ + weight_offset_ * g,
+               in_desc_,
+               data.dptr_ + data_offset_ * g,
+               conv_desc_,
+               back_algo_,
+               workspace.dptr_,
+               backward_workspace_byte_,
+               &beta,
+               out_desc_,
+               out.dptr_ + out_offset_ * g), CUDNN_STATUS_SUCCESS);
+      #endif
       if (!param_.no_bias) {
         beta = 1.0f;
         Tensor<gpu, 1> bias = in_data[deconv::kBias].get<gpu, 1, real_t>(s);
@@ -141,10 +152,6 @@ class CuDNNDeconvolutionOp : public Operator {
       }
       #if CUDNN_MAJOR <= 4
       CHECK_EQ(cudnnConvolutionBackwardFilter_v3(s->dnn_handle_,
-      #endif
-      #if CUDNN_MAJOR == 5
-      CHECK_EQ(cudnnConvolutionBackwardFilter(s->dnn_handle_,
-      #endif
                &alpha,
                out_desc_,
                grad.dptr_ + out_offset_ * g,
@@ -157,6 +164,21 @@ class CuDNNDeconvolutionOp : public Operator {
                &beta,
                filter_desc_,
                gwmat.dptr_ + weight_offset_ * g), CUDNN_STATUS_SUCCESS);
+      #elif CUDNN_MAJOR == 5
+      CHECK_EQ(cudnnConvolutionBackwardFilter(s->dnn_handle_,
+               &alpha,
+               out_desc_,
+               grad.dptr_ + out_offset_ * g,
+               in_desc_,
+               data.dptr_ + data_offset_ * g,
+               conv_desc_,
+               back_algo_w_,
+               workspace.dptr_,
+               backward_workspace_byte_,
+               &beta,
+               filter_desc_,
+               gwmat.dptr_ + weight_offset_ * g), CUDNN_STATUS_SUCCESS);
+      #endif
       CHECK_EQ(cudnnConvolutionForward(s->dnn_handle_,
                                        &alpha,
                                        out_desc_,
@@ -200,15 +222,22 @@ class CuDNNDeconvolutionOp : public Operator {
       CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc_), CUDNN_STATUS_SUCCESS);
       CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc_), CUDNN_STATUS_SUCCESS);
       CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc_), CUDNN_STATUS_SUCCESS);
+      #if CUDNN_MAJOR <=4
       CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
                                           dtype_,
-                                          #if CUDNN_MAJOR == 5
-                                          format_,
-                                          #endif
                                           data.shape_[1] / param_.num_group,
                                           param_.num_filter / param_.num_group,
                                           param_.kernel[0],
                                           param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+      #elif CUDNN_MAJOR ==5
+      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
+                                          dtype_,
+                                          format_,
+                                          data.shape_[1] / param_.num_group,
+                                          param_.num_filter / param_.num_group,
+                                          param_.kernel[0],
+                                          param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+      #endif
       CHECK_EQ(cudnnSetConvolution2dDescriptor(conv_desc_,
                                                param_.pad[0],
                                                param_.pad[1],

--- a/src/operator/cudnn_pooling-inl.h
+++ b/src/operator/cudnn_pooling-inl.h
@@ -139,17 +139,26 @@ class CuDNNPoolingOp : public Operator {
                                           out.shape_[1],
                                           out.shape_[2],
                                           out.shape_[3]), CUDNN_STATUS_SUCCESS);
+      #if CUDNN_MAJOR == 5
       CHECK_EQ(cudnnSetPooling2dDescriptor(pooling_desc_,
                                            mode_,
-                                           #if CUDNN_MAJOR == 5
                                            nan_prop_,
-                                           #endif
                                            param_.kernel[0],
                                            param_.kernel[1],
                                            param_.pad[0],
                                            param_.pad[1],
                                            param_.stride[0],
                                            param_.stride[1]), CUDNN_STATUS_SUCCESS);
+      #else
+      CHECK_EQ(cudnnSetPooling2dDescriptor(pooling_desc_,
+                                           mode_,
+                                           param_.kernel[0],
+                                           param_.kernel[1],
+                                           param_.pad[0],
+                                           param_.pad[1],
+                                           param_.stride[0],
+                                           param_.stride[1]), CUDNN_STATUS_SUCCESS);
+      #endif
     }
   }
   bool init_cudnn_;


### PR DESCRIPTION
Similar to https://github.com/dmlc/mxnet/pull/1497. Seems `#if` cannot be written inside `CHECK_EQ()`. VS compiler fails to expand the macro as we expected. 