### PR TITLE
Modifications when batch_size of data and label are not the same

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -37,6 +37,7 @@ class DataIter(object):
 
     def __init__(self):
         self.batch_size = 0
+        self.batch_size_of_label = None
 
     def __iter__(self):
         return self

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -759,7 +759,7 @@ class FeedForward(BASE_ESTIMATOR):
 
         # init optmizer
         if isinstance(self.optimizer, str):
-            batch_size = data.batch_size
+            batch_size = data.batch_size if data.batch_size_of_label is None else data.batch_size_of_label
             if kvstore and kvstore.type == 'dist_sync':
                 batch_size *= kvstore.num_workers
             optimizer = opt.create(self.optimizer,


### PR DESCRIPTION
Modifications for the python training code, when the of the batch_size of input data and label are not the same. Related to issue [#214](https://github.com/dmlc/mxnet/issues/214). Modifications for fast-rcnn training.

For now we can call `model.fit(X=your_data_iter)` to train the network where `your_data_iter` has different batch_size for the image and label.