### PR TITLE
use python to download and unzip files instead of wget, unzip command

### DIFF
--- a/example/image-classification/train_mnist.py
+++ b/example/image-classification/train_mnist.py
@@ -5,16 +5,26 @@ import os, sys
 import train_model
 
 def _download(data_dir):
-    if not os.path.isdir(data_dir):
-        os.system("mkdir " + data_dir)
+    if not os.path.exists(data_dir):
+        # os.mkdir(data_dir)  # make a directory
+        os.makedirs(data_dir)  # Recursive directory creation
     os.chdir(data_dir)
     if (not os.path.exists('train-images-idx3-ubyte')) or \
        (not os.path.exists('train-labels-idx1-ubyte')) or \
        (not os.path.exists('t10k-images-idx3-ubyte')) or \
        (not os.path.exists('t10k-labels-idx1-ubyte')):
-        os.system("wget http://webdocs.cs.ualberta.ca/~bx3/data/mnist.zip")
-        os.system("unzip -u mnist.zip; rm mnist.zip")
-    os.chdir("..")
+        url = 'http://webdocs.cs.ualberta.ca/~bx3/data/mnist.zip'
+        if sys.version_info.major == 2:
+            from urllib import urlretrieve
+        elif sys.version_info.major == 3:
+            from urllib.request import urlretrieve
+        urlretrieve(url, 'mnist.zip')
+        import zipfile
+        with zipfile.ZipFile('mnist.zip') as f:  # using with, so no need to close f explicitly
+            f.extractall()   # extract all files in current path
+        os.remove('mnist.zip')
+
+    os.chdir('..')
 
 def get_mlp():
     """
@@ -64,8 +74,8 @@ def get_iterator(data_shape):
         flat = False if len(data_shape) == 3 else True
 
         train           = mx.io.MNISTIter(
-            image       = data_dir + "train-images-idx3-ubyte",
-            label       = data_dir + "train-labels-idx1-ubyte",
+            image       = os.path.join(data_dir, "train-images-idx3-ubyte"),
+            label       = os.path.join(data_dir, "train-labels-idx1-ubyte"),
             input_shape = data_shape,
             batch_size  = args.batch_size,
             shuffle     = True,
@@ -74,8 +84,8 @@ def get_iterator(data_shape):
             part_index  = kv.rank)
 
         val = mx.io.MNISTIter(
-            image       = data_dir + "t10k-images-idx3-ubyte",
-            label       = data_dir + "t10k-labels-idx1-ubyte",
+            image       = os.path.join(data_dir, "t10k-images-idx3-ubyte"),
+            label       = os.path.join(data_dir, "t10k-labels-idx1-ubyte"),
             input_shape = data_shape,
             batch_size  = args.batch_size,
             flat        = flat,


### PR DESCRIPTION
this fixes #2237 #1559, for windows user, it is not convenient to use wget, mkdir, unzip like linux user.
we can use pure python code to download and unzip dataset, which works for both windows, linux/unix.
