### PR TITLE
Bilinear upsampling and deconvolution workspace

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -52,7 +52,7 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
     .describe("Number of groups partition. "
               "This option is not supported by CuDNN, you can use SliceChannel to num_group,"
               "apply convolution and concat instead to achieve the same need.");
-    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 4096)
+    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 8192)
     .describe("Tmp workspace for convolution (MB).");
     DMLC_DECLARE_FIELD(no_bias).set_default(false)
     .describe("Whether to disable bias parameter.");
@@ -265,8 +265,9 @@ class ConvolutionOp : public Operator {
     // if param_.workspace is set to zero the nstep_ equals ishape[0] (batch)
     nstep_ = std::max(
         std::min(
-          static_cast<index_t>(param_.workspace / (shape_colunit_.Size() + shape_dstunit_.Size())),
-          ishape[0]),
+            static_cast<index_t>(
+                param_.workspace / (shape_colunit_.Size() + shape_dstunit_.Size())),
+            ishape[0]),
         1U);
 
     mshadow::Shape<2> scol = mshadow::Shape2(shape_colunit_[0],

--- a/src/operator/deconvolution-inl.h
+++ b/src/operator/deconvolution-inl.h
@@ -47,7 +47,7 @@ struct DeconvolutionParam : public dmlc::Parameter<DeconvolutionParam> {
     .describe("deconvolution filter(channel) number");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
     .describe("number of groups partition");
-    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 4096)
+    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 8192)
     .describe("Tmp workspace for deconvolution (MB)");
     DMLC_DECLARE_FIELD(no_bias).set_default(true)
     .describe("Whether to disable bias parameter.");
@@ -247,7 +247,8 @@ class DeconvolutionOp : public Operator {
     // See convolution for workspace calculations
     nstep_ = std::max(
         std::min(
-            static_cast<index_t>(param_.workspace / shape_colunit_.Size() + shape_dstunit_.Size()),
+            static_cast<index_t>(
+                param_.workspace / (shape_colunit_.Size() + shape_dstunit_.Size())),
             ishape[0]),
         1U);
 

--- a/src/operator/upsampling-inl.h
+++ b/src/operator/upsampling-inl.h
@@ -33,6 +33,7 @@ struct UpSamplingParam : public dmlc::Parameter<UpSamplingParam> {
   int sample_type;
   int num_args;
   int multi_input_mode;
+  uint64_t workspace;
   DMLC_DECLARE_PARAMETER(UpSamplingParam) {
     DMLC_DECLARE_FIELD(scale)
     .set_range(1, 1000)
@@ -56,6 +57,8 @@ struct UpSamplingParam : public dmlc::Parameter<UpSamplingParam> {
     "upsampling, this can be 1-N; the size of output will be"
     "(scale*h_0,scale*w_0) and all other inputs will be upsampled to the"
     "same size. For bilinear upsampling this must be 2; 1 input and 1 weight.");
+    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 8192)
+    .describe("Tmp workspace for deconvolution (MB)");
   }
 };  // struct UpSamplingParam
 

--- a/src/operator/upsampling.cc
+++ b/src/operator/upsampling.cc
@@ -15,10 +15,11 @@ Operator *CreateOp<cpu>(UpSamplingParam param) {
   if (param.sample_type == up_enum::kNearest) {
     return new UpSamplingNearestOp<cpu>(param);
   } else if (param.sample_type == up_enum::kBilinear) {
-    DeconvolutionParam p;
+    DeconvolutionParam p = DeconvolutionParam();
     int kernel = 2 * param.scale - param.scale % 2;
     int stride = param.scale;
     int pad = static_cast<int>(ceil((param.scale - 1) / 2.));
+    p.workspace = param.workspace;
     p.num_group = param.num_filter;
     p.num_filter = param.num_filter;
     p.no_bias =  true;

--- a/src/operator/upsampling.cu
+++ b/src/operator/upsampling.cu
@@ -15,10 +15,11 @@ Operator *CreateOp<gpu>(UpSamplingParam param) {
   if (param.sample_type == up_enum::kNearest) {
     return new UpSamplingNearestOp<gpu>(param);
   } else if (param.sample_type == up_enum::kBilinear) {
-    DeconvolutionParam p;
+    DeconvolutionParam p = DeconvolutionParam();
     int kernel = 2 * param.scale - param.scale % 2;
     int stride = param.scale;
     int pad = static_cast<int>(ceil((param.scale - 1) / 2.));
+    p.workspace = param.workspace;
     p.num_group = param.num_filter;
     p.num_filter = param.num_filter;
     p.no_bias =  true;


### PR DESCRIPTION
This fixes a mistake I introduced in #944 and fixed bilinear upsamplings use of deconvolution. 

The workspace param of deconvolution was left uninitialized leading to random effects depending on the compiler version. This PR adds a workspace param to Upsampling and uses that to initalize deconvolution.