### PR TITLE
add ignore_label support for 2D softmax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 doc/html
 doc/latex
 doc/doc
+docs/web-data
 
 #dmlc
 config.mk
@@ -103,3 +104,4 @@ scala-package/*/*/target/
 *.classpath
 *.project
 *.settings
+


### PR DESCRIPTION
Allow standard softmax to use `ignore_label` (useful for dealing with padding in bucketing sequences).

Require dmlc/mshadow#114