### PR TITLE
Fix c_api for ListAttr

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -651,12 +651,18 @@ int MXSymbolListAttr(SymbolHandle symbol,
   MXAPIThreadLocalEntry *ret = MXAPIThreadLocalStore::Get();
   API_BEGIN();
   std::map<std::string, std::string> attr = std::move(s->ListAttr());
-  ret->ret_vec_charp.clear();
+  std::vector<std::string> attrList;
   *out_size = 0;
   for (auto it : attr) {
-    ret->ret_vec_charp.push_back(it.first.c_str());
-    ret->ret_vec_charp.push_back(it.second.c_str());
+    attrList.push_back(it.first);
+    attrList.push_back(it.second);
     (*out_size)++;
+  }
+
+  ret->ret_vec_str = std::move(attrList);
+  ret->ret_vec_charp.clear();
+  for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
+    ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());
   }
   *out = dmlc::BeginPtr(ret->ret_vec_charp);
   API_END();


### PR DESCRIPTION
The pointers stored in ret_vec_charp need to be managed by ret itself,
otherwise they are not going to be accessible by clients.

I noticed this while wrapping ListAttr for Julia.