### PR TITLE
Enable Bulk Execution of a Subgraph For Faster GPU Serving

### DIFF
--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -74,6 +74,10 @@ struct Resource {
    * \brief Get space requested as mshadow Tensor.
    *  The caller can request arbitrary size.
    *
+   *  This space can be shared with other calls to this->get_space.
+   *  So the caller need to serialize the calls when using the conflicted space.
+   *  The temp space will remain valid until release is called.
+   *
    * \param shape the Shape of returning tensor.
    * \param stream the stream of retruning tensor.
    * \return the mshadow tensor requested.
@@ -132,6 +136,16 @@ struct Resource {
         reinterpret_cast<DType*>(get_host_space_internal(shape.Size() * sizeof(DType))),
         shape, shape[ndim - 1], NULL);
   }
+  /*!
+   * \brief Release the all existing allocated space.
+   *  The existing allocated address will remain valdd
+   *  until release is called.
+   *
+   *  Even if user do not call release, the space occupation
+   *  of the resource will remain at most two times of maximum
+   *  requested space.
+   */
+  void release() const;
   /*!
    * \brief internal function to get space from resources.
    * \param size The size of the space.

--- a/src/operator/activation-inl.h
+++ b/src/operator/activation-inl.h
@@ -60,10 +60,6 @@ class ActivationOp : public Operator {
     Tensor<xpu, 2, DType> data = in_data[activation::kData].FlatTo2D<xpu, DType>(s);
     Tensor<xpu, 2, DType> out = out_data[activation::kOut].FlatTo2D<xpu, DType>(s);
     Assign(out, req[activation::kOut], F<ForwardOp>(data));
-    // Use asynchronize complete notification
-    // This is only intended as an example of async ops
-    if (s != NULL) s->Wait();
-    ctx.async_on_complete();
   }
 
   virtual void Backward(const OpContext &ctx,
@@ -83,16 +79,6 @@ class ActivationOp : public Operator {
     Tensor<xpu, 2, DType> m_out_data = out_data[activation::kOut].FlatTo2D<xpu, DType>(s);
     Tensor<xpu, 2, DType> m_in_grad = in_grad[activation::kData].FlatTo2D<xpu, DType>(s);
     Assign(m_in_grad, req[activation::kData], F<BackwardOp>(m_out_data) * m_out_grad);
-    // Use asynchronize complete notification
-    // This is only intended as an example of async ops
-    if (s != NULL) s->Wait();
-    ctx.async_on_complete();
-  }
-
-  virtual ExecType exec_type() const {
-    // Use asynchronize complete notification
-    // This is only intended as an example of async ops
-    return kAsync;
   }
 };  // class ActivationOp
 

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -6,6 +6,7 @@
 #include <dmlc/logging.h>
 #include <mxnet/resource.h>
 #include <mxnet/symbolic.h>
+#include <dmlc/timer.h>
 #include <memory>
 #include <map>
 #include <set>
@@ -288,6 +289,11 @@ GraphExecutor::GetOpExecEntry(uint32_t nid) {
 
 GraphExecutor::~GraphExecutor() {
   Engine::Get()->WaitForAll();
+  for (auto &kv : cached_seg_opr_) {
+    if (kv.second != nullptr) {
+      Engine::Get()->DeleteOperator(kv.second);
+    }
+  }
   // need to delete the operators before delete the NDArray they referenced.
   for (OpNode& node : op_nodes_) {
     node.DeleteOperator();
@@ -825,6 +831,36 @@ void GraphExecutor::InitOpNodes() {
 }
 
 void GraphExecutor::RunOps(bool is_train, size_t topo_start, size_t topo_end) {
+  // heurestic, only enable bulk on forward only
+  bool bulk_exec = prefer_bulk_execution_ && !monitor_callback_
+      && topo_start == 0 && num_forward_nodes_ == topo_order_.size();
+
+  if (bulk_exec) {
+    // encode things into a key
+    size_t key = topo_start * op_nodes_.size() + topo_end;
+    if (cached_seg_opr_.count(key) == 0) {
+      cached_seg_opr_[key] = this->CreateCachedOpr(topo_start, topo_end);
+      if (cached_seg_opr_.at(key) != nullptr) {
+        LOG(INFO) << "Created bulk execution on segment ["
+                  << topo_start << ", " << topo_end << ")";
+      }
+    }
+    auto cached_op = cached_seg_opr_.at(key);
+    if (cached_op != nullptr) {
+      Context* pctx = nullptr;
+      for (size_t i = topo_start; i < topo_end; ++i) {
+        uint32_t nid = topo_order_[i];
+        if (!op_nodes_[nid].activated) continue;
+        if (graph_.nodes[nid].is_variable()) continue;
+        OpNode& opnode = op_nodes_[nid];
+        opnode.op_ctx.is_train = is_train;
+        pctx = &(opnode.ctx);
+      }
+      Engine::Get()->Push(cached_op, *pctx);
+      return;
+    }
+  }
+
   for (size_t i = topo_start; i < topo_end; ++i) {
     uint32_t nid = topo_order_[i];
     if (!op_nodes_[nid].activated) continue;
@@ -941,6 +977,127 @@ void GraphExecutor::Backward(const std::vector<NDArray> &head_grads) {
         << "head_gradient is required in calling backward.";
   }
   RunOps(true, num_forward_nodes_, topo_order_.size());
+}
+
+Engine::OprHandle GraphExecutor::CreateCachedOpr(size_t topo_start, size_t topo_end) {
+  std::vector<Engine::VarHandle> read_vars;
+  std::vector<Engine::VarHandle> write_vars;
+  Context *pctx = nullptr;
+
+  for (size_t k = topo_start; k < topo_end; ++k) {
+    uint32_t nid = topo_order_[k];
+    OpNode& op_node = op_nodes_[nid];
+    if (!op_nodes_[nid].activated) continue;
+    if (graph_.nodes[nid].is_variable()) continue;
+    if (op_node.op->exec_type() != Operator::kSync) {
+      return nullptr;
+    }
+    if (pctx == nullptr) pctx = &(op_node.ctx);
+    if (*pctx != op_node.ctx) {
+      return nullptr;
+    }
+    const StaticGraph::Node& gnode = graph_.nodes[nid];
+    // AddTO: index is used to store in-place add resources.
+    const size_t ninput = gnode.inputs.size() - gnode.addto_index.size();
+
+    for (const DataEntryInfo& out : op_node.outputs) {
+      write_vars.push_back(out.data.var());
+      if (out.type == kTobeBindByExternal) return nullptr;
+    }
+
+    for (const DataEntryInfo& aux : op_node.aux_states) {
+      write_vars.push_back(aux.data.var());
+      if (aux.type == kTobeBindByExternal) return nullptr;
+    }
+
+    for (size_t i = 0; i < ninput; ++i) {
+      const StaticGraph::DataEntry& e = graph_.nodes[nid].inputs[i];
+      const DataEntryInfo &info = op_nodes_[e.source_id].outputs[e.index];
+      read_vars.push_back(info.data.var());
+      if (info.type == kTobeBindByExternal) return nullptr;
+    }
+
+    for (const Resource& r : op_node.op_ctx.requested) {
+      write_vars.push_back(r.var);
+    }
+  }
+  if (pctx == nullptr) return nullptr;
+  // deduplication
+  std::sort(write_vars.begin(), write_vars.end());
+  write_vars.resize(std::unique(write_vars.begin(), write_vars.end()) -
+                    write_vars.begin());
+  std::sort(read_vars.begin(), read_vars.end());
+  read_vars.resize(std::unique(read_vars.begin(), read_vars.end()) -
+                   read_vars.begin());
+  auto wit = write_vars.begin();
+  auto rtop = read_vars.begin();
+  for (auto rit = read_vars.begin(); rit != read_vars.end(); ++rit) {
+    while (wit != write_vars.end() && *wit < *rit) ++wit;
+    if (*wit != *rit) {
+      *rtop = *rit;
+      ++rtop;
+    }
+  }
+  read_vars.resize(rtop - read_vars.begin());
+
+  bool is_gpu = pctx->dev_mask() == gpu::kDevMask;
+  auto exec_fun = [this, topo_start, topo_end, is_gpu]
+      (RunContext ctx, Engine::CallbackOnComplete on_complete) {
+    std::vector<OpReqType> req;
+    std::vector<TBlob> in_data, out_data, aux_data;
+    for (size_t k = topo_start; k < topo_end; ++k) {
+      uint32_t nid = topo_order_[k];
+      if (!op_nodes_[nid].activated) continue;
+      if (graph_.nodes[nid].is_variable()) continue;
+      OpNode& op_node = op_nodes_[nid];
+      const StaticGraph::Node& gnode = graph_.nodes[nid];
+      CHECK_NE(op_node.op->exec_type(), Operator::kCrossDeviceCopy);
+      CHECK_NE(op_node.op->exec_type(), Operator::kAsync);
+      // AddTO: index is used to store in-place add resources.
+      const size_t ninput = gnode.inputs.size() - gnode.addto_index.size();
+      req.clear();
+      in_data.clear();
+      out_data.clear();
+      aux_data.clear();
+      for (const DataEntryInfo& out : op_node.outputs) {
+        req.push_back(out.op_req);
+        out_data.push_back(out.data.data());
+      }
+      for (size_t i = 0; i < gnode.addto_index.size(); ++i) {
+        CHECK_EQ(req[gnode.addto_index[i]], kWriteInplace);
+        req[gnode.addto_index[i]] = kAddTo;
+        const StaticGraph::DataEntry& e = graph_.nodes[nid].inputs[i + ninput];
+        const DataEntryInfo &info = op_nodes_[e.source_id].outputs[e.index];
+        CHECK_EQ(info.inplace_op_id, static_cast<int>(nid));
+      }
+      // aux
+      for (const DataEntryInfo& aux : op_node.aux_states) {
+        aux_data.push_back(aux.data.data());
+      }
+      // input
+      for (size_t i = 0; i < ninput; ++i) {
+        const StaticGraph::DataEntry& e = graph_.nodes[nid].inputs[i];
+        const DataEntryInfo &info = op_nodes_[e.source_id].outputs[e.index];
+        in_data.push_back(info.data.data());
+      }
+      // run the function.
+      Operator* op = op_node.op.get();
+      OpContext* op_ctx_ptr = &op_node.op_ctx;
+      op_ctx_ptr->run_ctx = ctx;
+      op->Forward(*op_ctx_ptr, in_data, req, out_data, aux_data);
+    }
+    if (is_gpu) {
+#if MXNET_USE_CUDA
+      // Wait GPU kernel to finish.
+      ctx.get_stream<gpu>()->Wait();
+#else
+      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+#endif
+    }
+    on_complete();
+  };
+  return Engine::Get()->NewOperator(
+      exec_fun, read_vars, write_vars, FnProperty::kNormal);
 }
 
 Executor *Executor::Bind(Symbol symbol,


### PR DESCRIPTION
This PR enables to push a subgraph as a group, removing sync between all the operations in the subgraph. It contains two commits

- Enable TempSpace resource to persist across several calls, so allocated space in GPU operator will have the same address valid as it executes
- Enable a CreateCachedOpr function to create an operator that executes over the subgraph.
   - The execution mode won't be selected when there is async or operations cross the devices.

Preliminary experiment show that it can improve the prediction speed of small batches on GPU.

see #2462

## Possible Improvement
A smarter scheduler to split the graph into several segments, with each one corresponds to a cached operatpr. 