### PR TITLE
Replaced iteritems() with items() for Python 2/3 compatibility

### DIFF
--- a/example/rnn/bucket_io.py
+++ b/example/rnn/bucket_io.py
@@ -57,7 +57,7 @@ def default_gen_buckets(sentences, batch_size, the_vocab):
 
     tl = 0
     buckets = []
-    for l, n in len_dict.iteritems(): # TODO: There are better heuristic ways to do this    
+    for l, n in len_dict.items(): # TODO: There are better heuristic ways to do this    
         if n + tl >= batch_size:
             buckets.append(l)
             tl = 0

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -244,7 +244,7 @@ class BaseModule(object):
                 break
             self.forward(eval_batch, is_train=False)
             pad = eval_batch.pad
-            outputs = [out[0:out.shape[0]-pad] for out in self.get_outputs()]
+            outputs = [out[0:out.shape[0]-pad].asnumpy() for out in self.get_outputs()]
 
             output_list.append(outputs)
 

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -177,10 +177,10 @@ class Module(BaseModule):
             else:
                 initializer(name, arr)
 
-        for name, arr in self._arg_params.iteritems():
+        for name, arr in self._arg_params.items():
             _impl(name, arr, arg_params)
 
-        for name, arr in self._aux_params.iteritems():
+        for name, arr in self._aux_params.items():
             _impl(name, arr, aux_params)
 
         self.params_initialized = True

--- a/tools/accnn/accnn.py
+++ b/tools/accnn/accnn.py
@@ -29,10 +29,10 @@ else:
 
 new_model = model
 Args = collections.namedtuple('ConvArgs', 'layer K')
-for layer, K in args.config['conv_params'].iteritems():
+for layer, K in args.config['conv_params'].items():
   arg = Args(layer=layer, K=K)  
   new_model = acc_conv.conv_vh_decomposition(new_model, arg)
-for layer, K in args.config['fc_params'].iteritems():
+for layer, K in args.config['fc_params'].items():
   arg = Args(layer=layer, K=K)  
   new_model = acc_fc.fc_decomposition(new_model, arg)
 new_model.save(args.save_model, 1)

--- a/tools/accnn/rank_selection.py
+++ b/tools/accnn/rank_selection.py
@@ -58,7 +58,7 @@ def get_ranksel(model, ratio):
   for i in xrange(n):
     dp[nxt] = {}    
     sys.stdout.flush()
-    for now_c, now_v in dp[now].iteritems():
+    for now_c, now_v in dp[now].items():
       for d in xrange(min(len(S[i]), D[i])):
         nxt_c = now_c + (d+1)*C[i][0]
         if nxt_c > EC:
@@ -74,7 +74,7 @@ def get_ranksel(model, ratio):
     now, nxt = nxt, now    
   maxv = -1e9
   target_c = 0
-  for c,v in dp[now].iteritems():
+  for c,v in dp[now].items():
     assert c <= EC, 'False'    
     if v > maxv:
       maxv = v

--- a/tools/accnn/utils.py
+++ b/tools/accnn/utils.py
@@ -41,7 +41,7 @@ def sym_factory(node, data):
   name = node['name']
   params = {}
   if 'param' in node:    
-    for k, v in node['param'].iteritems():
+    for k, v in node['param'].items():
       try:
         params[k] = ast.literal_eval(v)
       except ValueError, e:


### PR DESCRIPTION
A fix for #1976, using `items()` instead of `iteritems()` because it's the easiest change to make for Python 2/3 compatibility.