### PR TITLE
Correct init idx2name on multi-CPU/GPU training for FeedForward

### DIFF
--- a/example/image-classification/symbol_resnet.py
+++ b/example/image-classification/symbol_resnet.py
@@ -36,8 +36,8 @@ def get_conv(
         fix_gamma=False,
         momentum=bn_momentum,
         # Same with https://github.com/soumith/cudnn.torch/blob/master/BatchNormalization.lua
-        # eps=1e-5
-        # cuDNN v5 don't allow such small eps
+        # cuDNN v5 don't allow a small eps of 1e-5
+        eps=2e-5
     )
     return (
         # It's better to remove ReLU here

--- a/example/image-classification/symbol_resnet.py
+++ b/example/image-classification/symbol_resnet.py
@@ -36,7 +36,8 @@ def get_conv(
         fix_gamma=False,
         momentum=bn_momentum,
         # Same with https://github.com/soumith/cudnn.torch/blob/master/BatchNormalization.lua
-        eps=1e-5
+        # eps=1e-5
+        # cuDNN v5 don't allow such small eps
     )
     return (
         # It's better to remove ReLU here

--- a/example/image-classification/train_cifar10_resnet.py
+++ b/example/image-classification/train_cifar10_resnet.py
@@ -2,6 +2,37 @@
 Reproducing https://github.com/gcr/torch-residual-networks
 For image size of 32x32
 
+Test accuracy are 0.9309 and 0.9303 in this patch and Kaiming He's paper, respectively.
+The accuracy is the best one of the last 3 epochs (0.930288, 0.930889 and 0.929587),
+while the original paper select the best one in 5 runs.
+The dockerfile and log are in: https://gist.github.com/Answeror/f9160145e1c64bb509f52c00014bdb77
+
+The only difference between this patch and Facebook's implementation
+(https://github.com/gcr/torch-residual-networks and https://github.com/facebook/fb.resnet.torch) are:
+
+1. The kernel of shortcut with downsampling is 2x2 rather than 1x1.
+   I can't reproduce this accuracy with 1x1 kernel. Note the shortcut does not contain learnable parameters.
+2. I use a BatchNorm after data layer to simulate z-score normalization.
+   Although subtract (127, 127, 127) and divide 60 works equally well.
+3. An eps of 2e-5 is used in BatchNorm instead of 1e-5 because cuDNN v5 don't allow such small eps.
+
+Some details affect the accuracy:
+
+1. Z-score normalization of the input.
+2. Weight decay of all parameters (weight, bias, gamma, beta). See comments in `train_cifar10_resnet.py `for details.
+3. Nesterov momentum
+4. `fix_gamma=False` in BatchNorm (gamma is necessary because of the weight decay of the conv weight)
+5. Initialization
+6. 4 pixel padding
+
+And thanks #1230 (@freesouls) and #1041 (@shuokay) to provide preliminary implementations.
+
+## update@2016-06-08
+
+With #2366 and a batch size of 64, I got an accuracy of 0.939704 after 200 epochs on 2 GPUs.
+Note, **the accuracy is strongly affected by the batch size**, the more GPU you use, the smaller batch size should be.
+See https://gist.github.com/Answeror/f9160145e1c64bb509f52c00014bdb77#file-resnet-dual-gpu-log for the full log.
+
 References:
 
 Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun. "Deep Residual Learning for Image Recognition"

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -743,11 +743,6 @@ class FeedForward(BASE_ESTIMATOR):
 
         arg_names, param_names, aux_names = \
                 self._init_params(dict(data.provide_data+data.provide_label))
-        param_idx2name = {}
-        for i, n in enumerate(param_names):
-            for k in range(len(self.ctx)):
-                param_idx2name[i*len(self.ctx)+k] = n
-        self.kwargs["param_idx2name"] = param_idx2name
 
         # setup metric
         if not isinstance(eval_metric, metric.EvalMetric):
@@ -756,6 +751,15 @@ class FeedForward(BASE_ESTIMATOR):
         # create kvstore
         (kvstore, update_on_kvstore) = _create_kvstore(
             kvstore, len(self.ctx), self.arg_params)
+
+        param_idx2name = {}
+        if update_on_kvstore:
+            param_idx2name.update(enumerate(param_names))
+        else:
+            for i, n in enumerate(param_names):
+                for k in range(len(self.ctx)):
+                    param_idx2name[i*len(self.ctx)+k] = n
+        self.kwargs["param_idx2name"] = param_idx2name
 
         # init optmizer
         if isinstance(self.optimizer, str):


### PR DESCRIPTION
This patch is related to #2327 and #2337, which fix a bug of `idx2name` in multi-GPU environment for Module.
**Note, all previous codes which involved `lr_mult` and `wd_mult` in multi-GPU environment may suffer from this bug,**
for example, finetuning with `lr_mult` of lower layers fixed to zero on multi-GPU will give incorrect result.

With this patch, the ResNet example works on multi-GPU setting:

```
2016-06-07 11:19:56,313 Node[0] Start training with [gpu(0), gpu(1)]
2016-06-07 11:20:22,748 Node[0] Epoch[0] Batch [50]     Speed: 2504.86 samples/sec      Train-accuracy=0.122969
2016-06-07 11:20:25,337 Node[0] Epoch[0] Batch [100]    Speed: 2472.41 samples/sec      Train-accuracy=0.176094
2016-06-07 11:20:27,888 Node[0] Epoch[0] Batch [150]    Speed: 2509.07 samples/sec      Train-accuracy=0.225781
2016-06-07 11:20:30,465 Node[0] Epoch[0] Batch [200]    Speed: 2483.77 samples/sec      Train-accuracy=0.249531
2016-06-07 11:20:33,081 Node[0] Epoch[0] Batch [250]    Speed: 2446.37 samples/sec      Train-accuracy=0.286250
2016-06-07 11:20:35,754 Node[0] Epoch[0] Batch [300]    Speed: 2394.48 samples/sec      Train-accuracy=0.324062
2016-06-07 11:20:38,324 Node[0] Epoch[0] Batch [350]    Speed: 2490.45 samples/sec      Train-accuracy=0.337344
2016-06-07 11:20:40,480 Node[0] Epoch[0] Resetting Data Iterator
2016-06-07 11:20:40,480 Node[0] Epoch[0] Time cost=20.615
2016-06-07 11:20:40,541 Node[0] Saved checkpoint to "cifar10/resnet-0001.params"
2016-06-07 11:20:41,888 Node[0] Epoch[0] Validation-accuracy=0.398240
2016-06-07 11:20:44,471 Node[0] Epoch[1] Batch [50]     Speed: 2505.95 samples/sec      Train-accuracy=0.379688
2016-06-07 11:20:47,206 Node[0] Epoch[1] Batch [100]    Speed: 2339.58 samples/sec      Train-accuracy=0.409062
2016-06-07 11:20:49,807 Node[0] Epoch[1] Batch [150]    Speed: 2460.86 samples/sec      Train-accuracy=0.412656
2016-06-07 11:20:52,377 Node[0] Epoch[1] Batch [200]    Speed: 2491.13 samples/sec      Train-accuracy=0.445469
2016-06-07 11:20:55,055 Node[0] Epoch[1] Batch [250]    Speed: 2390.02 samples/sec      Train-accuracy=0.449375
2016-06-07 11:20:57,744 Node[0] Epoch[1] Batch [300]    Speed: 2379.72 samples/sec      Train-accuracy=0.468750
2016-06-07 11:21:00,305 Node[0] Epoch[1] Batch [350]    Speed: 2499.19 samples/sec      Train-accuracy=0.472500
2016-06-07 11:21:02,550 Node[0] Epoch[1] Resetting Data Iterator
2016-06-07 11:21:02,550 Node[0] Epoch[1] Time cost=20.662
2016-06-07 11:21:02,611 Node[0] Saved checkpoint to "cifar10/resnet-0002.params"
2016-06-07 11:21:03,633 Node[0] Epoch[1] Validation-accuracy=0.507612
```