### PR TITLE
[OP] Move sample op to operator_util, support source function

### DIFF
--- a/include/mxnet/operator_util.h
+++ b/include/mxnet/operator_util.h
@@ -61,6 +61,26 @@ struct EnvArguments {
 };
 
 /*!
+ * \brief source function that generate output based on env
+ *  The result container is pre-allocated with the correct shape.
+ * \param env The Environment arguments.
+ * \param ret The containter to store return value.
+ * \param req The requirement to stroe the ret.
+ * \param ctx Runtime context to execute the function.
+ */
+typedef void (*SourceFunction)(const EnvArguments& env,
+                               TBlob* ret,
+                               OpReqType req,
+                               RunContext ctx);
+
+/*!
+ * \brief Shape inference function to get the correct shape.
+ * \param env The Environment arguments.
+ * \return The inferred result shape.
+ */
+typedef TShape (*SourceShapeFunction)(const EnvArguments& env);
+
+/*!
  * \brief Unary function that takes a src and save result to ret.
  *  The result container is pre-allocated with the correct shape.
  * \param src The source data.
@@ -266,6 +286,11 @@ class SimpleOpRegEntry {
    */
   virtual TSelf& set_resource_request(ResourceRequest req) = 0;
   /*!
+   * \brief set source inference function.
+   * \param fshapeinfer The source function that peforms the operation.
+   */
+  virtual TSelf& set_shape_function(SourceShapeFunction fshapeinfer) = 0;
+  /*!
    * \brief set shape inference function.
    *  Default: out_shape = in_shape
    * \param fshapeinfer The unary function that peforms the operation.
@@ -277,6 +302,16 @@ class SimpleOpRegEntry {
    * \param fshapeinfer The binary function that peforms the operation.
    */
   virtual TSelf& set_shape_function(BinaryShapeFunction fshapeinfer) = 0;
