### PR TITLE
Add operator ROI pooling

### DIFF
--- a/src/operator/roi_pooling-inl.h
+++ b/src/operator/roi_pooling-inl.h
@@ -1,0 +1,185 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file roi_pooling-inl.h
+ * \brief roi pooling operator and symbol
+ * \author Kye-Hyeon Kim, Jian Guo
+*/
+#ifndef MXNET_OPERATOR_ROI_POOLING_INL_H_
+#define MXNET_OPERATOR_ROI_POOLING_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "./mshadow_op.h"
+#include "./operator_common.h"
+
+
+namespace mxnet {
+namespace op {
+
+// Declare enumeration of input order to make code more intuitive.
+// These enums are only visible within this header
+namespace roipool {
+enum ROIPoolingOpInputs {kData, kBox};
+enum ROIPoolingOpOutputs {kOut, kMaxIdx};
+}  // roipool
+
+struct ROIPoolingParam : public dmlc::Parameter<ROIPoolingParam> {
+  TShape pooled_size;
+  float spatial_scale;
+  DMLC_DECLARE_PARAMETER(ROIPoolingParam) {
+    // TODO(bing) change to only set lower bound
+    // add support for boolean
+    DMLC_DECLARE_FIELD(pooled_size)
+    .set_expect_ndim(2).enforce_nonzero()
+    .describe("target size: (h, w)");
+    DMLC_DECLARE_FIELD(spatial_scale).set_range(0.0, 1.0)
+    .describe("Ratio of input plane height (or w) to raw image height (or w).");
+  }
+};
+
+template<typename xpu>
+class ROIPoolingOp : public Operator {
+ public:
+  explicit ROIPoolingOp(ROIPoolingParam p) {
+    this->param_ = p;
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    // if (req[roipool::kOut] == kNullOp || req[roipool::kMaxIdx] == kNullOp) return;
+    CHECK_EQ(req[roipool::kOut], kWriteTo);
+    // CHECK_EQ(req[roipool::kMaxIdx], kWriteTo);
+    size_t expected = 2;
+    CHECK_EQ(in_data.size(), expected);
+    CHECK_EQ(out_data.size(), expected);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+
+    Tensor<xpu, 4> data = in_data[roipool::kData].get<xpu, 4, real_t>(s);
+    Tensor<xpu, 3> bbox = in_data[roipool::kBox].get<xpu, 3, real_t>(s);
+    Tensor<xpu, 4> out = out_data[roipool::kOut].get<xpu, 4, real_t>(s);
+    Tensor<xpu, 4> max_idx = out_data[roipool::kMaxIdx].get<xpu, 4, real_t>(s);
+
+    ROIPoolForward(out, data, bbox, max_idx, param_.spatial_scale);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    size_t expected = 2;
+    CHECK_EQ(in_data.size(), expected);
+    CHECK_EQ(out_data.size(), expected);
+    CHECK_EQ(out_grad[roipool::kOut].shape_[0], \
+        in_data[roipool::kBox].shape_[0] * in_data[roipool::kBox].shape_[1]);
+    CHECK_EQ(out_data[roipool::kMaxIdx].shape_[0], \
+        in_data[roipool::kBox].shape_[0] * in_data[roipool::kBox].shape_[1]);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+
+    Tensor<xpu, 4> grad_out = out_grad[roipool::kOut].get<xpu, 4, real_t>(s);
+    Tensor<xpu, 3> bbox = in_data[roipool::kBox].get<xpu, 3, real_t>(s);
+    Tensor<xpu, 4> max_idx = out_data[roipool::kMaxIdx].get<xpu, 4, real_t>(s);
+    Tensor<xpu, 4> grad_in = in_grad[roipool::kData].get<xpu, 4, real_t>(s);
+
+    ROIPoolBackward(grad_in, grad_out, bbox, max_idx, param_.spatial_scale);
+  }
+
+ private:
+  ROIPoolingParam param_;
+};  // class ROIPoolingOp
+
+// Decalre Factory function, used for dispatch specialization
+template<typename xpu>
+Operator* CreateOp(ROIPoolingParam param);
+
+#if DMLC_USE_CXX11
+class ROIPoolingProp : public OperatorProperty {
+ public:
+  std::vector<std::string> ListArguments() const override {
+    return {"data", "rois"};
+  }
+
+  std::vector<std::string> ListOutputs() const override {
+    return {"output", "maxidx"};
+  }
+
+  int NumOutputs() const override {
+    return 2;
+  }
+
+  int NumVisibleOutputs() const override {
+    return 1;
+  }
+
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    CHECK_EQ(in_shape->size(), 2) << "Input:[data, rois]";
+
+    // data: [batch_size, c, h, w]
+    TShape dshape = in_shape->at(roipool::kData);
+    CHECK_EQ(dshape.ndim(), 4) << "data should be a 4D tensor";
+
+    // bbox: [num_rois, 5]
+    TShape bshape = in_shape->at(roipool::kBox);
+    CHECK_EQ(bshape.ndim(), 3) << "bbox should be a 3D tensor of shape [batch, rois, 5]";
+    CHECK_EQ(bshape[2], 5) << "bbox should be a 3D tensor of shape [batch, rois, 5]";
+
+    // out: [num_rois, c, pooled_h, pooled_w]
+    // max_idx: [num_rois, c, pooled_h, pooled_w]
+    out_shape->clear();
+    out_shape->push_back(
+         Shape4(bshape[0] * bshape[1], dshape[1], param_.pooled_size[0], param_.pooled_size[1]));
+    out_shape->push_back(
+         Shape4(bshape[0] * bshape[1], dshape[1], param_.pooled_size[0], param_.pooled_size[1]));
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    ROIPoolingProp* roi_pooling_sym = new ROIPoolingProp();
+    roi_pooling_sym->param_ = this->param_;
+    return roi_pooling_sym;
+  }
+
+  std::string TypeString() const override {
+    return "ROIPooling";
+  }
+
+  // decalre dependency and inplace optimization options
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    return {out_grad[roipool::kOut], in_data[roipool::kBox], out_data[roipool::kMaxIdx]};
+  }
+
+  Operator* CreateOperator(Context ctx) const override;
+
+ private:
+  ROIPoolingParam param_;
+};  // class ROIPoolingProp
+#endif
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_ROI_POOLING_INL_H_

