### PR TITLE
fix a bug, you should save param first then reset

### DIFF
--- a/python/mxnet/module/bucketing_module.py
+++ b/python/mxnet/module/bucketing_module.py
@@ -155,6 +155,10 @@ class BucketingModule(BaseModule):
         shared_module : BucketingModule
             Default is `None`. This value is currently not used.
         """
+        # in case we already initialized params, keep it
+        if self.params_initialized:
+            arg_params, aux_params = self.get_params()
+
         # force rebinding is typically used when one want to switch from
         # training to prediction phase.
         if force_rebind:
@@ -163,10 +167,6 @@ class BucketingModule(BaseModule):
         if self.binded:
             self.logger.warning('Already binded, ignoring bind()')
             return
-
-        # in case we already initialized params, keep it
-        if self.params_initialized:
-            arg_params, aux_params = self.get_params()
 
         assert shared_module is None, 'shared_module for BucketingModule is not supported'
 


### PR DESCRIPTION
When I use BucketingModule for training, my batch size is 50, but I want a test(batch size is 1), I use this way, rebind a new shape. (batch size of data_test is 1)
       model.bind(data_shapes=data_test.provide_data, 
                          label_shapes=data_test.provide_label, 
                          for_training=False, 
                          force_rebind=True)
       model.predict(data_test)

but, there may be a bug, I make a change, it works. Because in get_params() assert self.binded, you shoud save param first.
