### PR TITLE
Fix for bug #1457 in convolution operator with dilate > 2

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -113,7 +113,7 @@ class ConvolutionOp : public Operator {
                                     param_.dilate[1]);
       } else {
         temp_col = unpack_patch2col(pad(data.Slice(i, i + step),
-                                        param_.pad[0], param_.pad[1]),
+                                    param_.pad[0], param_.pad[1]),
                                     param_.kernel[0],
                                     param_.kernel[1],
                                     param_.stride[0],
@@ -121,6 +121,7 @@ class ConvolutionOp : public Operator {
                                     param_.dilate[0],
                                     param_.dilate[1]);
       }
+
       const index_t gstride = temp_col.size(0) / param_.num_group;
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
         mshadow::Tensor<xpu, 2> tmpc = temp_col.Slice(gstride * gid,
@@ -338,9 +339,9 @@ class ConvolutionProp : public OperatorProperty {
         << "kernel size exceed input";
     (*out_shape)[conv::kOut][1] = param_.num_filter;
     (*out_shape)[conv::kOut][2] = (dshape[2] + 2 * param_.pad[0] -
-        (param_.dilate[0] == 1 ? ksize_y : ksize_y * param_.dilate[0] - 1)) / param_.stride[0] + 1;
+        (param_.dilate[0] * (ksize_y - 1) + 1 )) / param_.stride[0] + 1;
     (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] -
-        (param_.dilate[1] == 1 ? ksize_x : ksize_x * param_.dilate[1] - 1)) / param_.stride[1] + 1;
+        (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1] + 1;
     return true;
   }
 

