### PR TITLE
Added parentheses for print statements

### DIFF
--- a/tests/nightly/test_kvstore.py
+++ b/tests/nightly/test_kvstore.py
@@ -17,7 +17,7 @@ data = [[[np.random.random(s)*2-1 for i in range(nworker)] for s in shapes] for 
 
 ## individual key interface
 def test_kvstore(kv_type):
-    print kv_type
+    print(kv_type)
     kv = mx.kv.create(kv_type)
     kv.set_optimizer(mx.optimizer.create('test', lr))
     for k, s in zip(keys, shapes):
@@ -43,7 +43,7 @@ test_kvstore('local_allreduce_device')
 
 ## group keys interface
 def test_group_kvstore(kv_type):
-    print kv_type
+    print(kv_type)
     kv = mx.kv.create(kv_type)
     kv.set_optimizer(mx.optimizer.create('test', lr))
     kv.init(keys, [mx.nd.zeros(s) for s in shapes])


### PR DESCRIPTION
I added parentheses for the `print(kv_type)` statements to fix a failing test case when running the tests under Python 3. It's a minor change that ensures Python 2/3 compatibility. 