### PR TITLE
fix clang unsupported option -fopenmp issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ endif
 include $(config)
 include mshadow/make/mshadow.mk
 include $(DMLC_CORE)/make/dmlc.mk
-unexport NO_OPENMP
 
 # all tge possible warning tread
 WARNFLAGS= -Wall


### PR DESCRIPTION
clang: error: unsupported option '-fopenmp'