### PR TITLE
add neural-style to scala example

### DIFF
--- a/scala-package/examples/pom.xml
+++ b/scala-package/examples/pom.xml
@@ -155,16 +155,16 @@
       <groupId>com.sksamuel.scrimage</groupId>
       <artifactId>scrimage-core_2.10</artifactId>
       <version>2.1.5</version>
-  </dependency>
-  <dependency>
+    </dependency>
+    <dependency>
       <groupId>com.sksamuel.scrimage</groupId>
       <artifactId>scrimage-io-extra_2.10</artifactId>
       <version>2.1.5</version>
-  </dependency>
-  <dependency>
+    </dependency>
+    <dependency>
       <groupId>com.sksamuel.scrimage</groupId>
       <artifactId>scrimage-filters_2.10</artifactId>
       <version>2.1.5</version>
-  </dependency>
+    </dependency>
   </dependencies>
 </project>

--- a/scala-package/examples/pom.xml
+++ b/scala-package/examples/pom.xml
@@ -151,5 +151,20 @@
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.sksamuel.scrimage</groupId>
+      <artifactId>scrimage-core_2.10</artifactId>
+      <version>2.1.5</version>
+  </dependency>
+  <dependency>
+      <groupId>com.sksamuel.scrimage</groupId>
+      <artifactId>scrimage-io-extra_2.10</artifactId>
+      <version>2.1.5</version>
+  </dependency>
+  <dependency>
+      <groupId>com.sksamuel.scrimage</groupId>
+      <artifactId>scrimage-filters_2.10</artifactId>
+      <version>2.1.5</version>
+  </dependency>
   </dependencies>
 </project>

