### PR TITLE
Amalgamation and readme update for Android, JS and iOS support

### DIFF
--- a/amalgamation/Makefile
+++ b/amalgamation/Makefile
@@ -17,8 +17,8 @@ endif
 
 CFLAGS=-std=c++11 -Wno-unknown-pragmas -Wall
 ifneq ($(MIN), 1)
-	CFLAGS+= -I${OPENBLAS_ROOT}
-	LDFLAGS+=-L${OPENBLAS_ROOT} -lopenblas
+	CFLAGS+= -I${OPENBLAS_ROOT}/include
+	LDFLAGS+=-L${OPENBLAS_ROOT}/lib -lopenblas
 endif
 
 
@@ -27,12 +27,13 @@ all: android libmxnet_predict.a ${MXNET_ROOT}/lib/libmxnet_predict.so
 mxnet_predict0.d: mxnet_predict0.cc
 	${CXX} ${CFLAGS} -MD -MF $@ \
 	-I ${MXNET_ROOT}/ -I ${MXNET_ROOT}/mshadow/ -I ${MXNET_ROOT}/dmlc-core/include \
-	-I ${MXNET_ROOT}/include -c $+
+	-I ${MXNET_ROOT}/include \
+	-D__MIN__=$(MIN) -c $+
 	rm mxnet_predict0.o
 
 mxnet_predict-all.cc:  mxnet_predict0.d mxnet_predict0.cc
 	@echo "Generating amalgamation to " $@
-	python ./amalgamation.py $+ $@ $(MIN)
+	python ./amalgamation.py $+ $@ $(MIN) $(ANDROID)
 
 mxnet_predict-all.o: mxnet_predict-all.cc
 	${CXX} ${CFLAGS} -fPIC -o $@ -c $+
@@ -56,7 +57,9 @@ else
 endif
 
 libmxnet_predict.js: mxnet_predict-all.cc
-	emcc -std=c++11 -O2 -D__MXNET_JS__  -o $@ $+ -s EXPORTED_FUNCTIONS="['_MXPredCreate', '_MXPredGetOutputShape', '_MXPredSetInput', '_MXPredForward', '_MXPredPartialForward', '_MXPredGetOutput', '_MXPredFree', '_MXNDListCreate', '_MXNDListGet', '_MXNDListFree']" -s ALLOW_MEMORY_GROWTH=1
+	emcc -std=c++11 -O2 -D__MXNET_JS__  -o $@ $+ \
+	-s EXPORTED_FUNCTIONS="['_MXPredCreate', '_MXPredGetOutputShape', '_MXPredSetInput', '_MXPredForward', '_MXPredPartialForward', '_MXPredGetOutput', '_MXPredFree', '_MXNDListCreate', '_MXNDListGet', '_MXNDListFree']" \
+	-s ALLOW_MEMORY_GROWTH=1
 
 
 ${MXNET_ROOT}/lib/libmxnet_predict.so:  mxnet_predict-all.o

--- a/amalgamation/amalgamation.py
+++ b/amalgamation/amalgamation.py
@@ -11,14 +11,20 @@ blacklist = [
     ]
 
 if len(sys.argv) < 4:
-    print("Usage: <source.d> <source.cc> <output> [minumum=0]\n"
+    print("Usage: <source.d> <source.cc> <output> [minimum=0] [android=0]\n"
           "Minimum means no blas, no sse, no dependency, may run twice slower.")
     exit(0)
 
 minimum = int(sys.argv[4]) if len(sys.argv) > 4 else 0
+android = int(sys.argv[5]) if len(sys.argv) > 5 else 0
 
 if minimum:
-    blacklist += ['packet/sse-inl.h', 'emmintrin.h']
+    blacklist += ['packet/sse-inl.h', 'emmintrin.h', 'cblas.h']
+
+if android:
+    blacklist += ['config.h']
+    if 'packet/sse-inl.h' not in blacklist:
+        blacklist += ['packet/sse-inl.h']
 
 def get_sources(def_file):
     sources = []
@@ -64,7 +70,7 @@ def expand(x, pending):
         #print 'loop found: %s in ' % x, pending
         return
 
-    print >>out, "//===== EXPANDIND: %s =====\n" %x
+    print >>out, "//===== EXPANDING: %s =====\n" %x
     for line in open(x):
         if line.find('#include') < 0:
             out.write(line)
@@ -112,6 +118,9 @@ print >>f, '''
 
 #endif
 '''
+
+if minimum != 0 and android != 0 and 'complex.h' not in sysheaders:
+    sysheaders.append('complex.h')
 
 for k in sorted(sysheaders):
     print >>f, "#include <%s>" % k

--- a/amalgamation/mxnet_predict0.cc
+++ b/amalgamation/mxnet_predict0.cc
@@ -1,9 +1,15 @@
 // mexnet.cc
 
 #define MSHADOW_FORCE_STREAM
+
 #ifndef MSHADOW_USE_CBLAS
+#if (__MIN__ == 1)
+#define MSHADOW_USE_CBLAS 	0
+#else
 #define MSHADOW_USE_CBLAS 	1
 #endif
+#endif
+
 #define MSHADOW_USE_CUDA 	0
 #define MSHADOW_USE_MKL 	0
 #define MSHADOW_RABIT_PS 	0
@@ -26,12 +32,14 @@
 #include "src/symbol/static_graph.cc"
 #include "src/symbol/symbol.cc"
 #include "src/operator/operator.cc"
+#include "src/operator/operator_util.cc"
 #include "src/operator/activation.cc"
 #include "src/operator/batch_norm.cc"
 #include "src/operator/block_grad.cc"
 #include "src/operator/concat.cc"
 #include "src/operator/convolution.cc"
 #include "src/operator/dropout.cc"
+#include "src/operator/elementwise_unary_op.cc"
 #include "src/operator/elementwise_binary_op.cc"
 #include "src/operator/elementwise_sum.cc"
 #include "src/operator/fully_connected.cc"


### PR DESCRIPTION
Tested on OSX El Capitan 10.11.4. with ANDROID NDK version 11c. I have added all the latest fixes emerged in the issues related to amalgamation.

Successfully builded for:
- Android with and without BLAS
- Javascript 
- iOS with and without BLAS

Probably the all-in-one file (and the related compiled lib) could be smaller including fewer files, but I haven't enough mxnet knowledge to accurately select the minimum set of files.