### PR TITLE
Update Docker instructions

### DIFF
--- a/docs/how_to/build.md
+++ b/docs/how_to/build.md
@@ -293,15 +293,18 @@ make scalainstall
 
 ## Docker Images
 
-Builds of MXNet are available as [Docker](https://www.docker.com/whatisdocker) images:
-[MXNet Docker (CPU)](https://hub.docker.com/r/kaixhin/mxnet/) or [MXNet Docker (CUDA)](https://hub.docker.com/r/kaixhin/cuda-mxnet/).
-These are updated on a weekly basis with the latest builds of MXNet. Examples of running bash in a Docker container
-are as follows:
+Builds of MXNet are available as [Docker](https://www.docker.com) images:
+[MXNet Docker (CPU)](https://hub.docker.com/r/kaixhin/mxnet/) or
+[MXNet Docker (CUDA)](https://hub.docker.com/r/kaixhin/cuda-mxnet/).
+These are updated on a weekly basis with the latest builds of MXNet.
+Examples of running bash in a Docker container are as follows:
 
 ```bash
 sudo docker run -it kaixhin/mxnet
-sudo docker run -it --device /dev/nvidiactl --device /dev/nvidia-uvm --device /dev/nvidia0 kaixhin/cuda-mxnet:7.0
+sudo nvidia-docker run -it kaixhin/cuda-mxnet:7.0
 ```
 
-For a guide to Docker, see the [official docs](https://docs.docker.com/userguide/). For more details on how to use the
-MXNet Docker images, including requirements for CUDA support, consult the [source project](https://github.com/Kaixhin/dockerfiles).
+For a guide to Docker, see the [official docs](https://docs.docker.com).
+CUDA support requires [NVIDIA Docker](https://github.com/NVIDIA/nvidia-docker).
+For more details on how to use the MXNet Docker images,
+consult the [source project](https://github.com/Kaixhin/dockerfiles).


### PR DESCRIPTION
The CUDA Docker images are moving to use the NVIDIA Docker program, so I've updated the docs appropriately.