--- a/src/operator/roi_pooling.cc
+++ b/src/operator/roi_pooling.cc
@@ -1,0 +1,228 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file roi_pooling.cc
+ * \brief roi pooling operator
+ * \author Ross Girshick, Kye-Hyeon Kim, Jian Guo
+*/
+#include "./roi_pooling-inl.h"
+#include <mshadow/base.h>
+#include <mshadow/tensor.h>
+#include <mshadow/packet-inl.h>
+#include <mshadow/dot_engine-inl.h>
+#include <cassert>
+
+#define DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
+
+using std::max;
+using std::min;
+using std::floor;
+using std::ceil;
+
+namespace mshadow {
+template<typename Dtype>
+inline void ROIPoolForward(const Tensor<cpu, 4, Dtype> &out,
+                           const Tensor<cpu, 4, Dtype> &data,
+                           const Tensor<cpu, 3, Dtype> &bbox,
+                           const Tensor<cpu, 4, Dtype> &max_idx,
+                           const float spatial_scale_) {
+  const Dtype *bottom_data = data.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *top_data = out.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+  const int channels_ = data.size(1);
+  const int height_ = data.size(2);
+  const int width_ = data.size(3);
+  const int pooled_height_ = out.size(2);
+  const int pooled_width_ = out.size(3);
+
+  const int num_rois = bbox.size(0) * bbox.size(1);
+  const int batch_size = data.size(0);
+  const int data_size = data.size(1) * data.size(2) * data.size(3);
+  // For each ROI R = [batch_index x1 y1 x2 y2]: max pool over R
+  for (int n = 0; n < num_rois; ++n) {
+    int roi_batch_ind = bottom_rois[0];
+    int roi_start_w = round(bottom_rois[1] * spatial_scale_);
+    int roi_start_h = round(bottom_rois[2] * spatial_scale_);
+    int roi_end_w = round(bottom_rois[3] * spatial_scale_);
+    int roi_end_h = round(bottom_rois[4] * spatial_scale_);
+    assert(roi_batch_ind >= 0);
+    assert(roi_batch_ind < batch_size);
+
+    // force malformed ROIs to be 1 * 1
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    const Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                             / static_cast<Dtype>(pooled_height_);
+    const Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                             / static_cast<Dtype>(pooled_width_);
+
+    const Dtype* batch_data = bottom_data + data_size * roi_batch_ind;
+
+    for (int c = 0; c < channels_; ++c) {
+      for (int ph = 0; ph < pooled_height_; ++ph) {
+        for (int pw = 0; pw < pooled_width_; ++pw) {
+          // Compute pooling region for this output unit:
+          //  start (included) = floor(ph * roi_height / pooled_height_)
+          //  end (excluded) = ceil((ph + 1) * roi_height / pooled_height_)
+          int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+                                              * bin_size_h));
+          int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+                                              * bin_size_w));
+          int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+                                           * bin_size_h));
+          int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+                                           * bin_size_w));
+
+          hstart = min(max(hstart + roi_start_h, 0), height_);
+          hend = min(max(hend + roi_start_h, 0), height_);
+          wstart = min(max(wstart + roi_start_w, 0), width_);
+          wend = min(max(wend + roi_start_w, 0), width_);
+
+          bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+          const int pool_index = ph * pooled_width_ + pw;
+          if (is_empty) {
+            top_data[pool_index] = 0;
+            argmax_data[pool_index] = -1;
+          }
+
+          for (int h = hstart; h < hend; ++h) {
+            for (int w = wstart; w < wend; ++w) {
+              const int index = h * width_ + w;
+              if (batch_data[index] > top_data[pool_index]) {
+                top_data[pool_index] = batch_data[index];
+                argmax_data[pool_index] = index;
+              }
+            }
+          }
+        }
+      }
+      // Increment all data pointers by one channel
+      batch_data += data.size(2) * data.size(3);
+      top_data += out.size(2) * out.size(3);
+      argmax_data += max_idx.size(2) * max_idx.size(3);
+    }
+    // Increment ROI data pointer
+    bottom_rois += bbox.size(2);
+  }
+
+  return;
+}
+
+template<typename Dtype>
+inline void ROIPoolBackward(const Tensor<cpu, 4, Dtype> &in_grad,
+                            const Tensor<cpu, 4, Dtype> &out_grad,
+                            const Tensor<cpu, 3, Dtype> &bbox,
+                            const Tensor<cpu, 4, Dtype> &max_idx,
+                            const float spatial_scale_) {
+  const Dtype *top_diff = out_grad.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *bottom_diff = in_grad.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+
+  const int batch_size_ = in_grad.size(0);
+  const int channels_ = in_grad.size(1);
+  const int height_ = in_grad.size(2);
+  const int width_ = in_grad.size(3);
+  const int pooled_height_ = out_grad.size(2);
+  const int pooled_width_ = out_grad.size(3);
+
+  const int num_rois = bbox.size(0) * bbox.size(1);
+
+  for (int b = 0; b < batch_size_; ++b) {
+    for (int c = 0; c < channels_; ++c) {
+      for (int h = 0; h < height_; ++h) {
+        for (int w = 0; w < width_; ++w) {
+          int offset_bottom_diff = (b * channels_ + c) * height_ * width_;
+          offset_bottom_diff += h * height_ + w;
+
+          Dtype gradient = 0;
+          // Accumulate gradient over all ROIs that pooled this element
+          for (int roi_n = 0; roi_n < num_rois; ++roi_n) {
+            int roi_batch_ind = bottom_rois[0];
+            assert(roi_batch_ind >= 0);
+            assert(roi_batch_ind < batch_size_);
+            if (b != roi_batch_ind) {
+              continue;
+            }
+
+            int roi_start_w = round(bottom_rois[1] * spatial_scale_);
+            int roi_start_h = round(bottom_rois[2] * spatial_scale_);
+            int roi_end_w = round(bottom_rois[3] * spatial_scale_);
+            int roi_end_h = round(bottom_rois[4] * spatial_scale_);
+
+            bool in_roi = (w >= roi_start_w && w <= roi_end_w &&
+                           h >= roi_start_h && h <= roi_end_h);
+            if (!in_roi) {
+              continue;
+            }
+
+            // force malformed ROIs to be 1 * 1
+            int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+            int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+            const Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                                     / static_cast<Dtype>(pooled_height_);
+            const Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                                     / static_cast<Dtype>(pooled_width_);
+
+            // compute pooled regions correspond to original (h, w) point
+            int phstart = static_cast<int>(floor(static_cast<Dtype>(h - roi_start_h)
+                                                 * bin_size_h));
+            int pwstart = static_cast<int>(floor(static_cast<Dtype>(w - roi_start_w)
+                                                 * bin_size_w));
+            int phend = static_cast<int>(ceil(static_cast<Dtype>(h - roi_start_h + 1)
+                                              * bin_size_h));
+            int pwend = static_cast<int>(ceil(static_cast<Dtype>(w - roi_start_w + 1)
+                                              * bin_size_w));
+
+            // clip to boundaries of pooled region
+            phstart = min(max(phstart, 0), pooled_height_);
+            phend = min(max(phend, 0), pooled_height_);
+            pwstart = min(max(pwstart, 0), pooled_width_);
+            pwend = min(max(pwend, 0), pooled_width_);
+
+            // accumulate over gradients in pooled regions
+            int offset = (roi_n * channels_ + c) * pooled_height_ * pooled_width_;
+            const Dtype* offset_top_diff = top_diff + offset;
+            const Dtype* offset_argmax_data = argmax_data + offset;
+            for (int ph = phstart; ph < phend; ++ph) {
+              for (int pw = pwstart; pw < pwend; ++pw) {
+                const int pooled_index = ph * pooled_width_ + pw;
+                if (h * width_ + w == round(offset_argmax_data[pooled_index])) {
+                  gradient += offset_top_diff[pooled_index];
+                }
+              }
+            }
+
+            // Increment ROI data pointer
+            bottom_rois += bbox.size(2);
+          }
+          bottom_diff[offset_bottom_diff] = gradient;
+        }
+      }
+    }
+  }
+}
+}  // namespace mshadow
+
+namespace mxnet {
+namespace op {
+
+template<>
+Operator* CreateOp<cpu>(ROIPoolingParam param) {
+  return new ROIPoolingOp<cpu>(param);
+}
+
+// DO_BIND_DISPATCH comes from static_operator_common.h
+Operator* ROIPoolingProp::CreateOperator(Context ctx) const {
+  DO_BIND_DISPATCH(CreateOp, param_);
+}
+
+DMLC_REGISTER_PARAMETER(ROIPoolingParam);
+
+MXNET_REGISTER_OP_PROPERTY(ROIPooling, ROIPoolingProp)
+.describe("Resize regions of interest in an input plane to a fixed size by MAX pooling.")
+.add_argument("data", "Symbol[]", "[input tensor, regions of interest]")
+.add_arguments(ROIPoolingParam::__FIELDS__());
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/roi_pooling.cu
+++ b/src/operator/roi_pooling.cu
@@ -1,0 +1,259 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file roi_pooling.cu
+ * \brief roi pooling operator
+ * \author Ross Girshick, Kye-Hyeon Kim, Jian Guo
+*/
+#include "./roi_pooling-inl.h"
+#include <mshadow/tensor.h>
+#include <mshadow/cuda/reduce.cuh>
+#include <algorithm>
+#include <vector>
+
+#define FRCNN_CUDA_CHECK(condition) \
+  /* Code block avoids redefinition of cudaError_t error */ \
+  do { \
+    cudaError_t error = condition; \
+    CHECK_EQ(error, cudaSuccess) << " " << cudaGetErrorString(error); \
+  } while (0)
+
+#define FRCNN_DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
+#define FRCNN_NUM_THREADS 1024
+
+namespace mshadow {
+namespace cuda {
+
+template<typename Dtype>
+__global__ void ROIPoolForwardKernel(const int count, const Dtype* bottom_data,
+                                     const float spatial_scale, const int channels,
+                                     const int height, const int width,
+                                     const int pooled_height, const int pooled_width,
+                                     const Dtype* bottom_rois, Dtype* top_data,
+                                     Dtype* argmax_data) {
+  for (int index = blockIdx.x * blockDim.x + threadIdx.x;
+       index < count;
+       index += blockDim.x * gridDim.x) {
+    // (n, c, ph, pw) is an element in the pooled output
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
+
+    bottom_rois += n * 5;
+    int roi_batch_ind = bottom_rois[0];
+
+    if (roi_batch_ind < 0) {
+      top_data[index] = 0;
+      argmax_data[index] = 0;
+      continue;
+    }
+
+    int roi_start_w = round(bottom_rois[1] * spatial_scale);
+    int roi_start_h = round(bottom_rois[2] * spatial_scale);
+    int roi_end_w = round(bottom_rois[3] * spatial_scale);
+    int roi_end_h = round(bottom_rois[4] * spatial_scale);
+
+    // Force malformed ROIs to be 1x1
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                       / static_cast<Dtype>(pooled_height);
+    Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                       / static_cast<Dtype>(pooled_width);
+
+    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+                                        * bin_size_h));
+    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+                                        * bin_size_w));
+    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+                                     * bin_size_h));
+    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+                                     * bin_size_w));
+
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, 0), height);
+    hend = min(max(hend + roi_start_h, 0), height);
+    wstart = min(max(wstart + roi_start_w, 0), width);
+    wend = min(max(wend + roi_start_w, 0), width);
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+    // Define an empty pooling region to be zero
+    Dtype maxval = is_empty ? 0 : -FLT_MAX;
+    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+    int maxidx = -1;
+    bottom_data += (roi_batch_ind * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        int bottom_index = h * width + w;
+        if (bottom_data[bottom_index] > maxval) {
+          maxval = bottom_data[bottom_index];
+          maxidx = bottom_index;
+        }
+      }
+    }
+    top_data[index] = maxval;
+    argmax_data[index] = (Dtype)maxidx;
+  }
+}
+
+template<typename Dtype>
+inline void ROIPoolForward(const Tensor<gpu, 4, Dtype> &out,
+                           const Tensor<gpu, 4, Dtype> &data,
+                           const Tensor<gpu, 3, Dtype> &bbox,
+                           const Tensor<gpu, 4, Dtype> &max_idx,
+                           const float spatial_scale) {
+  const Dtype *bottom_data = data.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *top_data = out.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+  const int count = out.shape_.Size();
+  const int channels = data.size(1);
+  const int height = data.size(2);
+  const int width = data.size(3);
+  const int pooled_height = out.size(2);
+  const int pooled_width = out.size(3);
+  dim3 dimGrid((count + FRCNN_NUM_THREADS - 1) / FRCNN_NUM_THREADS);
+  dim3 dimBlock(FRCNN_NUM_THREADS);
+  CheckLaunchParam(dimGrid, dimBlock, "ROIPooling Forward");
+  cudaStream_t stream = Stream<gpu>::GetStream(out.stream_);
+  ROIPoolForwardKernel<Dtype><<<dimGrid, dimBlock, 0, stream>>>(
+      count, bottom_data, spatial_scale, channels, height, width,
+      pooled_height, pooled_width, bottom_rois, top_data, argmax_data);
+  FRCNN_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+template<typename Dtype>
+__global__ void ROIPoolBackwardKernel(const int count, const Dtype* top_diff,
+                                      const Dtype* argmax_data, const int num_rois,
+                                      const float spatial_scale, const int channels,
+                                      const int height, const int width,
+                                      const int pooled_height, const int pooled_width,
+                                      Dtype* bottom_diff, const Dtype* bottom_rois) {
+  for (int index = blockIdx.x * blockDim.x + threadIdx.x;
+       index < count;
+       index += blockDim.x * gridDim.x) {
+    // (n, c, h, w) coords in bottom data
+    int w = index % width;
+    int h = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+
+    Dtype gradient = 0;
+    // Accumulate gradient over all ROIs that pooled this element
+    for (int roi_n = 0; roi_n < num_rois; ++roi_n) {
+      const Dtype* offset_bottom_rois = bottom_rois + roi_n * 5;
+      int roi_batch_ind = offset_bottom_rois[0];
+      // Skip if ROI's batch index doesn't match n
+      if (n != roi_batch_ind) {
+        continue;
+      }
+
+      int roi_start_w = round(offset_bottom_rois[1] * spatial_scale);
+      int roi_start_h = round(offset_bottom_rois[2] * spatial_scale);
+      int roi_end_w = round(offset_bottom_rois[3] * spatial_scale);
+      int roi_end_h = round(offset_bottom_rois[4] * spatial_scale);
+
+      // Skip if ROI doesn't include (h, w)
+      const bool in_roi = (w >= roi_start_w && w <= roi_end_w &&
+                           h >= roi_start_h && h <= roi_end_h);
+      if (!in_roi) {
+        continue;
+      }
+
+      int offset = (roi_n * channels + c) * pooled_height * pooled_width;
+      const Dtype* offset_top_diff = top_diff + offset;
+      const Dtype* offset_argmax_data = argmax_data + offset;
+
+      // Compute feasible set of pooled units that could have pooled
+      // this bottom unit
+
+      // Force malformed ROIs to be 1x1
+      int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+      int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+
+      Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                         / static_cast<Dtype>(pooled_height);
+      Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                         / static_cast<Dtype>(pooled_width);
+
+      int phstart = floor(static_cast<Dtype>(h - roi_start_h) / bin_size_h);
+      int phend = ceil(static_cast<Dtype>(h - roi_start_h + 1) / bin_size_h);
+      int pwstart = floor(static_cast<Dtype>(w - roi_start_w) / bin_size_w);
+      int pwend = ceil(static_cast<Dtype>(w - roi_start_w + 1) / bin_size_w);
+
+      phstart = min(max(phstart, 0), pooled_height);
+      phend = min(max(phend, 0), pooled_height);
+      pwstart = min(max(pwstart, 0), pooled_width);
+      pwend = min(max(pwend, 0), pooled_width);
+
+      for (int ph = phstart; ph < phend; ++ph) {
+        for (int pw = pwstart; pw < pwend; ++pw) {
+          if (round(offset_argmax_data[ph * pooled_width + pw]) == (h * width + w)) {
+            gradient += offset_top_diff[ph * pooled_width + pw];
+          }
+        }
+      }
+    }
+    bottom_diff[index] = gradient;
+  }
+}
+
+template<typename Dtype>
+inline void ROIPoolBackward(const Tensor<gpu, 4, Dtype> &in_grad,
+                            const Tensor<gpu, 4, Dtype> &out_grad,
+                            const Tensor<gpu, 3, Dtype> &bbox,
+                            const Tensor<gpu, 4, Dtype> &max_idx,
+                            const float spatial_scale) {
+  const Dtype *top_diff = out_grad.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *bottom_diff = in_grad.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+  const int count = in_grad.shape_.Size();
+  const int num_rois = bbox.size(0);
+  const int channels = in_grad.size(1);
+  const int height = in_grad.size(2);
+  const int width = in_grad.size(3);
+  const int pooled_height = out_grad.size(2);
+  const int pooled_width = out_grad.size(3);
+  dim3 dimGrid((count + FRCNN_NUM_THREADS - 1) / FRCNN_NUM_THREADS);
+  dim3 dimBlock(FRCNN_NUM_THREADS);
+  CheckLaunchParam(dimGrid, dimBlock, "ROIPooling Backward");
+  cudaStream_t stream = Stream<gpu>::GetStream(in_grad.stream_);
+  ROIPoolBackwardKernel<Dtype><<<dimGrid, dimBlock, 0, stream>>>(
+      count, top_diff, argmax_data, num_rois, spatial_scale, channels, height, width,
+      pooled_height, pooled_width, bottom_diff, bottom_rois);
+  FRCNN_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+}  // namespace cuda
+
+template<typename Dtype>
+inline void ROIPoolForward(const Tensor<gpu, 4, Dtype> &out,
+                           const Tensor<gpu, 4, Dtype> &data,
+                           const Tensor<gpu, 3, Dtype> &bbox,
+                           const Tensor<gpu, 4, Dtype> &max_idx,
+                           const float spatial_scale) {
+  cuda::ROIPoolForward(out, data, bbox, max_idx, spatial_scale);
+}
+
+template<typename Dtype>
+inline void ROIPoolBackward(const Tensor<gpu, 4, Dtype> &in_grad,
+                            const Tensor<gpu, 4, Dtype> &out_grad,
+                            const Tensor<gpu, 3, Dtype> &bbox,
+                            const Tensor<gpu, 4, Dtype> &max_idx,
+                            const float spatial_scale) {
+  cuda::ROIPoolBackward(in_grad, out_grad, bbox, max_idx, spatial_scale);
+}
+
+}  // namespace mshadow
+
+
+namespace mxnet {
+namespace op {
+
+template<>
+Operator* CreateOp<gpu>(ROIPoolingParam param) {
+  return new ROIPoolingOp<gpu>(param);
+}
+}  // namespace op
+}  // namespace mxnet


### PR DESCRIPTION
ROI Pooling projects bounding box proposals from data input layer to internal layer and pools to a manually set output size. As suggested in the reply from [mshadow pull request 113](https://github.com/dmlc/mshadow/pull/113), I moved kernel functions of ROI pooling from mshadow to mxnet.
Note that this still remains a naive port from caffe. Any suggestions to improve this implementation is welcome.