### PR TITLE
add initial image argument to neural-style example

### DIFF
--- a/example/neural-style/run.py
+++ b/example/neural-style/run.py
@@ -137,7 +137,7 @@ model_executor.content.copyto(content_array)
 
 #get initial image representation
 img = mx.nd.zeros(content_np.shape, ctx=dev)
-if args.start_image == None:
+if args.initial_image == None:
     img[:] = mx.rnd.uniform(-0.1, 0.1, img.shape)
 else:
     img[:] = PreprocessOtherImage(args.start_image, shape=content_np.shape)


### PR DESCRIPTION
This adds a feature to set the initial image to be optimized from the command line for the neural-style example. This can be useful if you want to first run the program with a smaller max_long_edge, then use that for the initial image for a longer max_long_edge as this can help with speed optimizations. This may also be useful for general experimentation.
