### PR TITLE
scala-packag, Executor, shared memory bind and runtime reshaping

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Executor.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Executor.scala
@@ -124,6 +124,9 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
   protected var _argDict: Map[String, NDArray] = null
   protected var _auxDict: Map[String, NDArray] = null
   protected var monitorCallback: MXMonitorCallback = null
+  private[mxnet] var _ctx: Context = null
+  private[mxnet] var _gradsReq: Iterable[_] = null
+  private[mxnet] var _group2ctx: Map[String, Context] = null
 
   private var disposed = false
 
@@ -136,6 +139,98 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
       outputs.foreach(_.dispose())
       _LIB.mxExecutorFree(handle)
       disposed = true
+    }
+  }
+
+  /**
+   * Return a new executor with the same symbol and shared memory,
+   * but different input/output shapes.
+   * For runtime reshaping, variable length sequences, etc.
+   * The returned executor shares state with the current one,
+   * and cannot be used in parallel with it.
+   * @param partialShaping Whether to allow changing the shape of unspecified arguments.
+   * @param allowUpSizing Whether to allow allocating new ndarrays that's larger than the original.
+   * @param kwargs Map of string to Shape.
+   *                - new shape for arguments.
+   * @return
+   * executor A new executor that shares memory with this.
+   */
+  def reshape(partialShaping: Boolean = false, allowUpSizing: Boolean = false,
+    kwargs: Map[String, Shape]): Executor = {
+     val (argShapes, _, auxShapes) = this.symbol.inferShape(kwargs)
+     require(argShapes != null, "Insufficient argument shapes provided.")
+
+    var newArgDict = Map[String, NDArray]()
+    var newGradDict = Map[String, NDArray]()
+
+    this.symbol.listArguments().zipWithIndex.foreach { case (name, i) =>
+      val newShape = argShapes(i)
+      val arr = this.argArrays(i)
+      val dArr = if (this.gradArrays == null) null else this.gradArrays(i)
+      if (partialShaping || kwargs.contains(name) || newShape.equals(arr.shape)) {
+        if (newShape.product > arr.shape.product) {
+          require(allowUpSizing, s"New shape of arg:$name larger than original. " +
+                        "First making a big executor and then down sizing it " +
+                        "is more efficient than the reverse." +
+                        "If you really want to up size, set allowUpSizing = true " +
+                        "to enable allocation of new arrays.")
+          newArgDict = newArgDict + (name -> NDArray.empty(newShape, arr.context))
+          if (dArr != null) {
+            newGradDict = newGradDict + (name -> NDArray.empty(newShape, dArr.context))
+          }
+        } else {
+          newArgDict = newArgDict + (name -> arr.reshape(newShape.toArray))
+          if (dArr != null) {
+            newGradDict = newGradDict + (name -> dArr.reshape(newShape.toArray))
+          }
+        }
+      } else {
+        import java.lang.AssertionError
+        throw new  AssertionError(s"Shape of unspecified array arg:$name changed." +
+                    "This can cause the new executor to not share parameters " +
+                    "with the old one. Please check for error in network." +
+                    "If this is intended, set partialShaping = true to suppress this warning.")
+      }
+    }
+
+    var newAuxDict = Map[String, NDArray]()
+    val zip3 = (this.symbol.listAuxiliaryStates, auxShapes, this.auxArrays).zipped
+    zip3.foreach { case (name, newShape, arr) =>
+      if (partialShaping || newShape.equals(arr.shape)) {
+        if (newShape.product > arr.shape.product) {
+          require(allowUpSizing, s"New shape of aux:$name larger than original. " +
+                        "First making a big executor and then down sizing it " +
+                        "is more efficient than the reverse." +
+                        "If you really want to up size, set allowUpSizing = true " +
+                        "to enable allocation of new arrays.")
+          newAuxDict = newAuxDict + (name -> NDArray.empty(newShape, arr.context))
+        } else {
+          newAuxDict = newAuxDict + (name -> arr.reshape(newShape.toArray))
+        }
+      } else {
+        import java.lang.AssertionError
+        throw new  AssertionError(s"Shape of unspecified array aux:$name changed." +
+                  "This can cause the new executor to not share parameters " +
+                  "with the old one. Please check for error in network." +
+                  "If this is intended, set partialShaping = true to suppress this warning.")
+      }
+    }
+    if (this._gradsReq.isInstanceOf[Seq[_]]) {
+      this.symbol.bind(this._ctx,
+                          newArgDict,
+                          newGradDict,
+                          this._gradsReq.asInstanceOf[Seq[String]],
+                          newAuxDict,
+                          this._group2ctx,
+                          this)
+    } else {
+      this.symbol.bind(this._ctx,
+                          newArgDict,
+                          newGradDict,
+                          this._gradsReq.asInstanceOf[Map[String, String]],
+                          newAuxDict,
+                          this._group2ctx,
+                          this)
     }
   }
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -198,6 +198,20 @@ class LibInfo {
                               reqsArray: Array[Int],
                               auxArgsHandle: Array[NDArrayHandle],
                               out: ExecutorHandleRef): Int
