### PR TITLE
Update random seed in im2rec.py

### DIFF
--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -41,6 +41,7 @@ def write_list(path_out, image_list):
 
 def make_list(prefix_out, root, recursive, exts, num_chunks, train_ratio):
     image_list = list_image(root, recursive, exts)
+    random.seed(100)
     random.shuffle(image_list)
     N = len(image_list)
     chunk_size = (N+num_chunks-1)/num_chunks


### PR DESCRIPTION
I noticed that `im2rec.py` create two different lists if the _same_ command is executed twice.
Giving the same seed each time (in this case `100`) the same command will produce the same lists.