### PR TITLE
[Scala] pass env variables to ps-lite and do distributed training

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1005,8 +1005,17 @@ MXNET_DLL int MXDataIterGetPadNum(DataIterHandle handle,
 MXNET_DLL int MXDataIterGetLabel(DataIterHandle handle,
                                  NDArrayHandle *out);
 //--------------------------------------------
-// Part 5: basic KVStore interface
+// Part 6: basic KVStore interface
 //--------------------------------------------
+/*!
+ * \brief Initialized ps-lite environment variables
+ * \param num_vars number of variables to initialize
+ * \param keys environment keys
+ * \param vals environment values
+ */
+MXNET_DLL int MXInitPSEnv(mx_uint num_vars,
+                          const char **keys,
+                          const char **vals);
 /*!
  * \brief Create a kvstore
  * \param type the type of KVStore

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStoreServer.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStoreServer.scala
@@ -37,12 +37,16 @@ object KVStoreServer {
   def start(): Unit = {
     val isWorker = new RefInt
     checkCall(_LIB.mxKVStoreIsWorkerNode(isWorker))
-    if (isWorker.value == 0) {
-      val kvStore = KVStore.create("dist")
-      val server = new KVStoreServer(kvStore)
-      server.run()
-      sys.exit()
-    }
+    require(isWorker.value == 0, "cannot start kv-store server on worker node")
+    val kvStore = KVStore.create("dist")
+    val server = new KVStoreServer(kvStore)
+    server.run()
+  }
+
+  def init(env: Map[String, String]): Unit = {
+    val keys = env.keys.toArray
+    val vals = env.values.toArray
+    checkCall(_LIB.mxInitPSEnv(keys, vals))
   }
 }
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -63,6 +63,7 @@ class LibInfo {
   @native def mxNDArrayGetContext(handle: NDArrayHandle, devTypeId: RefInt, devId: RefInt): Int
 
   // KVStore Server
+  @native def mxInitPSEnv(keys: Array[String], values: Array[String]): Int
   @native def mxKVStoreRunServer(handle: KVStoreHandle, controller: KVServerControllerCallback): Int
 
   // KVStore

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/imclassification/TrainMnist.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/imclassification/TrainMnist.scala
@@ -4,6 +4,7 @@ import ml.dmlc.mxnet._
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
 
+import scala.collection.mutable
 import scala.collection.JavaConverters._
 
 object TrainMnist {
@@ -91,17 +92,33 @@ object TrainMnist {
         else if (inst.cpus != null) inst.cpus.split(',').map(id => Context.cpu(id.trim.toInt))
         else Array(Context.cpu(0))
 
-      logger.info("Start KVStoreServer for scheduler & servers")
-      KVStoreServer.start()
+      val envs: mutable.Map[String, String] = mutable.HashMap.empty[String, String]
+      envs.put("DMLC_ROLE", inst.role)
+      if (inst.schedulerHost != null) {
+        require(inst.schedulerPort > 0, "scheduler port not specified")
+        envs.put("DMLC_PS_ROOT_URI", inst.schedulerHost)
+        envs.put("DMLC_PS_ROOT_PORT", inst.schedulerPort.toString)
+        require(inst.numWorker > 0, "Num of workers must > 0")
+        envs.put("DMLC_NUM_WORKER", inst.numWorker.toString)
+        require(inst.numServer > 0, "Num of servers must > 0")
+        envs.put("DMLC_NUM_SERVER", inst.numServer.toString)
+      }
+      logger.info("Init PS environments")
+      KVStoreServer.init(envs.toMap)
 
-      ModelTrain.fit(dataDir = inst.dataDir,
-        batchSize = inst.batchSize, numExamples = inst.numExamples, devs = devs,
-        network = net, dataLoader = getIterator(dataShape),
-        kvStore = inst.kvStore, numEpochs = inst.numEpochs,
-        modelPrefix = inst.modelPrefix, loadEpoch = inst.loadEpoch,
-        lr = inst.lr, lrFactor = inst.lrFactor, lrFactorEpoch = inst.lrFactorEpoch,
-        monitorSize = inst.monitor)
-      logger.info("Finish fit ...")
+      if (inst.role != "worker") {
+        logger.info("Start KVStoreServer for scheduler & servers")
+        KVStoreServer.start()
+      } else {
+        ModelTrain.fit(dataDir = inst.dataDir,
+          batchSize = inst.batchSize, numExamples = inst.numExamples, devs = devs,
+          network = net, dataLoader = getIterator(dataShape),
+          kvStore = inst.kvStore, numEpochs = inst.numEpochs,
+          modelPrefix = inst.modelPrefix, loadEpoch = inst.loadEpoch,
+          lr = inst.lr, lrFactor = inst.lrFactor, lrFactorEpoch = inst.lrFactorEpoch,
+          monitorSize = inst.monitor)
+        logger.info("Finish fit ...")
+      }
     } catch {
       case ex: Exception => {
         logger.error(ex.getMessage, ex)
@@ -142,4 +159,15 @@ class TrainMnist {
   private val lrFactorEpoch: Float = 1f
   @Option(name = "--monitor", usage = "monitor the training process every N batch")
   private val monitor: Int = -1
+
+  @Option(name = "--role", usage = "scheduler/server/worker")
+  private val role: String = "worker"
+  @Option(name = "--scheduler-host", usage = "Scheduler hostname / ip address")
+  private val schedulerHost: String = null
+  @Option(name = "--scheduler-port", usage = "Scheduler port")
+  private val schedulerPort: Int = 0
+  @Option(name = "--num-worker", usage = "# of workers")
+  private val numWorker: Int = 1
+  @Option(name = "--num-server", usage = "# of servers")
+  private val numServer: Int = 1
 }

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1227,6 +1227,17 @@ int MXKVStoreBarrier(KVStoreHandle handle) {
   API_END();
 }
 
+int MXInitPSEnv(mx_uint num_vars,
+                const char **keys,
+                const char **vals) {
+  API_BEGIN();
+  std::unordered_map<std::string, std::string> kwargs;
+  for (mx_uint i = 0; i < num_vars; ++i) {
+    kwargs[std::string(keys[i])] = std::string(vals[i]);
+  }
+  KVStore::InitPSEnv(kwargs);
+  API_END();
+}
 
 int MXKVStoreIsWorkerNode(int *ret) {
   API_BEGIN();


### PR DESCRIPTION
related to https://github.com/dmlc/mxnet/issues/1637

example usage:
```
java -Xmx4m -cp \
  scala-package/assembly/osx-x86_64-cpu/target/*:scala-package/examples/target/*:scala-package/examples/target/classes/lib/* \
  ml.dmlc.mxnet.examples.imclassification.TrainMnist \
  --data-dir=./data/ \
  --num-epochs=5 \
  --network=mlp \
  --cpus=0 \
  --kv-store=dist_sync \
  --role=scheduler \
  --scheduler-host=127.0.0.1 \
  --scheduler-port=9191
```

and change argument role to 'worker' and 'server' for workers and servers