### PR TITLE
Fix Bug in Reshape Operator

### DIFF
--- a/src/operator/reshape-inl.h
+++ b/src/operator/reshape-inl.h
@@ -213,7 +213,7 @@ class ReshapeProp : public OperatorProperty {
         }
       }
 
-      if (neg_idx > 0) {
+      if (neg_idx >= 0) {
         tmp[neg_idx] = new_size;
       }
       TShape oshape(tmp.begin(), tmp.end());


### PR DESCRIPTION
The previous implementation has a bug when we use -1 in the 0-th dimension.

The error can be verified using the following code where the assertion fails.
```
net = mx.sym.Variable("data")
net = mx.sym.Reshape(net, shape=(-1, 0, 0, 0))
_, output_shape, __ = net.infer_shape(data=(2, 3, 5, 5))
assert (output_shape[0] == (2, 3, 5, 5))
```