### PR TITLE
Add operator Smooth L1 Loss

### DIFF
--- a/src/operator/make_loss-inl.h
+++ b/src/operator/make_loss-inl.h
@@ -48,10 +48,12 @@ class MakeLossOp : public Operator {
     CHECK_EQ(out_data.size(), 1);
     CHECK_EQ(in_data[make_loss_enum::kData].ndim(), 2)
     << "MakeLoss applies to all unary and binary operator with 2 dimension input";
-    Stream<xpu> *s = ctx.get_stream<xpu>();
-    Tensor<xpu, 2> data = in_data[make_loss_enum::kData].get<xpu, 2, real_t>(s);
-    Tensor<xpu, 2> out = out_data[make_loss_enum::kOut].get<xpu, 2, real_t>(s);
-    Assign(out, req[make_loss_enum::kData], F<mshadow_op::identity>(data));
+    if (req[make_loss_enum::kOut] != kWriteInplace) {
+      Stream<xpu> *s = ctx.get_stream<xpu>();
+      Tensor<xpu, 2> data = in_data[make_loss_enum::kData].get<xpu, 2, real_t>(s);
+      Tensor<xpu, 2> out = out_data[make_loss_enum::kOut].get<xpu, 2, real_t>(s);
+      Assign(out, req[make_loss_enum::kOut], data);
+    }
   }
 
   virtual void Backward(const OpContext &ctx,

--- a/src/operator/make_loss-inl.h
+++ b/src/operator/make_loss-inl.h
@@ -1,0 +1,134 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file make_loss-inl.h
+ * \brief special layer for propagating loss
+*/
+#ifndef MXNET_OPERATOR_MAKE_LOSS_INL_H_
+#define MXNET_OPERATOR_MAKE_LOSS_INL_H_
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+#include <utility>
+#include "./mshadow_op.h"
+#include "./operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+namespace make_loss_enum {
+enum MakeLossOpInputs {kData};
+enum MakeLossOpOutputs {kOut};
+}  // namespace make_loss_enum
+
+struct MakeLossParam : public dmlc::Parameter<MakeLossParam> {
+  float grad_scale;
+  DMLC_DECLARE_PARAMETER(MakeLossParam) {
+    DMLC_DECLARE_FIELD(grad_scale).set_default(1.0f)
+    .describe("gradient scale as a supplement to unary and binary operators");
+  }
+};
+
+template<typename xpu>
+class MakeLossOp : public Operator {
+ public:
+  explicit MakeLossOp(MakeLossParam param) : param_(param) {}
+
+  virtual void Forward(const OpContext &ctx,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 1) << "MakeLoss can only be used to one input";
+    CHECK_EQ(out_data.size(), 1);
+    CHECK_EQ(in_data[make_loss_enum::kData].ndim(), 2)
+    << "MakeLoss applies to all unary and binary operator with 2 dimension input";
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    Tensor<xpu, 2> data = in_data[make_loss_enum::kData].get<xpu, 2, real_t>(s);
+    Tensor<xpu, 2> out = out_data[make_loss_enum::kOut].get<xpu, 2, real_t>(s);
+    Assign(out, req[make_loss_enum::kData], F<mshadow_op::identity>(data));
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    Tensor<xpu, 2> grad = in_grad[make_loss_enum::kData].get<xpu, 2, real_t>(s);
+    Assign(grad, req[make_loss_enum::kData], ScalarExp<real_t>(param_.grad_scale));
+  }
+
+ private:
+  MakeLossParam param_;
+};  // class MakeLossOp
+
+template <typename xpu>
+Operator *CreateOp(MakeLossParam param);
+
+#if DMLC_USE_CXX11
+class MakeLossProp : public OperatorProperty {
+ public:
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  };
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    CHECK_EQ(in_shape->size(), 1);
+    const TShape &dshape = in_shape->at(make_loss_enum::kData);
+    if (dshape.ndim() == 0) return false;
+    out_shape->clear();
+    out_shape->push_back(dshape);
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new MakeLossProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "MakeLoss";
+  }
+
+  std::vector<int> DeclareBackwardDependency(
+      const std::vector<int> &out_grad,
+      const std::vector<int> &in_data,
+      const std::vector<int> &out_data) const override {
+    return {};
+  }
+
+  std::vector<std::pair<int, void*> > ForwardInplaceOption(
+      const std::vector<int> &in_data,
+      const std::vector<void*> &out_data) const override {
+    return {{in_data[make_loss_enum::kData], out_data[make_loss_enum::kOut]}};
+  }
+
+  Operator* CreateOperator(Context ctx) const override;
+
+ private:
+  MakeLossParam param_;
+};  // class MakeLossProperty
+
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_MAKE_LOSS_INL_H_

--- a/src/operator/make_loss.cc
+++ b/src/operator/make_loss.cc
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file make_loss.cc
+ * \brief special layer for propagating loss
+*/
+#include "./make_loss-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<cpu>(MakeLossParam param) {
+  return new MakeLossOp<cpu>(param);
+}
+
+Operator *MakeLossProp::CreateOperator(Context ctx) const {
+  DO_BIND_DISPATCH(CreateOp, param_);
+}
+
+DMLC_REGISTER_PARAMETER(MakeLossParam);
+
+MXNET_REGISTER_OP_PROPERTY(MakeLoss, MakeLossProp)
+.describe("Get output from a symbol and pass 1 gradient back. "
+"This is used as a terminal loss if unary and binary operator "
+"are used to composite a loss with no declaration of backward "
+"dependency")
+.add_argument("data", "Symbol", "Input data.")
+.add_arguments(MakeLossParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/make_loss.cu
+++ b/src/operator/make_loss.cu
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file make_loss.cu
+ * \brief special layer for propagating loss
+*/
+#include "./make_loss-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator *CreateOp<gpu>(MakeLossParam param) {
+  return new MakeLossOp<gpu>(param);
+}
+
+}  // namespace op
+}  // namespace mxnet
+

