### PR TITLE
Fixed bug in caffe_converter on windows, added windows instructions

### DIFF
--- a/tools/caffe_converter/README.md
+++ b/tools/caffe_converter/README.md
@@ -1,6 +1,6 @@
 # Convert Caffe Model to Mxnet Format
 
-### Build
+### Build (Linux)
 
 Either [Caffe's python package](http://caffe.berkeleyvision.org/installation.html) or [Google protobuf](https://developers.google.com/protocol-buffers/?hl=en) is required. The latter is often much easier to install:  
 
@@ -10,9 +10,25 @@ Either [Caffe's python package](http://caffe.berkeleyvision.org/installation.htm
 
 Now we can build the tool by running `make` in the current directory.
 
+### Build (Windows)
+
+Note: this tool currently only works on python 2.
+
+We must make sure that the installed python binding and protobuf compiler are using the same version of protobuf,
+so we install the bindings first, and then install the corresponding compiler.
+
+1. Install the protobuf bindings. At time of writing, the conda package manager has the most up to date version. Either run `conda install -c conda-forge protobuf` or `pip install protobuf`
+2. Download the win32 build of protoc from [Protocol Buffers Releases](https://github.com/google/protobuf/releases). Make sure to download the version that corresponds to the version of the bindings. Extract to any location then add that location to your `PATH`
+3. Run `make_win32.bat` to build the package
+
+
 ### How to use
 
-Use `./run.sh model_name` to download and convert a model. E.g. `./run.sh vgg19`
+Linux: Use `./run.sh model_name` to download and convert a model. E.g. `./run.sh vgg19`
+
+Windows: Use `python convert_model.py prototxt caffemodel outputprefix`  
+For example: `python convert_model.py VGG_ILSVRC_16_layers_deploy.prototxt VGG_ILSVRC_16_layers.caffemodel vgg16`
+
 
 ### Note
 

--- a/tools/caffe_converter/caffe_parse/parse_from_protobuf.py
+++ b/tools/caffe_converter/caffe_parse/parse_from_protobuf.py
@@ -10,7 +10,7 @@ def parse_caffemodel(filepath):
 
     returns: layers
     '''
-    f = open(filepath)
+    f = open(filepath, 'rb')
     contents = f.read()
 
     netparam = caffe_pb2.NetParameter()

--- a/tools/caffe_converter/make_win32.bat
+++ b/tools/caffe_converter/make_win32.bat
@@ -1,0 +1,3 @@
+@protoc --python_out=./ ./caffe_parse/caffe.proto
+@echo done.
+@pause


### PR DESCRIPTION
parse_from_protobuf.py does not open the caffemodel in binary mode. This causes a bug when parsing models in windows; the protobuf parser fails with a "Truncated message." error. Opening the file in binary mode resolves this.

Instructions have been added to the readme for using this tool under windows, along with a build script.
