### PR TITLE
add target_shape and adj to deconv for friendly using

### DIFF
--- a/src/operator/deconvolution-inl.h
+++ b/src/operator/deconvolution-inl.h
@@ -352,8 +352,8 @@ class DeconvolutionProp : public OperatorProperty {
         << "incorrect kernel size: " << param_.kernel;
     CHECK_GT(param_.stride.Size(), 0) \
         << "incorrect stride size: " << param_.stride;
-    CHECK_GE(ksize_y-1, adj_y) << "daj(y) must be samller than kernel(h)";
-    CHECK_GE(ksize_x-1, adj_x) << "daj(x) must be samller than kernel(w)";
+    CHECK_GE(ksize_y-1, adj_y) << "adj(y) must be samller than kernel(h)";
+    CHECK_GE(ksize_x-1, adj_x) << "adj(x) must be samller than kernel(w)";
     (*out_shape)[deconv::kOut][1] = param_.num_filter;
     (*out_shape)[deconv::kOut][2] = param_.stride[0] * (dshape[2] - 1) +
         ksize_y - 2 * pad_y + adj_y;

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -635,7 +635,31 @@ def check_deconvolution_gradient(input_shape, num_filter, pad):
     exe_deconv.backward(deconv_out_grad)
     assert reldiff(conv_args_grad[1].asnumpy(), deconv_args_grad[1].asnumpy()) < 1e-6
 
+def check_deconvolution_target_shape(input_shape, kernel, stride, pad, adj, target_shape=None):
+    data = mx.sym.Variable(name="data")
+    deconv = mx.sym.Deconvolution(
+        data=data, kernel=kernel, stride=stride, pad=pad, adj=adj, num_filter=5,
+        target_shape = target_shape if target_shape is not None else (0, 0))
+    arg_names = deconv.list_arguments()
+    arg_shapes, out_shapes, _ = deconv.infer_shape(data=input_shape)
+    assert out_shapes[0] == (input_shape[0], 5, 8, 8)
+
 def test_deconvolution():
+    check_deconvolution_target_shape(
+        input_shape         = (2,3,4,4),
+        kernel              = (3,3),
+        stride              = (2,2),
+        target_shape        = (8,8),
+        pad                 = (99,99),  # will be ignored
+        adj                 = (101,101),  # will be ignored
+    )
+    check_deconvolution_target_shape(
+        input_shape         = (2,3,4,4),
+        kernel              = (3,3),
+        stride              = (2,2),
+        pad                 = (1,1),
+        adj                 = (1,1),
+    )
     check_deconvolution_forward_backward(
         input_shape         = (1,1,5,5),
         num_filter          = 1,


### PR DESCRIPTION
related  #2428 
refer as https://github.com/torch/nn/blob/master/SpatialFullConvolution.lua  

add a test in test_operator.py for shape check. 
i also changed the  line in example/image-classification/train_mnist.py , from 
```conv2 = mx.symbol.Convolution(data=pool1, kernel=(5,5), num_filter=50)```
to:
```conv2 = mx.symbol.Deconvolution(data=pool1, kernel=(2,2), stride=(2,2), target_shape=(25,25), num_filter=50)``` for runing check, and the accuracy is also ok, so i think it should be ok for target_shape.