### PR TITLE
Make ccSGD behaviour match documentation w.r.t clip_gradient

### DIFF
--- a/src/optimizer/sgd-inl.h
+++ b/src/optimizer/sgd-inl.h
@@ -61,7 +61,7 @@ void sgd_mom_update(RunContext ctx, TBlob weight, const TBlob grad, TBlob mom,
   Tensor<xpu, 2> weight2d = weight.FlatTo2D<xpu, real_t>(s);
   Tensor<xpu, 2> mom2d = mom.FlatTo2D<xpu, real_t>(s);
   Tensor<xpu, 2> grad2d = grad.FlatTo2D<xpu, real_t>(s);
-  if (param.clip_gradient >= 0.0f) {
+  if (param.clip_gradient > 0.0f) {
     mom2d = param.momentum*mom2d -
             lr*(param.rescale_grad*F<sgd_clip>(grad2d, param.clip_gradient) + wd*weight2d);
   } else {


### PR DESCRIPTION
The documentation states that if glip_gradient > 0, then the gradient is
clipped.