--- a/src/operator/smooth_l1_unary-inl.h
+++ b/src/operator/smooth_l1_unary-inl.h
@@ -1,0 +1,115 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file smooth_l1_unary-inl.h
+ * \brief Smooth L1 loss
+*/
+#ifndef MXNET_OPERATOR_SMOOTH_L1_UNARY_INL_H_
+#define MXNET_OPERATOR_SMOOTH_L1_UNARY_INL_H_
+
+#include <mxnet/operator_util.h>
+#include "./mshadow_op.h"
+
+#if defined(__CUDACC__)
+#define XPU gpu
+#else
+#define XPU cpu
+#endif
+
+namespace mxnet {
+namespace op {
+
+namespace mshadow_op {
+/* Smooth L1 Loss is a loss specific for R-CNN franchise training
+ * Smooth L1 Loss function
+ * f(x) = 0.5 * (sigma * x) ^ 2,     x < 1 / sigma^2
+ *      = |x| - 0.5 / sigma / sigma, otherwise
+ * When sigma = 1, it is equivalent to Huber Loss evaluated at
+ * delta = 1.
+ * smooth_l1_loss = w_out * f(w_in * x)
+ * with w_in, w_out provided by input_data.
+ */
+struct smooth_l1_loss {
+  // a is x, b is sigma2
+  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
+    if (a > 1.0f / b) {
+      return a - 0.5f / b;
+    } else if (a < -1.0f / b) {
+      return -a - 0.5f / b;
+    } else {
+      return 0.5f * a * a * b;
+    }
+  }
+};  // struct smooth_l1_loss
+
+/* The derivative of smooth l1 loss is
+ * f'(x) = sigma^2 * x, x < 1 / sigma^2
+ *       = sign(x),     otherwise
+ */
+struct smooth_l1_gradient {
+  // a is x, b is sigma2
+  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
+    if (a > 1.0f / b) {
+      return 1.0f;
+    } else if (a < -1.0f / b) {
+      return -1.0f;
+    } else {
+      return b * a;
+    }
+  }
+};  // struct smooth_l1_derivative
+}  // namespace mshadow_op
+
+template<typename xpu>
+void SmoothL1Forward_(const TBlob& src,
+                      const EnvArguments& env,
+                      TBlob *ret,
+                      OpReqType req,
+                      RunContext ctx) {
+  using namespace mshadow;
+  using namespace mshadow::expr;
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  CHECK_EQ(ret->type_flag_, src.type_flag_)
+    << "Unary function only support input/output with the same type";
+  real_t sigma2 = env.scalar * env.scalar;
+  MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+    mshadow::Tensor<xpu, 2, DType> out = ret->get<xpu, 2, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> in = src.get<xpu, 2, DType>(s);
+    ASSIGN_DISPATCH(out, req,
+                    F<mshadow_op::smooth_l1_loss>(in, ScalarExp<DType>(sigma2)));
+  });
+}
+
+template<typename xpu>
+void SmoothL1BackwardUseIn_(const OutputGrad& out_grad,
+                            const Input0& in_data0,
+                            const EnvArguments& env,
+                            TBlob *in_grad,
+                            OpReqType req,
+                            RunContext ctx) {
+  using namespace mshadow;
+  using namespace mshadow::expr;
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  CHECK_EQ(in_grad->type_flag_, out_grad.data.type_flag_)
+    << "Unary function only support input/output with the same type";
+  CHECK_EQ(in_grad->type_flag_, in_data0.data.type_flag_)
+    << "Unary function only support input/output with the same type";
+  real_t sigma2 = env.scalar * env.scalar;
+  MSHADOW_TYPE_SWITCH(in_grad->type_flag_, DType, {
+    mshadow::Tensor<xpu, 2, DType> src = in_data0.data.get<xpu, 2, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> ograd = out_grad.data.get<xpu, 2, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> igrad = in_grad->get<xpu, 2, DType>(s);
+    ASSIGN_DISPATCH(igrad, req,
+                    ograd * F<mshadow_op::smooth_l1_gradient>(src, ScalarExp<DType>(sigma2)));
+  });
+}
+
+MXNET_REGISTER_SIMPLE_OP(smooth_l1, XPU)
+.set_function(XPU::kDevMask, SmoothL1Forward_<XPU>, kInplaceInOut)
+.set_gradient(XPU::kDevMask, SmoothL1BackwardUseIn_<XPU>, kInplaceOutIn)
+.set_enable_scalar(true)
+.describe("Calculate Smooth L1 Loss(lhs, scalar)");
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_SMOOTH_L1_UNARY_INL_H_

--- a/src/operator/smooth_l1_unary.cc
+++ b/src/operator/smooth_l1_unary.cc
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file smooth_l1_unary.cc
+ * \brief Smooth L1 loss
+*/
+#include "./smooth_l1_unary-inl.h"

--- a/src/operator/smooth_l1_unary.cu
+++ b/src/operator/smooth_l1_unary.cu
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file smooth_l1.cu
+ * \brief Smooth L1 loss
+*/
+#include "./smooth_l1_unary-inl.h"


### PR DESCRIPTION
Smooth L1 Loss is a loss first introduced in Fast R-CNN, which is a compromise of l1 and l2 losses. Parameter `sigma` is related to the turning point from square to linear. In default state `num_args` will be set as `2`, stating that only `data` and `target` are supplied to this loss function. For a more direct comparison with original caffe version, this implementation also supports two additional inputs:  `inside_weight` which scales input data and `outside_weight` which scales output loss.