### PR TITLE
Update build.md (delete only cuDNN V3 is supported)

### DIFF
--- a/docs/how_to/build.md
+++ b/docs/how_to/build.md
@@ -37,7 +37,7 @@ Optional libraries
 
 - `CUDA Toolkit >= v7.0` to run on nvidia GPUs
   - Requires GPU with support for `Compute Capability >= 2.0`
-- CUDNN to accelerate the GPU computation (only CUDNN 3 is supported)
+- CUDNN to accelerate the GPU computation
 - opencv for image augmentation
 
 We can edit `make/config.mk` to change the compile options, and then build by


### PR DESCRIPTION
Propose this PR to update information in instruction of how to build mxnet, since "only cuDNN 3 is supported" is out of date, and the same content in [http://mxnet.readthedocs.io/en/latest/how_to/build.html](http://mxnet.readthedocs.io/en/latest/how_to/build.html) should be updated too. 

Related information can be found in [Issue#2298](https://github.com/dmlc/mxnet/issues/2298). Thanks!