--- a/scala-package/examples/scripts/run_neuralstyle.sh
+++ b/scala-package/examples/scripts/run_neuralstyle.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-MXNET_ROOT=/home/ldpe2g/Mxnet/mxnet_scala/mxnet/mxnet
+MXNET_ROOT=$(cd "$(dirname $0)/../../.."; pwd)
 CLASS_PATH=$MXNET_ROOT/scala-package/assembly/linux-x86_64-gpu/target/*:$MXNET_ROOT/scala-package/examples/target/*:$MXNET_ROOT/scala-package/examples/target/classes/lib/*
-INPUT_IMG=$MXNET_ROOT/example/neural-style/input/IMG_4343.jpg 
-STYLE_IMG=$MXNET_ROOT/example/neural-style/input/starry_night.jpg 
+INPUT_IMG=$1 
+STYLE_IMG=$2 
 MODEL_PATH=$MXNET_ROOT/example/neural-style/model/vgg19.params
 OUTPUT_DIR=$MXNET_ROOT/example/neural-style/output
 

--- a/scala-package/examples/scripts/run_neuralstyle.sh
+++ b/scala-package/examples/scripts/run_neuralstyle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+MXNET_ROOT=/home/ldpe2g/Mxnet/mxnet_scala/mxnet/mxnet
+CLASS_PATH=$MXNET_ROOT/scala-package/assembly/linux-x86_64-gpu/target/*:$MXNET_ROOT/scala-package/examples/target/*:$MXNET_ROOT/scala-package/examples/target/classes/lib/*
+INPUT_IMG=$MXNET_ROOT/example/neural-style/input/IMG_4343.jpg 
+STYLE_IMG=$MXNET_ROOT/example/neural-style/input/starry_night.jpg 
+MODEL_PATH=$MXNET_ROOT/example/neural-style/model/vgg19.params
+OUTPUT_DIR=$MXNET_ROOT/example/neural-style/output
+
+java -Xmx1024m -cp $CLASS_PATH \
+	ml.dmlc.mxnet.examples.neuralstyle.NeuralStyle \
+	--content-image $INPUT_IMG  \
+	--style-image  $STYLE_IMG \
+	--model-path  $MODEL_PATH \
+	--output-dir $OUTPUT_DIR 

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/ModelVgg19.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/ModelVgg19.scala
@@ -6,6 +6,10 @@ import ml.dmlc.mxnet.NDArray
 import ml.dmlc.mxnet.Symbol
 import ml.dmlc.mxnet.Shape
 
+/**
+ * Definition for the neuralstyle network and initialize it with pretrained weight
+ * @author Depeng Liang
+ */
 object ModelVgg19 {
   case class ConvExecutor(executor: Executor, data: NDArray, dataGrad: NDArray,
                       style: Array[NDArray], content: NDArray)

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/ModelVgg19.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/ModelVgg19.scala
@@ -1,0 +1,101 @@
+package ml.dmlc.mxnet.examples.neuralstyle
+
+import ml.dmlc.mxnet.Context
+import ml.dmlc.mxnet.Executor
+import ml.dmlc.mxnet.NDArray
+import ml.dmlc.mxnet.Symbol
+import ml.dmlc.mxnet.Shape
+
+object ModelVgg19 {
+  case class ConvExecutor(executor: Executor, data: NDArray, dataGrad: NDArray,
+                      style: Array[NDArray], content: NDArray)
+
+  def getModel(modelPath: String, inputSize: (Int, Int), ctx: Context): ConvExecutor = {
+    // declare symbol
+    val data = Symbol.Variable("data")
+    val conv1_1 = Symbol.Convolution("conv1_1")(Map("data" -> data , "num_filter" -> 64,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu1_1 = Symbol.Activation("relu1_1")(Map("data" -> conv1_1 , "act_type" -> "relu"))
+    val conv1_2 = Symbol.Convolution("conv1_2")(Map("data" -> relu1_1 , "num_filter" -> 64,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu1_2 = Symbol.Activation("relu1_2")(Map("data" -> conv1_2 , "act_type" -> "relu"))
+    val pool1 = Symbol.Pooling("pool1")(Map("data" -> relu1_2 , "pad" -> "(0,0)",
+                                    "kernel" -> "(2,2)", "stride" -> "(2,2)", "pool_type" -> "avg"))
+    val conv2_1 = Symbol.Convolution("conv2_1")(Map("data" -> pool1 , "num_filter" -> 128,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu2_1 = Symbol.Activation("relu2_1")(Map("data" -> conv2_1 , "act_type" -> "relu"))
+    val conv2_2 = Symbol.Convolution("conv2_2")(Map("data" -> relu2_1 , "num_filter" -> 128,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu2_2 = Symbol.Activation("relu2_2")(Map("data" -> conv2_2 , "act_type" -> "relu"))
+    val pool2 = Symbol.Pooling("pool2")(Map("data" -> relu2_2 , "pad" -> "(0,0)",
+                                    "kernel" -> "(2,2)", "stride" -> "(2,2)", "pool_type" -> "avg"))
+    val conv3_1 = Symbol.Convolution("conv3_1")(Map("data" -> pool2 , "num_filter" -> 256,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu3_1 = Symbol.Activation("relu3_1")(Map("data" -> conv3_1 , "act_type" -> "relu"))
+    val conv3_2 = Symbol.Convolution("conv3_2")(Map("data" -> relu3_1 , "num_filter" -> 256,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu3_2 = Symbol.Activation("'relu3_2")(Map("data" -> conv3_2 , "act_type" -> "relu"))
+    val conv3_3 = Symbol.Convolution("conv3_3")(Map("data" -> relu3_2 , "num_filter" -> 256,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu3_3 = Symbol.Activation("relu3_3")(Map("data" -> conv3_3 , "act_type" -> "relu"))
+    val conv3_4 = Symbol.Convolution("conv3_4")(Map("data" -> relu3_3 , "num_filter" -> 256,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu3_4 = Symbol.Activation("relu3_4")(Map("data" -> conv3_4 , "act_type" -> "relu"))
+    val pool3 = Symbol.Pooling("pool3")(Map("data" -> relu3_4 , "pad" -> "(0,0)",
+                                    "kernel" -> "(2,2)", "stride" -> "(2,2)", "pool_type" -> "avg"))
+    val conv4_1 = Symbol.Convolution("conv4_1")(Map("data" -> pool3 , "num_filter" -> 512,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu4_1 = Symbol.Activation("relu4_1")(Map("data" -> conv4_1 , "act_type" -> "relu"))
+    val conv4_2 = Symbol.Convolution("conv4_2")(Map("data" -> relu4_1 , "num_filter" -> 512,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu4_2 = Symbol.Activation("relu4_2")(Map("data" -> conv4_2 , "act_type" -> "relu"))
+    val conv4_3 = Symbol.Convolution("conv4_3")(Map("data" -> relu4_2 , "num_filter" -> 512,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu4_3 = Symbol.Activation("relu4_3")(Map("data" -> conv4_3 , "act_type" -> "relu"))
+    val conv4_4 = Symbol.Convolution("conv4_4")(Map("data" -> relu4_3 , "num_filter" -> 512,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu4_4 = Symbol.Activation("relu4_4")(Map("data" -> conv4_4 , "act_type" -> "relu"))
+    val pool4 = Symbol.Pooling("pool4")(Map("data" -> relu4_4 , "pad" -> "(0,0)",
+                                    "kernel" -> "(2,2)", "stride" -> "(2,2)", "pool_type" -> "avg"))
+    val conv5_1 = Symbol.Convolution("conv5_1")(Map("data" -> pool4 , "num_filter" -> 512,
+                                        "pad" -> "(1,1)", "kernel" -> "(3,3)", "stride" -> "(1,1)",
+                                        "no_bias" -> false, "workspace" -> 1024))
+    val relu5_1 = Symbol.Activation("relu5_1")(Map("data" -> conv5_1 , "act_type" -> "relu"))
+
+    // style and content layers
+    val style = Symbol.Group(relu1_1, relu2_1, relu3_1, relu4_1, relu5_1)
+    val content = Symbol.Group(relu4_2)
+    val out = Symbol.Group(style, content)
+
+    // make executor
+    val (argShapes, outputShapes, auxShapes) = out.inferShape(
+      Map("data" -> Shape(1, 3, inputSize._1, inputSize._2)))
+    val argNames = out.listArguments()
+    val argDict = argNames.zip(argShapes.map(NDArray.zeros(_, ctx))).toMap
+    val gradDict = argNames.zip(argShapes.map(NDArray.zeros(_, ctx))).toMap
+    // init with pretrained weight
+    val pretrained = NDArray.load2Map(modelPath)
+    argNames.filter(_ != "data").foreach { name =>
+      argDict(name).set(pretrained(s"arg:$name"))
+    }
+    val executor = out.bind(ctx, argDict, gradDict)
+    val outArray = executor.outputs
+    ConvExecutor(executor = executor,
+                              data = argDict("data"),
+                              dataGrad = gradDict("data"),
+                              style = outArray.take(outArray.length - 1),
+                              content = outArray(outArray.length - 1))
+  }
+}

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/NeuralStyle.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/NeuralStyle.scala
@@ -1,0 +1,246 @@
+package ml.dmlc.mxnet.examples.neuralstyle
+
+import ml.dmlc.mxnet._
+import org.kohsuke.args4j.{CmdLineParser, Option}
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+import com.sksamuel.scrimage.Image
+import java.io.File
+import com.sksamuel.scrimage.Pixel
+import com.sksamuel.scrimage.filter.GaussianBlurFilter
+import com.sksamuel.scrimage.nio.JpegWriter
+import ml.dmlc.mxnet.optimizer.SGD
+import ml.dmlc.mxnet.optimizer.Adam
+
+object NeuralStyle {
+  case class Executor(executor: ml.dmlc.mxnet.Executor, data: NDArray, dataGrad: NDArray)
+
+  private val logger = LoggerFactory.getLogger(classOf[NeuralStyle])
+
+  def preprocessContentImage(path: String, longEdge: Int, ctx: Context): NDArray = {
+    val img = Image(new File(path))
+    logger.info(s"load the content image, size = ${(img.height, img.width)}")
+    val factor = longEdge.toFloat / Math.max(img.height, img.width)
+    val (newHeight, newWidth) = ((img.height * factor).toInt, (img.width * factor).toInt)
+    val resizedImg = img.scaleTo(newWidth, newHeight)
+    val sample = NDArray.empty(Shape(1, 3, newHeight, newWidth), ctx)
+    val datas = {
+      val rgbs = resizedImg.iterator.toArray.map { p =>
+        (p.red, p.green, p.blue)
+      }
+      val r = rgbs.map(_._1 - 123.68f)
+      val g = rgbs.map(_._2 - 116.779f)
+      val b = rgbs.map(_._3 - 103.939f)
+      r ++ g ++ b
+    }
+    sample.set(datas)
+    logger.info(s"resize the content image to ${(newHeight, newWidth)}")
+    sample
+  }
+
+  def preprocessStyleImage(path: String, shape: Shape, ctx: Context): NDArray = {
+    val img = Image(new File(path))
+    val resizedImg = img.scaleTo(shape(3), shape(2))
+    val sample = NDArray.empty(Shape(1, 3, shape(2), shape(3)), ctx)
+    val datas = {
+      val rgbs = resizedImg.iterator.toArray.map { p =>
+        (p.red, p.green, p.blue)
+      }
+      val r = rgbs.map(_._1 - 123.68f)
+      val g = rgbs.map(_._2 - 116.779f)
+      val b = rgbs.map(_._3 - 103.939f)
+      r ++ g ++ b
+    }
+    sample.set(datas)
+    sample
+  }
+
+  def clip(array: Array[Float]): Array[Float] = array.map { a =>
+    if (a < 0) 0f
+    else if (a > 255) 255f
+    else a
+  }
+
+  def postprocessImage(img: NDArray): Image = {
+    val datas = img.toArray
+    val spatialSize = img.shape(2) * img.shape(3)
+    val r = clip(datas.take(spatialSize).map(_ + 123.68f))
+    val g = clip(datas.drop(spatialSize).take(spatialSize).map(_ + 116.779f))
+    val b = clip(datas.takeRight(spatialSize).map(_ + 103.939f))
+    val pixels = for (i <- 0 until spatialSize)
+      yield Pixel(r(i).toInt, g(i).toInt, b(i).toInt, 255)
+    Image(img.shape(3), img.shape(2), pixels.toArray)
+  }
+
+  def saveImage(img: NDArray, filename: String, radius: Int): Unit = {
+    logger.info(s"save output to $filename")
+    val out = postprocessImage(img)
+    val gauss = GaussianBlurFilter(radius).op
+    val result = Image(out.width, out.height)
+    gauss.filter(out.awt, result.awt)
+    result.output(filename)(JpegWriter())
+  }
+
+  def styleGramExecutor(inputShape: Shape, ctx: Context): Executor = {
+    // symbol
+    val data = Symbol.Variable("conv")
+    val rsData = Symbol.Reshape()(Map("data" -> data,
+      "target_shape" -> s"(${inputShape(1)},${inputShape(2) * inputShape(3)})"))
+    val weight = Symbol.Variable("weight")
+    val rsWeight = Symbol.Reshape()(Map("data" -> weight,
+      "target_shape" -> s"(${inputShape(1)},${inputShape(2) * inputShape(3)})"))
+    val fc = Symbol.FullyConnected()(Map("data" -> rsData, "weight" -> rsWeight,
+      "no_bias" -> true, "num_hidden" -> inputShape(1)))
+    // executor
+    val conv = NDArray.zeros(inputShape, ctx)
+    val grad = NDArray.zeros(inputShape, ctx)
+    val args = Map("conv" -> conv, "weight" -> conv)
+    val gradMap = Map("conv" -> grad)
+    val reqs = Map("conv" -> "write", "weight" -> "null")
+    val executor = fc.bind(ctx, args, gradMap, reqs, Nil, null)
+    Executor(executor, conv, grad)
+  }
+
+  def twoNorm(array: Array[Float]): Float = {
+    Math.sqrt(array.map(x => x * x).sum.toDouble).toFloat
+  }
+
+  def main(args: Array[String]): Unit = {
+    val alle = new NeuralStyle
+    val parser: CmdLineParser = new CmdLineParser(alle)
+    try {
+      parser.parseArgument(args.toList.asJava)
+
+      val dev = if (alle.gpu >= 0) Context.gpu(alle.gpu) else Context.cpu(0)
+      val contentNp = preprocessContentImage(alle.contentImage, alle.maxLongEdge, dev)
+      val styleNp = preprocessStyleImage(alle.styleImage, contentNp.shape, dev)
+      val size = (contentNp.shape(2), contentNp.shape(3))
+
+      val modelExecutor = ModelVgg19.getModel(alle.modelPath, size, dev)
+      val gramExecutor = modelExecutor.style.map(arr => styleGramExecutor(arr.shape, dev))
+
+      // get style representation
+      val styleArray = gramExecutor.map { gram =>
+        NDArray.zeros(gram.executor.outputs(0).shape, dev)
+      }
+      modelExecutor.data.set(styleNp)
+      modelExecutor.executor.forward()
+
+      for(i <- 0 until modelExecutor.style.length) {
+        modelExecutor.style(i).copyTo(gramExecutor(i).data)
+        gramExecutor(i).executor.forward()
+        gramExecutor(i).executor.outputs(0).copyTo(styleArray(i))
+      }
+
+      // get content representation
+      val contentArray = NDArray.zeros(modelExecutor.content.shape, dev)
+      val contentGrad = NDArray.zeros(modelExecutor.content.shape, dev)
+      modelExecutor.data.set(contentNp)
+      modelExecutor.executor.forward()
+      modelExecutor.content.copyTo(contentArray)
+
+      // train
+      val img = Random.uniform(-0.1f, 0.1f, contentNp.shape, dev)
+      val lr = new FactorScheduler(step = 10, factor = 0.9f)
+
+      saveImage(contentNp, s"${alle.outputDir}/input.jpg", alle.guassianRadius)
+      saveImage(styleNp, s"${alle.outputDir}/style.jpg", alle.guassianRadius)
+//      val optimizer = new SGD(
+//          learningRate = alle.lr,
+//          momentum = 0.9f,
+//          wd = 0.005f,
+//          clipGradient = 10,
+//          lrScheduler = lr)
+       val optimizer = new Adam(
+          learningRate = alle.lr,
+          wd = 0.005f,
+          clipGradient = 10,
+          lrScheduler = lr)
+      val optimState = optimizer.createState(0, img)
+
+      logger.info(s"start training arguments $alle")
+
+      var oldImg = img.copy()
+      var gradArray: Array[NDArray] = null
+      var eps = 0f
+      var trainingDone = false
+      var e = 0
+      while(e < alle.maxNumEpochs && !trainingDone) {
+        modelExecutor.data.set(img)
+        modelExecutor.executor.forward()
+
+        // style gradient
+        for(i <- 0 until modelExecutor.style.length) {
+          val gram = gramExecutor(i)
+          gram.data.set(modelExecutor.style(i))
+          gram.executor.forward()
+          gram.executor.backward(gram.executor.outputs(0) - styleArray(i))
+          val tmp = gram.data.shape(1) * gram.data.shape(1) *
+            gram.data.shape(2) * gram.data.shape(3)
+          gram.dataGrad.set(gram.dataGrad / tmp.toFloat)
+          gram.dataGrad.set(gram.dataGrad * alle.styleWeight)
+        }
+
+        // content gradient
+        contentGrad.set((modelExecutor.content - contentArray) * alle.contentWeight)
+
+        // image gradient
+        gradArray = gramExecutor.map(_.dataGrad) :+ contentGrad
+        modelExecutor.executor.backward(gradArray)
+
+        optimizer.update(0, img, modelExecutor.dataGrad, optimState)
+        eps = twoNorm((oldImg - img).toArray) / twoNorm(img.toArray)
+        oldImg.set(img)
+        logger.info(s"epoch $e, relative change $eps")
+
+        if(eps < alle.stopEps) {
+          logger.info("eps < args.stop_eps, training finished")
+          trainingDone = true
+        }
+        if((e + 1) % alle.saveEpochs == 0) {
+          saveImage(img, s"${alle.outputDir}/tmp_${e + 1}.jpg", alle.guassianRadius)
+        }
+        e = e + 1
+      }
+      saveImage(img, s"${alle.outputDir}/out.jpg", alle.guassianRadius)
+      logger.info("Finish fit ...")
+    } catch {
+      case ex: Exception => {
+        logger.error(ex.getMessage, ex)
+        parser.printUsage(System.err)
+        sys.exit(1)
+      }
+    }
+  }
+}
+
+class NeuralStyle {
+  @Option(name = "--model", usage = "the pretrained model to use: ['vgg']")
+  private val model: String = "vgg19"
+  @Option(name = "--content-image", usage = "the content image")
+  private val contentImage: String = "input/IMG_4343.jpg"
+  @Option(name = "--style-image", usage = "the style image")
+  private val styleImage: String = "input/starry_night.jpg"
+  @Option(name = "--model-path", usage = "the model file path")
+  private val modelPath: String = "model/vgg19.params"
+  @Option(name = "--stop-eps", usage = "stop if the relative chanage is less than eps")
+  private val stopEps: Float = 0.0005f
+  @Option(name = "--content-weight", usage = "the weight for the content image")
+  private val contentWeight: Float = 20f
+  @Option(name = "--style-weight", usage = "the weight for the style image")
+  private val styleWeight: Float = 1f
+  @Option(name = "--max-num-epochs", usage = "the maximal number of training epochs")
+  private val maxNumEpochs: Int = 1000
+  @Option(name = "--max-long-edge", usage = "resize the content image")
+  private val maxLongEdge: Int = 600
+  @Option(name = "--lr", usage = "the initial learning rate")
+  private val lr: Float = 10f
+  @Option(name = "--gpu", usage = "which gpu card to use, -1 means using cpu")
+  private val gpu: Int = 0
+  @Option(name = "--output-dir", usage = "the output directory")
+  private val outputDir: String = "output"
+  @Option(name = "--save-epochs", usage = "save the output every n epochs")
+  private val saveEpochs: Int = 50
+  @Option(name = "--guassian-radius", usage = "the gaussian blur filter radius")
+  private val guassianRadius: Int = 1
+}


### PR DESCRIPTION
It takes 506 epoches to generate the following result:
http://pan.baidu.com/s/1cdVMn8


main different between python version: 
1, optimizer: use Adam instead of SGD and change the leraning rate from 0.1f to 10f,
   because there was some problems when using SGD, or may be I was not implemented it correctly.

2, use gaussian blur for image denoising because I am not yet find anything library of java or scala that implemented the chambolle denoising algorithm.

run: 
java -Xmx1024m -cp scala-package/assembly/linux-x86_64-gpu/target/*:scala-package/examples/target/*:scala-package/examples/target/classes/lib/* ml.dmlc.mxnet.examples.neuralstyle.NeuralStyle --content-image input/IMG_4343.jpg  --style-image input/starry_night.jpg --model-path model/vgg19.params --output-dir output 
