### PR TITLE
Power, Maximum and Proper broadcasting support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ endif
 CFLAGS += -I$(ROOTDIR)/mshadow/ -I$(ROOTDIR)/dmlc-core/include -fPIC -Iinclude $(MSHADOW_CFLAGS)
 LDFLAGS = -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)
 ifeq ($(DEBUG), 1)
-	NVCCFLAGS = -D_FORCE_INLINES -g -G -O0 -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
+	NVCCFLAGS = -Xcompiler -std=c++98 -D_FORCE_INLINES -g -G -O0 -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
 else
-	NVCCFLAGS = -D_FORCE_INLINES -g -O3 -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
+	NVCCFLAGS = -Xcompiler -std=c++98 -D_FORCE_INLINES -g -O3 -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
 endif
 
 ifndef LINT_LANG

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -714,6 +714,31 @@ def power(lhs, rhs):
             NDArray._power_scalar,
             NDArray._rpower_scalar)
 
+def maximum(lhs, rhs):
+    """ Perform maximum operator
+
+    Parameters
+    ----------
+    lhs : Array or float value
+        left hand side operand
+
+    rhs : Array of float value
+        right hand side operand
+
+    Returns
+    -------
+    out: Array
+        result array
+    """
+    return _ufunc_helper(
+            lhs,
+            rhs,
+            NDArray._maximum,
+            lambda x, y: x if x > y else y,
+            NDArray._maximum_scalar,
+            None)
+
+
 def true_divide(lhs, rhs):
     """ Same as numpy's true_divide. It adjusts the output type to present the best answer,
     regardless of input types.

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -160,6 +160,12 @@ class NDArray(object):
         else:
             raise TypeError('type %s not supported' % str(type(other)))
 
+    def __pow__(self, other):
+        return power(self, other)
+
+    def __rpow__(self, other):
+        return power(other, self)
+
     def __truediv__(self, other):
         return self.__div__(other)
 
@@ -679,6 +685,44 @@ def divide(lhs, rhs):
         elif lsize > rsize:
             rhs = rhs.broadcast_to(lhs.shape)
         return NDArray._div(lhs, rhs)
+    else:
+        raise TypeError('type %s not supported' % str(type(rhs)))
+    # pylint: enable= no-member, protected-access
+
+def power(lhs, rhs):
+    """ Perform power operator
+
+    Parameters
+    ----------
+    lhs : Array or float value
+        left hand side operand
+
+    rhs : Array of float value
+        right hand side operand
+
+    Returns
+    -------
+    out: Array
+        result array
+    """
+    # pylint: disable= no-member, protected-access
+    if isinstance(lhs, numeric_types):
+        if isinstance(rhs, numeric_types):
+            return lhs ** rhs
+        elif isinstance(rhs, NDArray):
+            return NDArray._rpower_scalar(rhs, float(lhs))
+        else:
+            raise TypeError('type %s not supported' % str(type(rhs)))
+    elif isinstance(rhs, numeric_types):
+        return NDArray._power_scalar(lhs, float(rhs))
+    elif isinstance(rhs, NDArray):
+        lsize = functools.reduce(operator.mul, lhs.shape)
+        rsize = functools.reduce(operator.mul, rhs.shape)
+        if lsize < rsize:
+            lhs = lhs.broadcast_to(rhs.shape)
+        elif lsize > rsize:
+            rhs = rhs.broadcast_to(lhs.shape)
+        return NDArray._power(lhs, rhs)
     else:
         raise TypeError('type %s not supported' % str(type(rhs)))
     # pylint: enable= no-member, protected-access


### PR DESCRIPTION
1. Add power operator in python side with broadcasting support
2. Add maximum operator in python side with broadcasting support
3. Unify broadcasting logic in one `_ufunc_helper` function
4. Temporarily fix problem with cuda and gcc 6.1. gcc 6.1 has default `std=c++14` turned on, so need to add flags to explicitly disable it for nvcc. However, this will cause some warnings.