### PR TITLE
Fix Crop layer bug which only takes 2 inputs, with improved doc

### DIFF
--- a/src/operator/crop.cc
+++ b/src/operator/crop.cc
@@ -1,6 +1,6 @@
 /*!
  * Copyright (c) 2015 by Contributors
- * \file concat.cc
+ * \file crop.cc
  * \brief
  * \author Wei Wu
 */
@@ -21,8 +21,11 @@ Operator* CropProp::CreateOperator(Context ctx) const {
 DMLC_REGISTER_PARAMETER(CropParam);
 
 MXNET_REGISTER_OP_PROPERTY(Crop, CropProp)
-.describe("Crop the 2nd and 3rd dim of input data, with the corresponding size of w_h or "
-"with width and height of the second input symbol")
+.describe("Crop the 2nd and 3rd dim of input data, with the corresponding size of h_w or "
+"with width and height of the second input symbol, i.e., with one input, we need h_w to "
+"specify the crop height and width, otherwise the second input symbol's size will be used")
+.add_argument("data", "Symbol or Symbol[]", "Tensor or List of Tensors, the second input "
+"will be used as crop_like shape reference")
 .add_arguments(CropParam::__FIELDS__())
 .set_key_var_num_args("num_args");
 }  // namespace op


### PR DESCRIPTION
- Fix a bug in Crop layer that always CHECK_EQ(#inputs, 2), while inputs can be 1,2,3 as is determined by num_args
- Fix the bug that always set the second input in_grad to 0, as sometimes there is only one input
- Correct typos in layer documents
- Detailed description for this layer as the original one is so vague that one may not understand what to do with this layer without proper example