### PR TITLE
Extend makeloss to arbitrary input tensor shape

### DIFF
--- a/src/operator/make_loss-inl.h
+++ b/src/operator/make_loss-inl.h
@@ -46,12 +46,10 @@ class MakeLossOp : public Operator {
     using namespace mshadow::expr;
     CHECK_EQ(in_data.size(), 1) << "MakeLoss can only be used to one input";
     CHECK_EQ(out_data.size(), 1);
-    CHECK_EQ(in_data[make_loss_enum::kData].ndim(), 2)
-    << "MakeLoss applies to all unary and binary operator with 2 dimension input";
     if (req[make_loss_enum::kOut] != kWriteInplace) {
       Stream<xpu> *s = ctx.get_stream<xpu>();
-      Tensor<xpu, 2> data = in_data[make_loss_enum::kData].get<xpu, 2, real_t>(s);
-      Tensor<xpu, 2> out = out_data[make_loss_enum::kOut].get<xpu, 2, real_t>(s);
+      Tensor<xpu, 2> data = in_data[make_loss_enum::kData].FlatTo2D<xpu, real_t>(s);
+      Tensor<xpu, 2> out = out_data[make_loss_enum::kOut].FlatTo2D<xpu, real_t>(s);
       Assign(out, req[make_loss_enum::kOut], F<mshadow_op::identity>(data));
     }
   }
@@ -66,7 +64,7 @@ class MakeLossOp : public Operator {
     using namespace mshadow;
     using namespace mshadow::expr;
     Stream<xpu> *s = ctx.get_stream<xpu>();
-    Tensor<xpu, 2> grad = in_grad[make_loss_enum::kData].get<xpu, 2, real_t>(s);
+    Tensor<xpu, 2> grad = in_grad[make_loss_enum::kData].FlatTo2D<xpu, real_t>(s);
     Assign(grad, req[make_loss_enum::kData], ScalarExp<real_t>(param_.grad_scale));
   }
 

--- a/src/operator/smooth_l1_unary-inl.h
+++ b/src/operator/smooth_l1_unary-inl.h
@@ -72,8 +72,8 @@ void SmoothL1Forward_(const TBlob& src,
     << "Unary function only support input/output with the same type";
   real_t sigma2 = env.scalar * env.scalar;
   MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
-    mshadow::Tensor<xpu, 2, DType> out = ret->get<xpu, 2, DType>(s);
-    mshadow::Tensor<xpu, 2, DType> in = src.get<xpu, 2, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> out = ret->FlatTo2D<xpu, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> in = src.FlatTo2D<xpu, DType>(s);
     ASSIGN_DISPATCH(out, req,
                     F<mshadow_op::smooth_l1_loss>(in, ScalarExp<DType>(sigma2)));
   });
@@ -95,9 +95,9 @@ void SmoothL1BackwardUseIn_(const OutputGrad& out_grad,
     << "Unary function only support input/output with the same type";
   real_t sigma2 = env.scalar * env.scalar;
   MSHADOW_TYPE_SWITCH(in_grad->type_flag_, DType, {
-    mshadow::Tensor<xpu, 2, DType> src = in_data0.data.get<xpu, 2, DType>(s);
-    mshadow::Tensor<xpu, 2, DType> ograd = out_grad.data.get<xpu, 2, DType>(s);
-    mshadow::Tensor<xpu, 2, DType> igrad = in_grad->get<xpu, 2, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> src = in_data0.data.FlatTo2D<xpu, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> ograd = out_grad.data.FlatTo2D<xpu, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> igrad = in_grad->FlatTo2D<xpu, DType>(s);
     ASSIGN_DISPATCH(igrad, req,
                     ograd * F<mshadow_op::smooth_l1_gradient>(src, ScalarExp<DType>(sigma2)));
   });


### PR DESCRIPTION
Loss is by convention a 2d tensor but can also be 4d in the fully convolutional network case. Replacing `get_with_shape` by `FlatTo2D` will extend elementwise losses to arbitrary input tensor shape.