+  @native def mxExecutorBindEX(handle: SymbolHandle,
+                              deviceTypeId: Int,
+                              deviceID: Int,
+                              numCtx: Int,
+                              ctxMapKeys: Array[String],
+                              ctxMapDevTypes: Array[Int],
+                              ctxMapDevIDs: Array[Int],
+                              numArgs: Int,
+                              argsHandle: Array[NDArrayHandle],
+                              argsGradHandle: Array[NDArrayHandle],
+                              reqsArray: Array[Int],
+                              auxArgsHandle: Array[NDArrayHandle],
+                              sharedExec: ExecutorHandle,
+                              out: ExecutorHandleRef): Int
   // scalastyle:on parameterNum
   @native def mxSymbolSaveToFile(handle: SymbolHandle, fname: String): Int
   @native def mxSymbolCreateFromFile(fname: String, handle: SymbolHandleRef): Int

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
@@ -387,7 +387,7 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) {
       // TODO: NDArray dtype
       NDArray.zeros(shape, ctx)
     }
-    bind(ctx, argNDArrays, gradNDArrays, gradReq, auxNDArrays, null)
+    bind(ctx, argNDArrays, gradNDArrays, gradReq, auxNDArrays, null, null)
   }
 
   /**
@@ -421,6 +421,10 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) {
    *                    to the corresponding NDArray,
    *                  - In either case, all the auxiliary_states need to be provided.
    * @param group2ctx The dict mapping the ``ctx_group`` attribute to the context assignment.
+   * @param sharedExec Executor to share memory with.
+   *                 - This is intended for runtime reshaping, variable length sequences, etc.
+   *                 - The returned executor shares state with shared_exec,
+   *                   and should not be used in parallel with it.
    * @return The generated Executor
    * @note
    * Auxiliary states are special states of symbols that do not corresponds to an argument,
@@ -433,212 +437,228 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) {
    */
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Seq[NDArray],
            gradReq: String, auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Seq[NDArray],
            gradReq: String, auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Map[String, NDArray],
            gradReq: String, auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Map[String, NDArray],
            gradReq: String, auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Seq[NDArray],
            gradReq: String, auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Seq[NDArray],
            gradReq: String, auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Map[String, NDArray],
            gradReq: String, auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Map[String, NDArray],
            gradReq: String, auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, argsGrad,
