### PR TITLE
fix conv / deconv bug on non-square stride

### DIFF
--- a/example/numpy-ops/weighted_logistic_regression.py
+++ b/example/numpy-ops/weighted_logistic_regression.py
@@ -1,0 +1,55 @@
+import os
+import numpy as np
+import mxnet as mx
+# MXNET_CPU_WORKER_NTHREADS must be greater than 1 for custom op to work on CPU
+os.environ["MXNET_CPU_WORKER_NTHREADS"] = "2"
+
+class WeightedLogisticRegression(mx.operator.CustomOp):
+    def __init__(self, pos_grad_scale, neg_grad_scale):
+        self.pos_grad_scale = float(pos_grad_scale)
+        self.neg_grad_scale = float(neg_grad_scale)
+    def forward(self, is_train, req, in_data, out_data, aux):
+        self.assign(out_data[0], req[0], mx.nd.divide(1, (1 + mx.nd.exp(- in_data[0]))))
+    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
+        in_grad[0][:] = ((out_data[0] - 1) * in_data[1] * self.pos_grad_scale + out_data[0] * (1 - in_data[1]) * self.neg_grad_scale) / out_data[0].shape[1]
+
+@mx.operator.register("weighted_logistic_regression")
+class WeightedLogisticRegressionProp(mx.operator.CustomOpProp):
+    def __init__(self, pos_grad_scale, neg_grad_scale):
+        self.pos_grad_scale = pos_grad_scale
+        self.neg_grad_scale = neg_grad_scale
+        super(WeightedLogisticRegressionProp, self).__init__(False)
+    def list_arguments(self):
+        return ['data', 'label']
+    def list_outputs(self):
+        return ['output']
+    def infer_shape(self, in_shape):
+        shape = in_shape[0]
+        return [shape, shape], [shape]
+    def create_operator(self, ctx, shapes, dtypes):
+        return WeightedLogisticRegression(self.pos_grad_scale, self.neg_grad_scale)
+
+if __name__ == '__main__':
+    m, n = 2, 5
+    pos, neg = 1, 0.1
+    data = mx.sym.Variable('data')
+    wlr = mx.sym.Custom(data, pos_grad_scale = pos, neg_grad_scale = neg, name = 'wlr', op_type = 'weighted_logistic_regression')
+    lr = mx.sym.LogisticRegressionOutput(data, name = 'lr')
+    exe1 = wlr.simple_bind(ctx = mx.gpu(1), data = (2 * m, n))
+    exe2 = lr.simple_bind(ctx = mx.gpu(1), data = (2 * m, n))
+    exe1.arg_dict['data'][:] = np.ones([2 * m, n])
+    exe2.arg_dict['data'][:] = np.ones([2 * m, n])
+    exe1.arg_dict['wlr_label'][:] = np.vstack([np.ones([m, n]), np.zeros([m, n])])
+    exe2.arg_dict['lr_label'][:] = np.vstack([np.ones([m, n]), np.zeros([m, n])])
+    exe1.forward(is_train = True)
+    exe2.forward(is_train = True)
+    print('wlr output:')
+    print(exe1.outputs[0].asnumpy())
+    print('lr output:')
+    print(exe2.outputs[0].asnumpy())
+    exe1.backward()
+    exe2.backward()
+    print('wlr grad:')
+    print(exe1.grad_dict['data'].asnumpy())
+    print('lr grad:')
+    print(exe2.grad_dict['data'].asnumpy())

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -230,7 +230,9 @@ class ConvolutionOp : public Operator {
                               param_.kernel[0],
                               param_.kernel[1],
                               param_.stride[0],
-                              param_.dilate[0]));
+                              param_.stride[1],
+                              param_.dilate[0],
+                              param_.dilate[1]));
       } else {
         Shape<4> pshape = data.Slice(i, i + step).shape_;
         pshape[2] += 2 * param_.pad[0];
@@ -241,7 +243,9 @@ class ConvolutionOp : public Operator {
                                    param_.kernel[0],
                                    param_.kernel[1],
                                    param_.stride[0],
-                                   param_.dilate[0]),
+                                   param_.stride[1],
+                                   param_.dilate[0],
+                                   param_.dilate[1]),
                     gdata[i][0].shape_));
       }
     }

--- a/src/operator/deconvolution-inl.h
+++ b/src/operator/deconvolution-inl.h
@@ -127,6 +127,8 @@ class DeconvolutionOp : public Operator {
                                    param_.kernel[0],
                                    param_.kernel[1],
                                    param_.stride[0],
+                                   param_.stride[1],
+                                   1,
                                    1);  // Deconvolution only support dilate equals 1
       } else {
         Shape<4> pshape = out.Slice(i, i + step).shape_;
@@ -137,6 +139,8 @@ class DeconvolutionOp : public Operator {
                                         param_.kernel[0],
                                         param_.kernel[1],
                                         param_.stride[0],
+                                        param_.stride[1],
+                                        1,
                                         1),  // Deconvolution only support dilate equals 1
                                         out[i][0].shape_);
       }


### PR DESCRIPTION
Below code works on mxnet 0.5.0 but raises an error on mxnet 0.7.0.

```
import mxnet as mx

rect = (2, 4)
data_shape = (5, 3, 16, 16)
data = mx.sym.Variable(name = 'data')
conv = mx.sym.Convolution(data, kernel = rect, stride = rect, num_filter = 32, name = 'conv')
deconv = mx.sym.Deconvolution(conv, kernel = rect, stride = rect, num_filter = 3, name = 'deconv')
lr = mx.sym.LogisticRegressionOutput(data = deconv, label = data, name = 'lr')
print(lr.infer_shape(data = data_shape)[1][0])
exe = lr.simple_bind(ctx = mx.gpu(1), data = data_shape)
exe.forward(is_train = True)
exe.outputs[0].asnumpy()
exe.backward()
```

After adding 4 lines to convolution-inl.h / deconvolution-inl.h it can run.

I still wonder why the above code can run smoothly on mxnet 0.5.0 although there's no such 4 lines in convolution-inl.h / deconvolution-inl.h.
