### PR TITLE
Update submodule + Revise broadcast/reduce_with_axis usage

### DIFF
--- a/src/ndarray/ndarray_function-inl.h
+++ b/src/ndarray/ndarray_function-inl.h
@@ -264,7 +264,7 @@ void EvalBroadcast<DEVICE>(TBlob const& src, TBlob* ret, int size, RunContext ct
   mshadow::Stream<xpu>* s = ctx.get_stream<xpu>();
   mshadow::Tensor<xpu, 3> out = ret->get<xpu, 3, real_t>(s);
   mshadow::Tensor<xpu, 2> in = src.get<xpu, 2, real_t>(s);
-  out = mshadow::expr::broadcast_with_axis(in, 0, size);
+  out = mshadow::expr::broadcast_with_axis<0>(in, 0, size);
 }
 
 // declarations

--- a/src/operator/broadcast_reduce_op-inl.h
+++ b/src/operator/broadcast_reduce_op-inl.h
@@ -81,7 +81,7 @@ void ReduceMid(TBlob const& src,
   mshadow::Stream<xpu>* s = ctx.get_stream<xpu>();
   mshadow::Tensor<xpu, 2> out = ret->get<xpu, 2, real_t>(s);
   mshadow::Tensor<xpu, 3> in = src.get<xpu, 3, real_t>(s);
-  out = mshadow::expr::reduce_with_axis<Reducer, false>(in, 1);
+  out = mshadow::expr::reduce_with_axis<Reducer, false, 0>(in, 1);
 }
 
 // backward function that takes input value of the op
@@ -100,7 +100,7 @@ void SumMidBackward_(const OutputGrad& out_grad,
     mshadow::Tensor<xpu, 2, DType> ograd = out_grad.data.get<xpu, 2, DType>(s);
     mshadow::Tensor<xpu, 3, DType> igrad = in_grad->get<xpu, 3, DType>(s);
     ASSIGN_DISPATCH(igrad, req,
-      broadcast_with_axis(ograd, 0, igrad.shape_[1]));
+      broadcast_with_axis<0>(ograd, 0, igrad.shape_[1]));
   });
 }
 
@@ -129,7 +129,7 @@ void ReduceChannel(const TBlob &src,
   Tensor<xpu, 3> in = src.get_with_shape<xpu, 3, real_t>(
     Shape3(src.shape_[0], src.shape_[1], src.Size()/src.shape_[0]/src.shape_[1]),
     s);
-  out = reduce_with_axis<Reducer, get_mask>(in, 1);
+  out = reduce_with_axis<Reducer, get_mask, 0>(in, 1);
 }
 
 // return a shape of ReduceChannel output

--- a/src/operator/softmax_activation-inl.h
+++ b/src/operator/softmax_activation-inl.h
@@ -111,9 +111,9 @@ class SoftmaxActivationOp : public Operator {
     // get requested temp space
     Tensor<xpu, 2> workspace = ctx.requested[softmax_activation::kTempSpace].get_space<xpu>(
         Shape2(batch_size, rest_size), s);
-    workspace = reduce_with_axis<red::sum, false>(m_out_grad * m_out_data, 1);
+    workspace = reduce_with_axis<red::sum, false, 0>(m_out_grad * m_out_data, 1);
     Assign(m_in_grad, req[softmax_activation::kData],
-        m_out_data * (m_out_grad - broadcast_with_axis(workspace, 0, channel_num)));
+        m_out_data * (m_out_grad - broadcast_with_axis<0>(workspace, 0, channel_num)));
   }
 
  private:


### PR DESCRIPTION
Refer to the discussion in https://github.com/dmlc/mshadow/pull/121
We can now use `broadcast_with_axis<0>(..)` for no keepdim broadcasting and `broadcast_with_axis<1>(..)` for keepdim broadcasting.