### PR TITLE
Improve NDArray Load

### DIFF
--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -618,7 +618,11 @@ bool NDArray::Load(dmlc::Stream *strm) {
   if (ctx.dev_mask() == cpu::kDevMask) {
     *this = std::move(temp); return true;
   } else {
+    #if MXNET_USE_CUDA == 1
     *this = temp.Copy(ctx); return true;
+    #else
+    *this = std::move(temp); return true;
+    #endif
   }
 }
 


### PR DESCRIPTION
In current code, if GPU NDArray is saved in env with CUDA, loading will be fine; But if load in env without CUDA, it will crash with error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "../../python/mxnet/ndarray.py", line 951, in load
    ctypes.byref(names)))
  File "../../python/mxnet/base.py", line 77, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [13:38:17] src/ndarray/ndarray.cc:283: GPU is not enabled
```