--- a/src/operator/convolution.cu
+++ b/src/operator/convolution.cu
@@ -15,7 +15,11 @@ namespace op {
 template<>
 Operator* CreateOp<gpu>(ConvolutionParam param) {
 #if MXNET_USE_CUDNN == 1
-  return new CuDNNConvolutionOp(param);
+  if (param.dilate[0]==1 && param.dilate[1]==1) {
+	  return new CuDNNConvolutionOp(param);
+  } else {
+	  return new ConvolutionOp<gpu>(param);
+  }
 #else
   return new ConvolutionOp<gpu>(param);
 #endif // MXNET_USE_CUDNN

--- a/tests/python/unittest/test_convolution_dilate.py
+++ b/tests/python/unittest/test_convolution_dilate.py
@@ -1,0 +1,93 @@
+import numpy as np
+import mxnet as mx
+
+def test_impulse_response(dil=(1,1), kernel_shape=(3,3), verbose=False):
+    # Input for spike response
+    spike_imgs = np.zeros(shape=(1,1,33,33), dtype=np.float32)
+    spike_imgs[0,0,16,16] = 1.0
+    spike_img = mx.nd.array(spike_imgs)
+    spike_img2 = mx.nd.array(spike_imgs)
+
+
+    kernel_weights = mx.nd.ones(shape=tuple([1,1]+list(kernel_shape)), dtype=np.float32)
+    kernel_weights2 = mx.nd.ones(shape=tuple([1,1]+list(kernel_shape)), dtype=np.float32)
+
+    kernel = mx.symbol.Variable('kernel')
+    in_img = mx.symbol.Variable('input')
+    net = mx.symbol.Convolution(in_img, num_filter=1,kernel=kernel_shape, dilate=dil, no_bias="true", name='test_convolution')
+    net.list_arguments()
+    be = net.bind(mx.cpu(), args={ 'input' : spike_img, 'test_convolution_weight' : kernel_weights},
+                args_grad={'input' : spike_img2, 'test_convolution_weight' : kernel_weights2 } )
+    be.forward(True)
+    out_o = be.outputs[0].asnumpy()
+    ndo = be.outputs[0]
+    
+    out_grads = np.zeros(shape=be.outputs[0].shape, dtype=np.float32)
+    out_grads[0,0, 16,16] = 1.0
+    out_grad = mx.nd.array(out_grads)
+    be.backward([out_grad])
+    vgrad = be.grad_arrays[0].asnumpy()
+    out = out_o.reshape((out_o.shape[2],out_o.shape[3]))
+    nzx,nzy = np.nonzero(out)
+    assert(np.sum(out)==np.prod(kernel_shape))
+    assert(np.sum(vgrad)==np.prod(kernel_shape))
+
+    if (verbose):
+	    print "Output Shape = %d,%d" % (be.outputs[0].shape[2],be.outputs[0].shape[3] )
+	    print "Impulse Response for convolution with kernel shape %d, %d, dilate=%d,%d - Output Size: %d, %d" % (kernel_shape[0],kernel_shape[1], dil[0], dil[1], out.shape[0], out.shape[1])
+	    for i in range(len(nzx)):
+        	print "(%d,%d)=%f" % (nzx[i],nzy[i], out[nzx[i], nzy[i]])
+    if (verbose):
+	    np.set_printoptions(threshold=1000000)
+	    print "Input Inverse Impulse Response for convolution with kernel shape %d, %d, dilate=%d,%d - Output Size: %d, %d" % (kernel_shape[0],kernel_shape[1], dil[0], dil[1], vgrad.shape[2], vgrad.shape[3])
+	    for i in range(vgrad.shape[2]):
+		for j in range(vgrad.shape[3]):
+			if (vgrad[0,0,i,j]!=0.0):
+				print "(%d,%d)=%f" % (i,j,vgrad[0,0,i,j] )
+
+    # Now check whether the input gradient was computed correctly
+    input_grad = mx.nd.array(vgrad)
+
+    be = net.bind(mx.cpu(), args={ 'input' : input_grad, 'test_convolution_weight' : kernel_weights})
+    be.forward(True)
+    out_o = be.outputs[0].asnumpy()
+    assert(out_o[0,0,16,16]==np.prod(kernel_shape))
+
+    rnd_kernel_s = np.random.uniform(low=0.0, high=1.0, size=tuple([1,1]+list(kernel_shape))).astype(np.float32)
+    impulse_error = mx.nd.array(out_o/np.sum(out_o)) # This should be 1.0 at [0,0,16,16]
+    rnd_kernel = mx.nd.array(rnd_kernel_s)
+
+    rnd_kernel2 = mx.nd.array(rnd_kernel_s)
+    white_in = mx.nd.ones(shape=(1,1,33,33))
+    white_in2 = mx.nd.ones(shape=(1,1,33,33))
+
+    be = net.bind(mx.cpu(), args={ 'input' : white_in, 'test_convolution_weight' : rnd_kernel},
+                args_grad={'input' : white_in2, 'test_convolution_weight' : rnd_kernel2 } )
+
+    be.forward(True)
+    be.backward([impulse_error])
+    out_orig = be.outputs[0].asnumpy()
+    kernel_gradient = be.grad_arrays[1].asnumpy()
+    
+    dkernel = mx.nd.array(rnd_kernel_s + kernel_gradient)
+
+    be = net.bind(mx.cpu(), args={ 'input' : white_in, 'test_convolution_weight' : dkernel})
+
+    be.forward(True)
+    out = be.outputs[0].asnumpy()
+    # Now do a simple check of the kernel gradient
+    assert(out[0,0,16,16] - np.sum(kernel_gradient) - out_orig[0,0,16,16] < 0.001)
+    
+
+if __name__=='__main__':  
+	test_impulse_response((1,1), kernel_shape=(3,3), verbose=False)
+	test_impulse_response((2,2), kernel_shape=(3,3), verbose=False)
+	test_impulse_response((3,3), kernel_shape=(3,3), verbose=False)
+	test_impulse_response((2,2), kernel_shape=(4,4), verbose=False)
+	test_impulse_response((2,2), kernel_shape=(2,3), verbose=False)
+	test_impulse_response((1,1), kernel_shape=(2,3), verbose=False)
+	test_impulse_response((3,3), kernel_shape=(2,3), verbose=False)
+	test_impulse_response((3,3), kernel_shape=(3,2), verbose=False)
+	test_impulse_response((1,1), kernel_shape=(1,1), verbose=False)
+
+


### PR DESCRIPTION
Fix for bug https://github.com/dmlc/mxnet/issues/1457 

This is the second merge request for this fix, since it was first neccessary to fix mshadow, which has just been merged. 

See https://github.com/dmlc/mshadow/pull/102

It is now neccessary to perform also these changes, or convolution is broken if dilate is set to a value > 2.