-               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx)
+               Seq.fill(symbolArguments.size)(gradReq), auxStates, group2ctx, sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Seq[NDArray],
            gradsReq: Seq[String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Seq[NDArray],
            gradsReq: Seq[String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Seq[String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Seq[String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Seq[NDArray],
            gradsReq: Seq[String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Seq[NDArray],
            gradsReq: Seq[String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Seq[String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Seq[String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Seq[NDArray],
            gradsReq: Map[String, String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Seq[NDArray],
            gradsReq: Map[String, String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Map[String, String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Map[String, String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Seq[NDArray],
            gradsReq: Map[String, String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Seq[NDArray],
            gradsReq: Map[String, String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Map[String, String], auxStates: Seq[NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Map[String, NDArray],
            gradsReq: Map[String, String], auxStates: Map[String, NDArray],
-           group2ctx: Map[String, Context]): Executor = {
+           group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     val symbolArguments = listArguments()
-    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx)
+    bindHelper(ctx, symbolArguments, args, argsGrad, gradsReq, auxStates, group2ctx,
+      sharedExec)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Seq[NDArray]): Executor = {
-    bind(ctx, args, argsGrad, "write", Nil, null)
+    bind(ctx, args, argsGrad, "write", Nil, null, null)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Map[String, NDArray]): Executor = {
-    bind(ctx, args, argsGrad, "write", Nil, null)
+    bind(ctx, args, argsGrad, "write", Nil, null, null)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray], argsGrad: Seq[NDArray]): Executor = {
-    bind(ctx, args, argsGrad, "write", Nil, null)
+    bind(ctx, args, argsGrad, "write", Nil, null, null)
   }
 
   def bind(ctx: Context, args: Seq[NDArray], argsGrad: Map[String, NDArray]): Executor = {
-    bind(ctx, args, argsGrad, "write", Nil, null)
+    bind(ctx, args, argsGrad, "write", Nil, null, null)
   }
 
   def bind(ctx: Context, args: Seq[NDArray]): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, null,
-               Seq.fill(symbolArguments.size)("write"), Nil, null)
+               Seq.fill(symbolArguments.size)("write"), Nil, null, null)
   }
 
   def bind(ctx: Context, args: Map[String, NDArray]): Executor = {
     val symbolArguments = listArguments()
     bindHelper(ctx, symbolArguments, args, null,
-      Seq.fill(symbolArguments.size)("write"), Nil, null)
+      Seq.fill(symbolArguments.size)("write"), Nil, null, null)
   }
 
   private def bindHelper(ctx: Context, symbolArguments: Seq[String],
                          args: Iterable[_], argsGrad: Iterable[_],
                          gradsReq: Iterable[_], auxStates: Iterable[_],
-                         group2ctx: Map[String, Context]): Executor = {
+                         group2ctx: Map[String, Context], sharedExec: Executor): Executor = {
     require(args != null && !args.isInstanceOf[Set[_]])
     require(argsGrad == null || !argsGrad.isInstanceOf[Set[_]])
     require(auxStates == null || !auxStates.isInstanceOf[Set[_]])
@@ -705,7 +725,8 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) {
     }
 
     val execHandle = new ExecutorHandleRef
-    checkCall(_LIB.mxExecutorBindX(handle,
+    val sharedHadle = if (sharedExec != null) sharedExec.handle else 0L
+    checkCall(_LIB.mxExecutorBindEX(handle,
                                    ctx.deviceTypeid,
                                    ctx.deviceId,
                                    ctxMapKeys.size,
@@ -717,11 +738,19 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) {
                                    argsGradHandle,
                                    reqsArray,
                                    auxArgsHandle,
+                                   sharedHadle,
                                    execHandle))
-    val executor = new Executor(execHandle.value, this)
+    val executor = new Executor(execHandle.value, this.clone())
     executor.argArrays = argsNDArray
     executor.gradArrays = argsGradNDArray
     executor.auxArrays = auxStatesNDArray
+    executor._ctx = new Context(ctx.deviceType, ctx.deviceId)
+    executor._gradsReq = gradsReq
+    executor._group2ctx =
+      if (group2ctx == null) null
+      else group2ctx.map { case (key, value) =>
+        (key -> new Context(value.deviceType, value.deviceId))
+      }.toMap
     executor
   }
 

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/ExecutorSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/ExecutorSuite.scala
@@ -40,4 +40,24 @@ class ExecutorSuite extends FunSuite with BeforeAndAfterAll {
     assert(reldiff(lhsGrad, lhsGrad2) < 1e-6)
     assert(reldiff(rhsGrad, rhsGrad2) < 1e-6)
   }
+
+  test("reshape") {
+    val x = Symbol.Variable("x")
+    val y = Symbol.FullyConnected()(Map("data" -> x, "num_hidden" -> 4))
+
+    val exec = y.simpleBind(Context.cpu(), "write", shapeDict = Map("x" -> Shape(5, 4)))
+    exec.argArrays(0).set(1)
+    exec.argArrays(1).set(1)
+    exec.argArrays(2).set(0)
+
+    val newExec = exec.reshape(kwargs = Map("x" -> Shape(3, 4)))
+    newExec.forward(isTrain = false)
+    // test sub exec forward
+    assert(newExec.outputs(0).toArray.forall(_ == 4))
+    // test shared memory
+    assert(exec.outputs(0).toArray.take(3).forall(_ == 4))
+    // test base exec forward
+    exec.forward(isTrain = false)
+    assert(exec.outputs(0).toArray.forall(_ == 4))
+  }
 }

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/ModelParallelSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/ModelParallelSuite.scala
@@ -31,7 +31,8 @@ class ModelParallelSuite extends FunSuite with BeforeAndAfterAll {
       argsGrad = arrGrad,
       gradReq = "write",
       auxStates = Nil,
-      group2ctx = Map("dev1" -> Context.cpu(0), "dev2" -> Context.cpu(1)))
+      group2ctx = Map("dev1" -> Context.cpu(0), "dev2" -> Context.cpu(1)),
+      sharedExec = null)
 
     arr(0).set(1f)
     arr(1).set(2f)

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -1335,6 +1335,61 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxExecutorBindX
   return ret;
 }
 
+JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxExecutorBindEX
+  (JNIEnv *env, jobject obj, jlong symbolPtr, jint deviceTypeId, jint deviceID, jint numCtx,
+    jobjectArray jctxMapKeys, jintArray jctxMapDevTypes, jintArray jctxMapDevIDs, jint numArgs,
+    jlongArray jargsHandle, jlongArray jargsGradHandle, jintArray jreqsArray,
+    jlongArray jauxArgsHandle, jlong jsharedExec, jobject jexecOut) {
+  ExecutorHandle out;
+  int auxStatesLen = env->GetArrayLength(jauxArgsHandle);
+  ExecutorHandle sharedExec = nullptr;
+  if ((long)jsharedExec != 0L) sharedExec = reinterpret_cast<ExecutorHandle>(jsharedExec);
+
+  const char **mapKeys = new const char *[numCtx];
+  for (size_t i = 0; i < numCtx; i++) {
+    jstring jkey = reinterpret_cast<jstring>(env->GetObjectArrayElement(jctxMapKeys, i));
+    const char *key = env->GetStringUTFChars(jkey, 0);
+    mapKeys[i] = key;
+    env->DeleteLocalRef(jkey);
+  }
+  jlong *auxStates = env->GetLongArrayElements(jauxArgsHandle, NULL);
+  jint *gradReqType = env->GetIntArrayElements(jreqsArray, NULL);
+  jlong *inArgs = env->GetLongArrayElements(jargsHandle, NULL);
+  jlong *argGradStore = env->GetLongArrayElements(jargsGradHandle, NULL);
+  jint *mapDevTypes = env->GetIntArrayElements(jctxMapDevTypes, NULL);
+  jint *mapDevIDs = env->GetIntArrayElements(jctxMapDevIDs, NULL);
+  int ret = MXExecutorBindEX(reinterpret_cast<SymbolHandle>(symbolPtr),
+                            deviceTypeId,
+                            deviceID,
+                            static_cast<mx_uint>(numCtx),
+                            mapKeys,
+                            mapDevTypes,
+                            mapDevIDs,
+                            static_cast<mx_uint>(numArgs),
+                            reinterpret_cast<NDArrayHandle *>(inArgs),
+                            reinterpret_cast<NDArrayHandle *>(argGradStore),
+                            reinterpret_cast<mx_uint *>(gradReqType),
+                            static_cast<mx_uint>(auxStatesLen),
+                            reinterpret_cast<NDArrayHandle *>(auxStates),
+                            sharedExec,
+                            &out);
+  env->ReleaseIntArrayElements(jctxMapDevIDs, mapDevIDs, 0);
+  env->ReleaseIntArrayElements(jctxMapDevTypes, mapDevTypes, 0);
+  env->ReleaseLongArrayElements(jargsGradHandle, argGradStore, 0);
+  env->ReleaseLongArrayElements(jargsHandle, inArgs, 0);
+  env->ReleaseIntArrayElements(jreqsArray, gradReqType, 0);
+  env->ReleaseLongArrayElements(jauxArgsHandle, auxStates, 0);
+  for (size_t i = 0; i < numCtx; i++) {
+    jstring jkey = (jstring) env->GetObjectArrayElement(jctxMapKeys, i);
+    env->ReleaseStringUTFChars(jkey, mapKeys[i]);
+    env->DeleteLocalRef(jkey);
+  }
+  delete[] mapKeys;
+
+  SetLongField(env, jexecOut, reinterpret_cast<jlong>(out));
+  return ret;
+}
+
 JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxRandomSeed
   (JNIEnv *env, jobject obj, jint seed) {
   return MXRandomSeed(seed);

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -1343,7 +1343,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxExecutorBindEX
   ExecutorHandle out;
   int auxStatesLen = env->GetArrayLength(jauxArgsHandle);
   ExecutorHandle sharedExec = nullptr;
-  if ((long)jsharedExec != 0L) sharedExec = reinterpret_cast<ExecutorHandle>(jsharedExec);
+  if ((int32_t)jsharedExec != 0) sharedExec = reinterpret_cast<ExecutorHandle>(jsharedExec);
 
   const char **mapKeys = new const char *[numCtx];
   for (size_t i = 0; i < numCtx; i++) {


### PR DESCRIPTION
Following the pr https://github.com/dmlc/mxnet/pull/1408, 
add the same functionality to scala-pkg executor.