### PR TITLE
a script to determine whether core of libmxnet is changed

### DIFF
--- a/tests/travis/is_core_changed.sh
+++ b/tests/travis/is_core_changed.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# this is a util script to test whether the "core" of
+# mxnet has changed. Please modify the regex patterns here
+# to ensure the components are covered if you add new "core"
+# components to mxnet
+
+# DEBUG
+git status
+git branch
+
+core_patterns=(
+  '^dmlc-core'
+  '^matlab'
+  '^plugin'
+  '^python'
+  '^src'
+  '^tools'
+  '^R-package'
+  '^amalgamation'
+  '^include'
+  '^mshadow'
+  '^ps-lite'
+  '^scala-package'
+  '^tests'
+)
+
+git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD master) > changed_names.txt
+
+for pat in ${core_patterns[@]}; do
+  if grep "$pat" changed_names.txt
+  then
+    exit
+  fi
+done
+
+exit 1 # means nothing has changed

--- a/tests/travis/is_core_changed.sh
+++ b/tests/travis/is_core_changed.sh
@@ -6,9 +6,12 @@
 # components to mxnet
 
 # DEBUG
-git status
-git branch
+echo "Files changed in this PR includes:"
+echo "**********************************"
+git diff --name-only HEAD^
+echo "**********************************"
 
+# we ignore examples, and docs
 core_patterns=(
   '^dmlc-core'
   '^matlab'
@@ -25,13 +28,12 @@ core_patterns=(
   '^tests'
 )
 
-git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD master) > changed_names.txt
-
 for pat in ${core_patterns[@]}; do
-  if grep "$pat" changed_names.txt
+  if git diff --name-only HEAD^ | grep "$pat"
   then
     exit
   fi
 done
 
+echo "I think we are good to skip this travis ci run now"
 exit 1 # means nothing has changed

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+tests/travis/is_core_changed.sh
+
 if [ ${TASK} == "lint" ]; then
     make lint || exit -1
     echo "Check documentations of c++ code..."
@@ -123,6 +125,6 @@ if [ ${TASK} == "scala_test" ]; then
 
     make scalapkg || exit -1
     make scalatest || exit -1
-    
+
     exit 0
 fi

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-tests/travis/is_core_changed.sh
+if ! tests/travis/is_core_changed.sh
+then
+  exit 0
+fi
 
 if [ ${TASK} == "lint" ]; then
     make lint || exit -1

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if ! tests/travis/is_core_changed.sh
+then
+  exit 0
+fi
+
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then
     brew update
     brew tap homebrew/science


### PR DESCRIPTION
Try to avoid running travis-CI if only the doc or examples are modified.

Ready to be merged. Though it still takes at least 2 minutes to run the test because the system is apt-get installing everything.