### PR TITLE
small fix to batchnorm

### DIFF
--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -40,7 +40,7 @@ class Initializer(object):
         elif name.endswith("moving_mean"):
             self._init_zero(name, arr)
         elif name.endswith("moving_var"):
-            self._init_zero(name, arr)
+            self._init_one(name, arr)
         elif name.endswith("moving_inv_var"):
             self._init_zero(name, arr)
         elif name.endswith("moving_avg"):
@@ -61,6 +61,9 @@ class Initializer(object):
 
     def _init_zero(self, _, arr):
         arr[:] = 0.0
+
+    def _init_one(self, _, arr):
+        arr[:] = 1.0
 
     def _init_bias(self, _, arr):
         arr[:] = 0.0

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -115,7 +115,7 @@ class CuDNNBatchNormOp : public Operator {
                                                       mean_desc_,
                                                       gamma.dptr_,
                                                       beta.dptr_,
-                                                      param_.momentum,
+                                                      1 - param_.momentum,
                                                       moving_mean.dptr_,
                                                       moving_inv_var.dptr_,
                                                       param_.eps,


### PR DESCRIPTION
1. cudnn's exponentialAverageFactor is 1-momentum
2. initialize moving_var with 1 as is in https://github.com/torch/nn/blob/master/BatchNormalization.lua#L54