+  /*!
+   * \brief set function of the function to be fsource
+   * \param dev_mask The device mask of the function can act on.
+   * \param fsource The unary function that peforms the operation.
+   * \param register_symbolic Whether register a symbolic operator as well.
+   */
+  virtual TSelf& set_function(
+      int dev_mask,
+      SourceFunction fsource,
+      SimpleOpRegOption register_symbolic = kRegisterSymbolic) = 0;
   /*!
    * \brief set function of the function to be funary
    * \param dev_mask The device mask of the function can act on.

--- a/python/mxnet/random.py
+++ b/python/mxnet/random.py
@@ -38,17 +38,17 @@ def uniform(low, high, shape=None, ctx=None, out=None):
         if isinstance(shape, int):
             shape = (shape,)
         out = empty(shape, ctx)
-    return NDArray._random_uniform(low, high, out=out)
+    return NDArray._sample_uniform(low=low, high=high, shape=out.shape, out=out)
 
 
-def normal(mean, stdvar, shape=None, ctx=None, out=None):
+def normal(loc, scale, shape=None, ctx=None, out=None):
     """Generate normal(Gaussian) distribution N(mean, stdvar^2) with shape.
 
     Parameters
     ----------
-    mean : float
+    loc : float
         The mean of the normal distribution.
-    stdvar : float
+    scale : float
         The standard deviation of normal distribution.
     shape : tuple, optional
         Output shape of the NDArray generated.
@@ -71,7 +71,7 @@ def normal(mean, stdvar, shape=None, ctx=None, out=None):
         if isinstance(shape, int):
             shape = (shape,)
         out = empty(shape, ctx)
-    return NDArray._random_gaussian(mean, stdvar, out=out)
+    return NDArray._sample_normal(loc=loc, scale=scale, shape=out.shape, out=out)
 
 
 def seed(seed_state):
@@ -96,4 +96,3 @@ def seed(seed_state):
         raise ValueError('sd must be int')
     seed_state = ctypes.c_int(int(seed_state))
     check_call(_LIB.MXRandomSeed(seed_state))
-

--- a/src/operator/operator_util.cc
+++ b/src/operator/operator_util.cc
@@ -15,6 +15,7 @@ namespace mxnet {
 namespace op {
 
 class SimpleOpPropBase;
+class SimpleSourceOpProp;
 class SimpleUnaryOpProp;
 class SimpleBinaryOpProp;
 
@@ -64,6 +65,12 @@ class SimpleOpRegEntryImpl : public SimpleOpRegEntry {
     return *this;
   }
 
+  TSelf& set_shape_function(SourceShapeFunction fshapeinfer) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    source_shape_ = fshapeinfer;
+    return *this;
+  }
+
   TSelf& set_shape_function(UnaryShapeFunction fshapeinfer) override {
     std::lock_guard<std::mutex> lock(mutex_);
     unary_shape_ = fshapeinfer;
@@ -73,6 +80,21 @@ class SimpleOpRegEntryImpl : public SimpleOpRegEntry {
   TSelf& set_shape_function(BinaryShapeFunction fshapeinfer) override {
     std::lock_guard<std::mutex> lock(mutex_);
     binary_shape_ = fshapeinfer;
+    return *this;
+  }
+
+  TSelf& set_function(int dev_mask,
+                      SourceFunction fsource,
+                      SimpleOpRegOption register_symbolic) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    SetFunction(&fsource_, dev_mask, fsource, "SourceFunction");
+    if (++reg_counter_ == 1) {
+      this->RegisterSourceImperative();
+      register_symbolic_ = (register_symbolic == kRegisterSymbolic);
+      if (register_symbolic_) {
+        this->RegisterSourceSymbolic();
+      }
+    }
     return *this;
   }
 
@@ -178,6 +200,7 @@ class SimpleOpRegEntryImpl : public SimpleOpRegEntry {
  protected:
   // make friend with unary op
   friend class SimpleOpPropBase;
+  friend class SimpleSourceOpProp;
   friend class SimpleUnaryOpProp;
   friend class SimpleBinaryOpProp;
   // internal mutex
@@ -196,6 +219,11 @@ class SimpleOpRegEntryImpl : public SimpleOpRegEntry {
   bool enable_kwargs_{false};
   // resource requirements
   std::vector<ResourceRequest> resource_requests_;
+  // ------ source functions ----
+  // source shape inference information.
+  SourceShapeFunction source_shape_{nullptr};
+  // source functions on each device mask
+  std::vector<SourceFunction> fsource_;
   // ------ unary functions -----
   // unary shape inference information.
   UnaryShapeFunction unary_shape_{nullptr};
@@ -266,6 +294,10 @@ class SimpleOpRegEntryImpl : public SimpleOpRegEntry {
     }
     return *op_reg_;
   }
+  // register source function.
+  void RegisterSourceImperative();
+  // register source symbolic function.
+  void RegisterSourceSymbolic();
   // register unary function.
   void RegisterUnaryImperative();
   // register unary symbolic function.
@@ -295,6 +327,264 @@ SimpleOpRegistry::~SimpleOpRegistry() {
     delete kv.second;
   }
 }
+
+// base class
+struct SimpleOpScalarParam :
+      public dmlc::Parameter<SimpleOpScalarParam> {
+  float scalar;
+  DMLC_DECLARE_PARAMETER(SimpleOpScalarParam) {
+    DMLC_DECLARE_FIELD(scalar)
+        .describe("scalar value.");
+  }
+};
+
+DMLC_REGISTER_PARAMETER(SimpleOpScalarParam);
+
+class SimpleOpPropBase : public OperatorProperty {
+ public:
+  std::string name;
+  EnvArguments env;
+  SimpleOpRegEntryImpl* source;
+
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    if (source->enable_kwargs_) {
+      env.kwargs = kwargs;
+    } else if (source->enable_scalar_) {
+      SimpleOpScalarParam param;
+      param.Init(kwargs);
+      env.scalar = param.scalar;
+    } else {
+      CHECK_EQ(kwargs.size(), 0)
+          << "Operator " << source->symbol_name_ << " donot accept any keyword arguments";
+    }
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    if (source->enable_kwargs_) {
+      return std::map<std::string, std::string>(
+          env.kwargs.begin(), env.kwargs.end());
+    } else if (source->enable_scalar_) {
+      SimpleOpScalarParam param;
+      param.scalar = env.scalar;
+      return param.__DICT__();
+    } else {
+      return std::map<std::string, std::string>();
+    }
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+      const std::vector<TShape> &in_shape) const override {
+    return source->resource_requests_;
+  }
+
+  std::vector<ResourceRequest> BackwardResource(
+      const std::vector<TShape> &in_shape) const override {
+    return source->resource_requests_;
+  }
+
+  bool InferType(std::vector<int> *in_type,
+                 std::vector<int> *out_type,
+                 std::vector<int> *aux_type) const override {
+    CHECK_LE(in_type->size(), this->ListArguments().size());
+    int dtype = -1;
+    // reduce dtype to a common one.
+    for (unsigned i = 0; i < in_type->size(); ++i) {
+      if (dtype == -1) {
+        dtype = in_type->at(i);
+      } else {
+        CHECK(in_type->at(i) == -1 ||
+              in_type->at(i) == dtype) <<
+          "Non-uniform input data type. Expected " << dtype << "got " << in_type->at(i);
+      }
+    }
+
+    if (dtype == -1) {
+      LOG(FATAL) << "At least one input type needs to be specified.";
+      return false;
+    }
+
+    int n_in = this->ListArguments().size();
+    in_type->clear();
+    for (int i = 0; i < n_in; ++i) in_type->push_back(dtype);
+
+    int n_out = this->ListOutputs().size();
+    out_type->clear();
+    for (int i = 0; i < n_out; ++i) out_type->push_back(dtype);
+
+    int n_aux = this->ListAuxiliaryStates().size();
+    aux_type->clear();
+    for (int i = 0; i < n_aux; ++i) aux_type->push_back(dtype);
+    return true;
+  }
+
+  std::string TypeString() const override {
+    return name;
+  }
+};
+
+//-------------------------------------
+// source function Implementation
+//-------------------------------------
+void SimpleOpRegEntryImpl::RegisterSourceImperative() {
+  CHECK_EQ(reg_counter_, 1);
+  // The body to be registered
+  auto body = [this] (NDArray** used_vars,
+                      real_t* s,
+                      NDArray** mutate_vars,
+                      int num_params,
+                      char** param_keys,
+                      char** param_vals) {
+    NDArray* out = mutate_vars[0];
+    // setup env.
+    EnvArguments env;
+    if (enable_scalar_) env.scalar = s[0];
+    if (enable_kwargs_) {
+      for (int i = 0; i < num_params; ++i) {
+        env.kwargs.emplace_back(std::make_pair(
+            std::string(param_keys[i]), std::string(param_vals[i])));
+      }
+    } else {
+      CHECK_EQ(num_params, 0)
+        << "operator " << this->name << " do not take keyword arguments";
+    }
+    // shape inference.
+    CHECK(source_shape_ != nullptr);
+    TShape dshape = source_shape_(env);
+    // check output shape.
+    CHECK(!out->is_none());
+    CHECK(out->shape() == dshape) << "target shape mismatch "
+    << out->shape() << " vs. " << dshape;
+
+    // important: callback must always capture by value
+    NDArray ret = *out;
+    // request resources.
+    std::vector<Engine::VarHandle> write_vars = {ret.var()};
+    for (ResourceRequest req : resource_requests_) {
+      env.resource.push_back(ResourceManager::Get()->Request(ret.ctx(), req));
+      write_vars.push_back(env.resource.back().var);
+    }
+    // check if the function exist
+    int dev_mask = ret.ctx().dev_mask();
+    // error message
+    if (static_cast<size_t>(dev_mask) >= fsource_.size() ||
+        fsource_[dev_mask] == nullptr) {
+      if (dev_mask == gpu::kDevMask) {
+        LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+      }
+      LOG(FATAL) << "Function " << this->name
+                 << "not registered for device " << dev_mask;
+    }
+    // invoke the function
+    SourceFunction fun = fsource_[dev_mask];
+    OpReqType req = kWriteTo;
+
+    Engine::Get()->PushSync([ret, fun, dev_mask, req, env](RunContext ctx) {
+        ret.CheckAndAlloc();
+        TBlob tmp = ret.data();
+        (*fun)(env, &tmp, req, ctx);
+#if MXNET_USE_CUDA
+        if (dev_mask == gpu::kDevMask) {
+          ctx.get_stream<gpu>()->Wait();
+        }
+#endif
+      }, ret.ctx(), {}, write_vars);
+  };
+  // register the function.
+  NDArrayReg()
+      .set_body(body)
+      .set_num_use_vars(0)
+      .set_num_mutate_vars(1);
+  if (enable_scalar_) {
+      NDArrayReg()
+          .set_num_scalars(1)
+          .add_argument("scalar", "float", "scalar input to the function");
+  }
+}
+
+// operator to invoke unary function.
+struct SimpleSourceOperator : public Operator {
+  EnvArguments env;
+  SourceFunction forward;
+
+  void Forward(const OpContext &ctx,
+               const std::vector<TBlob> &in_data,
+               const std::vector<OpReqType> &req,
+               const std::vector<TBlob> &out_data,
+               const std::vector<TBlob> &aux_args) override {
+    if (ctx.requested.size() != 0) env.resource = ctx.requested;
+    CHECK_EQ(in_data.size(), 0);
+    CHECK_EQ(out_data.size(), 1);
+    TBlob out = out_data[0];
+    (*forward)(env, &out, req[0], ctx.run_ctx);
+  }
+
+  void Backward(const OpContext &ctx,
+                const std::vector<TBlob> &out_grad,
+                const std::vector<TBlob> &in_data,
+                const std::vector<TBlob> &out_data,
+                const std::vector<OpReqType> &req,
+                const std::vector<TBlob> &in_grad,
+                const std::vector<TBlob> &aux_args) override {
+    LOG(FATAL) << "no gradient can be done";
+    // no nothing.
+  }
+};  // class SimpleUnaryOperator
+
+class SimpleSourceOpProp : public SimpleOpPropBase {
+ public:
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    CHECK_EQ(in_shape->size(), 0)
+        << in_shape->size();
+    CHECK(source->source_shape_ != nullptr);
+    out_shape->clear();
+    out_shape->push_back((*(source->source_shape_))(env));
+    return true;
+  }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new SimpleSourceOpProp();
+    ptr->source = source;
+    ptr->name = name;
+    ptr->env = env;
+    return ptr;
+  }
+
+  Operator* CreateOperator(Context ctx) const override {
+    size_t dev_mask = ctx.dev_mask();
+    SimpleSourceOperator *op = new SimpleSourceOperator();
+    CHECK(dev_mask < source->fsource_.size() && source->fsource_[dev_mask] != nullptr);
+    op->forward = source->fsource_[dev_mask];
+    op->env = this->env;
+    return op;
+  }
+
+  std::vector<std::string> ListArguments() const override {
+    return {};
+  }
+
+  bool InferType(std::vector<int> *in_type,
+                 std::vector<int> *out_type,
+                 std::vector<int> *aux_type) const override {
+    out_type->clear();
+    out_type->push_back(mshadow::kFloat32);
+    return true;
+  }
+};
+
+void SimpleOpRegEntryImpl::RegisterSourceSymbolic() {
+  // register the operator
+  auto op_factory = [this]() {
+    SimpleSourceOpProp *prop = new SimpleSourceOpProp();
+    prop->name = this->symbol_name_;
+    prop->source = this;
+    return prop;
+  };
+  OpReg()
+      .set_body(op_factory);
+}
+
 //-------------------------------------
 // unary function Implementation
 //-------------------------------------
@@ -457,99 +747,6 @@ struct SimpleUnaryOperator : public Operator {
   }
 };  // class SimpleUnaryOperator
 
-struct SimpleOpScalarParam :
-      public dmlc::Parameter<SimpleOpScalarParam> {
-  float scalar;
-  DMLC_DECLARE_PARAMETER(SimpleOpScalarParam) {
-    DMLC_DECLARE_FIELD(scalar)
-        .describe("scalar value.");
-  }
-};
-
-DMLC_REGISTER_PARAMETER(SimpleOpScalarParam);
-
-class SimpleOpPropBase : public OperatorProperty {
- public:
-  std::string name;
-  EnvArguments env;
-  SimpleOpRegEntryImpl* source;
-
-  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
-    if (source->enable_kwargs_) {
-      env.kwargs = kwargs;
-    } else if (source->enable_scalar_) {
-      SimpleOpScalarParam param;
-      param.Init(kwargs);
-      env.scalar = param.scalar;
-    } else {
-      CHECK_EQ(kwargs.size(), 0)
-          << "Operator " << source->symbol_name_ << " donot accept any keyword arguments";
-    }
-  }
-
-  std::map<std::string, std::string> GetParams() const override {
-    if (source->enable_kwargs_) {
-      return std::map<std::string, std::string>(
-          env.kwargs.begin(), env.kwargs.end());
-    } else if (source->enable_scalar_) {
-      SimpleOpScalarParam param;
-      param.scalar = env.scalar;
-      return param.__DICT__();
-    } else {
-      return std::map<std::string, std::string>();
-    }
-  }
-
-  std::vector<ResourceRequest> ForwardResource(
-      const std::vector<TShape> &in_shape) const override {
-    return source->resource_requests_;
-  }
-
-  std::vector<ResourceRequest> BackwardResource(
-      const std::vector<TShape> &in_shape) const override {
-    return source->resource_requests_;
-  }
-
-  bool InferType(std::vector<int> *in_type,
-                 std::vector<int> *out_type,
-                 std::vector<int> *aux_type) const override {
-    CHECK_LE(in_type->size(), this->ListArguments().size());
-    int dtype = -1;
-    // reduce dtype to a common one.
-    for (unsigned i = 0; i < in_type->size(); ++i) {
-      if (dtype == -1) {
-        dtype = in_type->at(i);
-      } else {
-        CHECK(in_type->at(i) == -1 ||
-              in_type->at(i) == dtype) <<
-          "Non-uniform input data type. Expected " << dtype << "got " << in_type->at(i);
-      }
-    }
-
-    if (dtype == -1) {
-      LOG(FATAL) << "At least one input type needs to be specified.";
-      return false;
-    }
-
-    int n_in = this->ListArguments().size();
-    in_type->clear();
-    for (int i = 0; i < n_in; ++i) in_type->push_back(dtype);
-
-    int n_out = this->ListOutputs().size();
-    out_type->clear();
-    for (int i = 0; i < n_out; ++i) out_type->push_back(dtype);
-
-    int n_aux = this->ListAuxiliaryStates().size();
-    aux_type->clear();
-    for (int i = 0; i < n_aux; ++i) aux_type->push_back(dtype);
-    return true;
-  }
-
-  std::string TypeString() const override {
-    return name;
-  }
-};
-
 class SimpleUnaryOpProp : public SimpleOpPropBase {
  public:
   bool InferShape(std::vector<TShape> *in_shape,
@@ -644,10 +841,8 @@ void SimpleOpRegEntryImpl::RegisterUnarySymbolic() {
   };
   OpReg()
       .set_body(op_factory)
-      .add_argument("lhs", "Symbol", "Left symbolic input to the function")
-      .add_argument("rhs", "Symbol", "Left symbolic input to the function");
+      .add_argument("src", "Symbol", "Left symbolic input to the function");
 }
-
 
 //-------------------------------------
 // binary function Implementation
@@ -933,7 +1128,7 @@ void SimpleOpRegEntryImpl::RegisterBinarySymbolic() {
   OpReg()
       .set_body(op_factory)
       .add_argument("lhs", "Symbol", "Left symbolic input to the function")
-      .add_argument("rhs", "Symbol", "Left symbolic input to the function");
+      .add_argument("rhs", "Symbol", "Right symbolic input to the function");
 }
 
 }  // namespace op

--- a/src/operator/sample_op-inl.h
+++ b/src/operator/sample_op-inl.h
@@ -1,0 +1,112 @@
+/*!
+ *  Copyright (c) 2016 by Contributors
+ * \file sample_op-inl.h
+ * \brief Function defintion sampling operators.
+ */
+#ifndef MXNET_OPERATOR_SAMPLE_OP_INL_H_
+#define MXNET_OPERATOR_SAMPLE_OP_INL_H_
+
+#include <mxnet/operator_util.h>
+#include "./mshadow_op.h"
+
+#if defined(__CUDACC__)
+#define XPU gpu
+#else
+#define XPU cpu
+#endif
+
+namespace mxnet {
+namespace op {
+
+struct SampleUniformParam : public dmlc::Parameter<SampleUniformParam> {
+  float low;
+  float high;
+  TShape shape;
+  DMLC_DECLARE_PARAMETER(SampleUniformParam) {
+    DMLC_DECLARE_FIELD(low).set_default(0.0f)
+        .describe("The lower bound of distribution");
+    DMLC_DECLARE_FIELD(high).set_default(1.0f)
+        .describe("The upper bound of distribution");
+    DMLC_DECLARE_FIELD(shape)
+        .describe("The shape of the output");
+  }
+};
+
+struct SampleNormalParam : public dmlc::Parameter<SampleNormalParam> {
+  float loc;
+  float scale;
+  TShape shape;
+  DMLC_DECLARE_PARAMETER(SampleNormalParam) {
+    DMLC_DECLARE_FIELD(loc).set_default(0.0f)
+        .describe("Mean of the distribution.");
+    DMLC_DECLARE_FIELD(scale).set_default(1.0f)
+        .describe("Standard deviation of the distribution.");
+    DMLC_DECLARE_FIELD(shape)
+        .describe("The shape of the output");
+  }
+};
+
+template<typename xpu>
+void SampleUniform_(const EnvArguments& env,
+                    TBlob *ret,
+                    OpReqType req,
+                    RunContext ctx) {
+  using namespace mxnet::op;
+  using namespace mshadow::expr;
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  CHECK_EQ(ret->type_flag_, mshadow::kFloat32)
+      << "only support float32 rnd so far";
+  SampleUniformParam param;
+  param.Init(env.kwargs);
+  mshadow::Random<xpu, float> *prnd = env.resource[0].get_random<xpu, float>(s);
+  mshadow::Tensor<xpu, 2, float> tmp = ret->FlatTo2D<xpu, float>(s);
+  prnd->SampleUniform(&tmp, float(param.low), float(param.high));  // NOLINT(*)
+}
+
+template<typename xpu>
+void SampleNormal_(const EnvArguments& env,
+                   TBlob *ret,
+                   OpReqType req,
+                   RunContext ctx) {
+  using namespace mxnet::op;
+  using namespace mshadow::expr;
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  CHECK_EQ(ret->type_flag_, mshadow::kFloat32)
+      << "only support float32 rnd so far";
+  SampleNormalParam param;
+  param.Init(env.kwargs);
+  mshadow::Random<xpu, float> *prnd = env.resource[0].get_random<xpu, float>(s);
+  mshadow::Tensor<xpu, 2, float> tmp = ret->FlatTo2D<xpu, float>(s);
+  prnd->SampleGaussian(&tmp, float(param.loc), float(param.scale));  // NOLINT(*)
+}
+
+template<typename ParamType>
+inline TShape SampleShape(const EnvArguments& env) {
+  ParamType param;
+  param.Init(env.kwargs);
+  return param.shape;
+}
+
+// sample uniform
+MXNET_REGISTER_SIMPLE_OP(_sample_uniform, XPU)
+.set_symbol_op_name("uniform")
+.set_enable_kwargs(true)
+.set_resource_request(ResourceRequest::kRandom)
+.set_function(XPU::kDevMask, SampleUniform_<XPU>)
+.set_shape_function(SampleShape<SampleUniformParam>)
+.describe("Sample a uniform distribution")
+.add_arguments(SampleUniformParam::__FIELDS__());
+
+// sample normal
+MXNET_REGISTER_SIMPLE_OP(_sample_normal, XPU)
+.set_symbol_op_name("normal")
+.set_enable_kwargs(true)
+.set_resource_request(ResourceRequest::kRandom)
+.set_function(XPU::kDevMask, SampleNormal_<XPU>)
+.set_shape_function(SampleShape<SampleNormalParam>)
+.describe("Sample a normal distribution")
+.add_arguments(SampleNormalParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_SAMPLE_OP_INL_H_

--- a/src/operator/sample_op.cc
+++ b/src/operator/sample_op.cc
@@ -1,0 +1,16 @@
+/*!
+ *  Copyright (c) 2016 by Contributors
+ * \file sample_op.cc
+ * \brief CPU Implementation of sample op
+ */
+// this will be invoked by cc
+#include "./sample_op-inl.h"
+
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(SampleUniformParam);
+DMLC_REGISTER_PARAMETER(SampleNormalParam);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/sample_op.cu
+++ b/src/operator/sample_op.cu
@@ -1,0 +1,7 @@
+/*!
+ *  Copyright (c) 2016 by Contributors
+ * \file sample_op.cu
+ * \brief GPU Implementation of sample op
+ */
+// this will be invoked by nvcc and compile GPU version
+#include "./sample_op-inl.h"

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -23,10 +23,42 @@ def check_with_device(device):
         assert abs(np.mean(un1.asnumpy()) - (a+b)/2) < 0.1
 
 
+def check_symbolic_random(dev):
+    a, b = -10, 10
+    mu, sigma = 10, 2
+    shape = (100, 100)
+    X = mx.sym.Variable("X")
+    Y = mx.sym.uniform(low=a, high=b, shape=shape) + X
+    x = mx.nd.zeros(shape, ctx=dev)
+    xgrad = mx.nd.zeros(shape, ctx=dev)
+    yexec = Y.bind(dev, {'X' : x}, {'X': xgrad})
+    mx.random.seed(128)
+    yexec.forward()
+    yexec.backward(yexec.outputs[0])
+    un1 = (yexec.outputs[0] - x).copyto(dev)
+    assert same(xgrad.asnumpy(), un1.asnumpy())
+    mx.random.seed(128)
+    yexec.forward()
+    un2 = (yexec.outputs[0] - x).copyto(dev)
+    assert same(un1.asnumpy(), un2.asnumpy())
+    assert abs(np.mean(un1.asnumpy()) - (a+b)/2) < 0.1
+
+    Y = mx.sym.normal(loc=mu, scale=sigma, shape=shape)
+    yexec = Y.simple_bind(dev)
+    mx.random.seed(128)
+    yexec.forward()
+    ret1 = yexec.outputs[0].copyto(dev)
+    mx.random.seed(128)
+    ret2 = mx.random.normal(mu, sigma, shape)
+    assert same(ret1.asnumpy(), ret2.asnumpy())
+    assert abs(np.mean(ret1.asnumpy()) - mu) < 0.1
+    assert abs(np.std(ret1.asnumpy()) - sigma) < 0.1
+
+
 def test_random():
     check_with_device(mx.cpu())
+    check_symbolic_random(mx.cpu())
 
 
 if __name__ == '__main__':
     test_random()
-


### PR DESCRIPTION
This PR enables a symbolic sampling operator under mx.sym.normal and mx.sym.uniform under unified operator API. This makes plugin sampler in the graph easier.

## Changes to do in language APiS
The subsequent package should update the functions as in the python to change NDArray._random_uniform to NDArray._sample_uniform.

The previous registered _random_uniform is still there, but will be removed update the changes in R, julia and scala package follows up. Please reply to this issue after these packages are updates. 

@pluskid @thirdwing @javelinjs 