### PR TITLE
Fix bug in MXExecutorBindEX

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -949,7 +949,7 @@ MXNET_DLL int MXExecutorBindEX(SymbolHandle symbol_handle,
                                mx_uint *grad_req_type,
                                mx_uint aux_states_len,
                                NDArrayHandle *aux_states,
-                               ExecutorHandle *shared_exec,
+                               ExecutorHandle shared_exec,
                                ExecutorHandle *out);
 /*!
  * \brief set a call back to notify the completion of operation

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1032,7 +1032,7 @@ int MXExecutorBindEX(SymbolHandle symbol_handle,
                      mx_uint *grad_req_type,
                      mx_uint aux_states_len,
                      NDArrayHandle *aux_states,
-                     ExecutorHandle *shared_exec,
+                     ExecutorHandle shared_exec,
                      ExecutorHandle *out) {
   API_BEGIN();
   Symbol *symb = static_cast<Symbol*>(symbol_handle);


### PR DESCRIPTION
Fix the mistake in passing in the shared executor to MXExecutorBindEX.