### PR TITLE
fix worker node could not exit

### DIFF
--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -37,6 +37,7 @@ class KVStoreDist : public KVStoreLocal {
   virtual ~KVStoreDist() {
     Engine::Get()->WaitForAll();
     if (IsWorkerNode()) {
+      ps::Postoffice::Get()->Barrier(ps::kWorkerGroup);
       if (get_rank() == 0) {
         // stop the executor at servers
         SendCommandToServers(kStopServer, "");


### PR DESCRIPTION
https://github.com/dmlc/mxnet/issues/2412
fix worker node could not exit
Wait all worker nodes to send kStopServer command.
