### PR TITLE
Smallfix of rnn example

### DIFF
--- a/example/rnn/README.md
+++ b/example/rnn/README.md
@@ -3,7 +3,7 @@ RNN Example
 This folder contains RNN examples using low level symbol interface.
 
 - [lstm.py](lstm.py) Functions for building a LSTM Network
-- [lstm_ptb.py](lstm_ptb.py) PennTreeBank language model by using LSTM
+- [lstm_bucketing.py](lstm_bucketing.py) PennTreeBank language model by using LSTM
 - [char_lstm.ipynb](char_lstm.ipynb) Notebook to demo how to train a character LSTM by using ```lstm.py```
 
 

--- a/example/rnn/bucket_io.py
+++ b/example/rnn/bucket_io.py
@@ -22,7 +22,7 @@ def default_read_content(path):
         return content
 
 def default_build_vocab(path):
-    content = read_content(path)
+    content = default_read_content(path)
     content = content.split(' ')
     idx = 1 # 0 is left for zero-padding
     the_vocab = {}

--- a/example/rnn/lstm_bucketing.py
+++ b/example/rnn/lstm_bucketing.py
@@ -6,7 +6,7 @@ import numpy as np
 import mxnet as mx
 
 from lstm import lstm_unroll
-from bucket_io import BucketSentenceIter, build_vocab
+from bucket_io import BucketSentenceIter, default_build_vocab
 
 def Perplexity(label, pred):
     loss = 0.
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
     contexts = [mx.context.gpu(i) for i in range(1)]
 
-    vocab = build_vocab("./data/ptb.train.txt")
+    vocab = default_build_vocab("./data/ptb.train.txt")
 
     def sym_gen(seq_len):
         return lstm_unroll(num_lstm_layer, seq_len, len(vocab),


### PR DESCRIPTION
I find `build_vocab` should be `default_build_vocab` and `read_content` should  be `default_read_content`.