### PR TITLE
Automatically adjust num of threads used by make

### DIFF
--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y build-essential git libopenblas-dev lib
 RUN git clone --recursive https://github.com/dmlc/mxnet/ && cd mxnet && \
     cp make/config.mk . && \
     echo "USE_BLAS=openblas" >>config.mk && \
-    make -j8
+    make -j$(nproc)
 
 # python pakcage
 RUN apt-get install -y python-numpy wget unzip

--- a/docker/cuda/Dockerfile
+++ b/docker/cuda/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone --recursive https://github.com/dmlc/mxnet/ && cd mxnet && \
     echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk && \
     echo "USE_CUDNN=1" >>config.mk && \
     echo "USE_BLAS=openblas" >>config.mk && \
-    make -j8 ADD_LDFLAGS=-L/usr/local/cuda/lib64/stubs
+    make -j$(nproc) ADD_LDFLAGS=-L/usr/local/cuda/lib64/stubs
 ENV LD_LIBRARY_PATH /usr/local/cuda/lib64:$LD_LIBRARY_PATH 
 
 # python pakcage

--- a/docs/how_to/build.md
+++ b/docs/how_to/build.md
@@ -59,7 +59,7 @@ sudo apt-get install -y build-essential git libatlas-base-dev libopencv-dev
 Then build mxnet
 ```bash
 git clone --recursive https://github.com/dmlc/mxnet
-cd mxnet; make -j4
+cd mxnet; make -j$(nproc)
 ```
 
 ### Building on OSX
@@ -77,7 +77,7 @@ Then build mxnet
 
 ```bash
 git clone --recursive https://github.com/dmlc/mxnet
-cd mxnet; cp make/osx.mk ./config.mk; make -j4
+cd mxnet; cp make/osx.mk ./config.mk; make -j$(sysctl -n hw.ncpu)
 ```
 
 Troubleshooting:
@@ -95,7 +95,7 @@ ln -s path1 /usr/local/lib/libgomp.dylib
 
 ```
 
-then run `make -j4` again.
+then run `make -j$(sysctl -n hw.ncpu)` again.
 
 
 ### Building on Windows

--- a/docs/how_to/cloud.md
+++ b/docs/how_to/cloud.md
@@ -72,7 +72,7 @@ echo "USE_CUDNN=1" >>config.mk
 echo "USE_BLAS=atlas" >> config.mk
 echo "USE_DIST_KVSTORE = 1" >>config.mk
 echo "USE_S3=1" >>config.mk
-make -j8
+make -j$(nproc)
 ```
 
 To test whether everything is installed properly, we train a Convolutional neural network on MNIST using a GPU:


### PR DESCRIPTION
This fixes #2304 and now the `make` command should be able to have the best performance during compilation.