### PR TITLE
cudnn auto tuning

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -62,7 +62,7 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
     .add_enum("off", conv::kOff)
     .add_enum("limited_workspace", conv::kLimited)
     .add_enum("fastest", conv::kFastest)
-    .set_default(0)
+    .set_default(conv::kLimited)
     .describe("Whether to find convolution algo by running performance test."
               "Leads to higher startup time but may give better speed");
   }

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -25,6 +25,7 @@ namespace conv {
 enum ConvolutionOpInputs {kData, kWeight, kBias};
 enum ConvolutionOpOutputs {kOut};
 enum ConvolutionOpResource {kTempSpace};
+enum ConvolutionOpCudnnTune {kOff, kLimited, kFastest};
 }
 
 struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
@@ -36,6 +37,7 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
   uint32_t num_group;
   uint64_t workspace;
   bool no_bias;
+  int cudnn_tune;
   DMLC_DECLARE_PARAMETER(ConvolutionParam) {
     int shape[] = {1, 1};
     DMLC_DECLARE_FIELD(kernel).describe("convolution kernel size: (y, x)");
@@ -56,6 +58,13 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
     .describe("Tmp workspace for convolution (MB).");
     DMLC_DECLARE_FIELD(no_bias).set_default(false)
     .describe("Whether to disable bias parameter.");
+    DMLC_DECLARE_FIELD(cudnn_tune)
+    .add_enum("off", conv::kOff)
+    .add_enum("limited_workspace", conv::kLimited)
+    .add_enum("fastest", conv::kFastest)
+    .set_default(0)
+    .describe("Whether to find convolution algo by running performance test."
+              "Leads to higher startup time but may give better speed");
   }
 };
 
@@ -289,7 +298,10 @@ class ConvolutionOp : public Operator {
 };  // class ConvolutionOp
 
 template<typename xpu>
-Operator* CreateOp(ConvolutionParam param, int dtype);
+Operator* CreateOp(ConvolutionParam param, int dtype,
+                   std::vector<TShape> *in_shape,
+                   std::vector<TShape> *out_shape,
+                   Context ctx);
 
 #if DMLC_USE_CXX11
 class ConvolutionProp : public OperatorProperty {

--- a/src/operator/convolution.cc
+++ b/src/operator/convolution.cc
@@ -10,7 +10,10 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator* CreateOp<cpu>(ConvolutionParam param, int dtype) {
+Operator* CreateOp<cpu>(ConvolutionParam param, int dtype,
+                        std::vector<TShape> *in_shape,
+                        std::vector<TShape> *out_shape,
+                        Context ctx) {
   Operator *op = NULL;
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
     op = new ConvolutionOp<cpu, DType>(param);
@@ -19,13 +22,14 @@ Operator* CreateOp<cpu>(ConvolutionParam param, int dtype) {
 }
 
 // DO_BIND_DISPATCH comes from operator_common.h
-Operator *ConvolutionProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
-                                     std::vector<int> *in_type) const {
+Operator *ConvolutionProp::CreateOperatorEx(Context ctx,
+                                            std::vector<TShape> *in_shape,
+                                            std::vector<int> *in_type) const {
   std::vector<TShape> out_shape, aux_shape;
   std::vector<int> out_type, aux_type;
   CHECK(InferType(in_type, &out_type, &aux_type));
   CHECK(InferShape(in_shape, &out_shape, &aux_shape));
-  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0]);
+  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], in_shape, &out_shape, ctx);
 }
 
 DMLC_REGISTER_PARAMETER(ConvolutionParam);

--- a/src/operator/convolution.cu
+++ b/src/operator/convolution.cu
@@ -6,6 +6,7 @@
 */
 
 #include "./convolution-inl.h"
+#include <vector>
 #if MXNET_USE_CUDNN == 1
 #include "./cudnn_convolution-inl.h"
 #endif  // MXNET_USE_CUDNN

--- a/src/operator/convolution.cu
+++ b/src/operator/convolution.cu
@@ -13,12 +13,15 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator* CreateOp<gpu>(ConvolutionParam param, int dtype) {
+Operator* CreateOp<gpu>(ConvolutionParam param, int dtype,
+                        std::vector<TShape> *in_shape,
+                        std::vector<TShape> *out_shape,
+                        Context ctx) {
   Operator *op = NULL;
 #if MXNET_USE_CUDNN == 1
   if (param.dilate[0] == 1 && param.dilate[1] == 1) {
     MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
-      op = new CuDNNConvolutionOp<DType>(param);
+      op = new CuDNNConvolutionOp<DType>(param, in_shape, out_shape, ctx);
     })
   } else {
     MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {

--- a/src/operator/cudnn_convolution-inl.h
+++ b/src/operator/cudnn_convolution-inl.h
@@ -43,9 +43,6 @@ class CuDNNConvolutionOp : public Operator {
       TuneCudnnConvolution(param, in_shape, out_shape, ctx, dtype_,
                            &algo_, &back_algo_, &back_algo_w_,
                            &forward_workspace_byte_, &backward_workspace_byte_);
-      LOG(INFO) << "Selecting " << static_cast<int>(algo_) << " for forward.";
-      LOG(INFO) << "Selecting " << static_cast<int>(back_algo_) << " for backward data.";
-      LOG(INFO) << "Selecting " << static_cast<int>(back_algo_w_) << " for backward filter.";
     }
   }
 

--- a/src/operator/cudnn_convolution-inl.h
+++ b/src/operator/cudnn_convolution-inl.h
@@ -12,18 +12,14 @@
 #include "./convolution-inl.h"
 namespace mxnet {
 namespace op {
-#if defined(__CUDACC__) && MXNET_USE_CUDNN == 1
+#if MXNET_USE_CUDNN == 1
 template<typename DType>
 class CuDNNConvolutionOp : public Operator {
  public:
-  explicit CuDNNConvolutionOp(ConvolutionParam param) {
-    this->param_ = param;
-    // convert MB to words
-    param_.workspace = (param_.workspace << 20) / sizeof(DType);
-    init_cudnn_ = false;
-    // TODO(xxx): fp16
-    dtype_ = mshadow::DataType<DType>::kCudnnFlag;
-  }
+  CuDNNConvolutionOp(ConvolutionParam param,
+                              std::vector<TShape> *in_shape,
+                              std::vector<TShape> *out_shape,
+                              Context ctx);
 
   ~CuDNNConvolutionOp() {
     if (init_cudnn_) {
@@ -51,9 +47,6 @@ class CuDNNConvolutionOp : public Operator {
     CHECK_EQ(data.CheckContiguous(), true);
     CHECK_EQ(wmat.CheckContiguous(), true);
     CHECK_EQ(out.CheckContiguous(), true);
-    if (!init_cudnn_) {
-      Init(s, in_data, out_data);
-    }
     Tensor<gpu, 1, DType> workspace =
         ctx.requested[conv::kTempSpace].get_space_typed<gpu, 1, DType>(
                                  mshadow::Shape1(forward_workspace_), s);
@@ -197,139 +190,6 @@ class CuDNNConvolutionOp : public Operator {
   }
 
  private:
-  inline void Init(mshadow::Stream<gpu> *s,
-                   const std::vector<TBlob> &in_data,
-                   const std::vector<TBlob> &out_data) {
-    using namespace mshadow;
-    size_t expected = param_.no_bias ? 2 : 3;
-    #if CUDNN_MAJOR == 5
-    format_ = CUDNN_TENSOR_NCHW;
-    #endif
-    CHECK_EQ(in_data.size(), expected);
-    CHECK_EQ(out_data.size(), 1);
-    if (!init_cudnn_) {
-      init_cudnn_ = true;
-      size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
-      size_t back_size = 0;
-      size_t back_size_w = 0;
-      Tensor<gpu, 4, DType> data = in_data[conv::kData].get<gpu, 4, DType>(s);
-      Tensor<gpu, 4, DType> out = out_data[conv::kOut].get<gpu, 4, DType>(s);
-      data_offset_ = data.shape_[1] / param_.num_group * data.shape_[2] * data.shape_[3];
-      out_offset_ = out.shape_[1] /param_.num_group * out.shape_[2] * out.shape_[3];
-      weight_offset_ = param_.num_filter / param_.num_group * data.shape_[1] / param_.num_group
-                       * param_.kernel[0] * param_.kernel[1];
-      CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc_), CUDNN_STATUS_SUCCESS);
-      #if CUDNN_MAJOR == 5
-      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
-                                          dtype_,
-                                          format_,
-                                          param_.num_filter / param_.num_group,
-                                          data.shape_[1] / param_.num_group,
-                                          param_.kernel[0],
-                                          param_.kernel[1]), CUDNN_STATUS_SUCCESS);
-      #else
-      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
-                                          dtype_,
-                                          param_.num_filter / param_.num_group,
-                                          data.shape_[1] / param_.num_group,
-                                          param_.kernel[0],
-                                          param_.kernel[1]), CUDNN_STATUS_SUCCESS);
-      #endif
-      CHECK_EQ(cudnnSetConvolution2dDescriptor(conv_desc_,
-                                               param_.pad[0],
-                                               param_.pad[1],
-                                               param_.stride[0],
-                                               param_.stride[1],
-                                               1,
-                                               1,
-                                               CUDNN_CROSS_CORRELATION), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnSetTensor4dDescriptorEx(in_desc_,
-                                            dtype_,
-                                            data.shape_[0],
-                                            data.shape_[1] / param_.num_group,
-                                            data.shape_[2],
-                                            data.shape_[3],
-                                            data.shape_[1] * data.shape_[2] * data.shape_[3],
-                                            data.shape_[2] * data.shape_[3],
-                                            data.shape_[3],
-                                            1), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnSetTensor4dDescriptorEx(out_desc_,
-                                            dtype_,
-                                            out.shape_[0],
-                                            out.shape_[1] / param_.num_group,
-                                            out.shape_[2],
-                                            out.shape_[3],
-                                            out.shape_[1] * out.shape_[2] * out.shape_[3],
-                                            out.shape_[2] * out.shape_[3],
-                                            out.shape_[3],
-                                            1), CUDNN_STATUS_SUCCESS);
-      if (!param_.no_bias) {
-        Tensor<gpu, 1, DType> bias = in_data[conv::kBias].get<gpu, 1, DType>(s);
-        bias_offset_ = bias.shape_[0] / param_.num_group;
-        CHECK_EQ(cudnnSetTensor4dDescriptor(bias_desc_,
-                                            CUDNN_TENSOR_NCHW,
-                                            dtype_,
-                                            1,
-                                            bias.shape_[0] / param_.num_group,
-                                            1,
-                                            1), CUDNN_STATUS_SUCCESS);
-      }
-      CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
-      CHECK_EQ(cudnnGetConvolutionForwardAlgorithm(s->dnn_handle_,
-               in_desc_,
-               filter_desc_,
-               conv_desc_,
-               out_desc_,
-               CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &algo_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
-               in_desc_,
-               out_desc_,
-               conv_desc_,
-               filter_desc_,
-               CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &back_algo_w_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardDataAlgorithm(s->dnn_handle_,
-               filter_desc_,
-               out_desc_,
-               conv_desc_,
-               in_desc_,
-               CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &back_algo_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardDataWorkspaceSize(s->dnn_handle_,
-               filter_desc_,
-               out_desc_,
-               conv_desc_,
-               in_desc_,
-               back_algo_,
-               &back_size), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardFilterWorkspaceSize(s->dnn_handle_,
-               in_desc_,
-               out_desc_,
-               conv_desc_,
-               filter_desc_,
-               back_algo_w_,
-               &back_size_w), CUDNN_STATUS_SUCCESS);
-      backward_workspace_byte_ = std::max(back_size, back_size_w);
-      CHECK_EQ(cudnnGetConvolutionForwardWorkspaceSize(s->dnn_handle_,
-               in_desc_,
-               filter_desc_,
-               conv_desc_,
-               out_desc_,
-               algo_,
-               &forward_workspace_byte_), CUDNN_STATUS_SUCCESS);
-      forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
-      backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
-    }
-  }
-
   bool init_cudnn_;
   size_t forward_workspace_;
   size_t backward_workspace_;
@@ -353,7 +213,7 @@ class CuDNNConvolutionOp : public Operator {
   #endif
   ConvolutionParam param_;
 };
-#endif  // __CUDACC__ && CUDNN
+#endif  // CUDNN
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/cudnn_convolution-inl.h
+++ b/src/operator/cudnn_convolution-inl.h
@@ -351,9 +351,9 @@ class CuDNNConvolutionOp : public Operator {
                  out_desc_,
                  algo_,
                  &forward_workspace_byte_), CUDNN_STATUS_SUCCESS);
-        forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
-        backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
       }
+      forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
+      backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
     }
   }
 

--- a/src/operator/cudnn_convolution-inl.h
+++ b/src/operator/cudnn_convolution-inl.h
@@ -13,13 +13,41 @@
 namespace mxnet {
 namespace op {
 #if MXNET_USE_CUDNN == 1
+void TuneCudnnConvolution(ConvolutionParam param,
+                          std::vector<TShape> *in_shape,
+                          std::vector<TShape> *out_shape,
+                          Context ctx,
+                          cudnnDataType_t dtype,
+                          cudnnConvolutionFwdAlgo_t *algo_,
+                          cudnnConvolutionBwdDataAlgo_t *back_algo_,
+                          cudnnConvolutionBwdFilterAlgo_t *back_algo_w_,
+                          size_t *forward_workspace_byte_,
+                          size_t *backward_workspace_byte_);
+
 template<typename DType>
 class CuDNNConvolutionOp : public Operator {
  public:
-  CuDNNConvolutionOp(ConvolutionParam param,
+  explicit CuDNNConvolutionOp(ConvolutionParam param,
                               std::vector<TShape> *in_shape,
                               std::vector<TShape> *out_shape,
-                              Context ctx);
+                              Context ctx) {
+    using namespace mshadow;
+    this->param_ = param;
+    // convert MB to words
+    param_.workspace = (param_.workspace << 20) / sizeof(DType);
+    init_cudnn_ = false;
+    // TODO(xxx): fp16
+    dtype_ = mshadow::DataType<DType>::kCudnnFlag;
+
+    if (param.cudnn_tune != conv::kOff) {
+      TuneCudnnConvolution(param, in_shape, out_shape, ctx, dtype_,
+                           &algo_, &back_algo_, &back_algo_w_,
+                           &forward_workspace_byte_, &backward_workspace_byte_);
+      LOG(INFO) << "Selecting " << static_cast<int>(algo_) << " for forward.";
+      LOG(INFO) << "Selecting " << static_cast<int>(back_algo_) << " for backward data.";
+      LOG(INFO) << "Selecting " << static_cast<int>(back_algo_w_) << " for backward filter.";
+    }
+  }
 
   ~CuDNNConvolutionOp() {
     if (init_cudnn_) {
@@ -47,6 +75,9 @@ class CuDNNConvolutionOp : public Operator {
     CHECK_EQ(data.CheckContiguous(), true);
     CHECK_EQ(wmat.CheckContiguous(), true);
     CHECK_EQ(out.CheckContiguous(), true);
+    if (!init_cudnn_) {
+      Init(s, in_data, out_data);
+    }
     Tensor<gpu, 1, DType> workspace =
         ctx.requested[conv::kTempSpace].get_space_typed<gpu, 1, DType>(
                                  mshadow::Shape1(forward_workspace_), s);
@@ -190,6 +221,142 @@ class CuDNNConvolutionOp : public Operator {
   }
 
  private:
+  inline void Init(mshadow::Stream<gpu> *s,
+                   const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    size_t expected = param_.no_bias ? 2 : 3;
+    #if CUDNN_MAJOR == 5
+    format_ = CUDNN_TENSOR_NCHW;
+    #endif
+    CHECK_EQ(in_data.size(), expected);
+    CHECK_EQ(out_data.size(), 1);
+    if (!init_cudnn_) {
+      init_cudnn_ = true;
+      size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
+      size_t back_size = 0;
+      size_t back_size_w = 0;
+      Tensor<gpu, 4, DType> data = in_data[conv::kData].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> out = out_data[conv::kOut].get<gpu, 4, DType>(s);
+      data_offset_ = data.shape_[1] / param_.num_group * data.shape_[2] * data.shape_[3];
+      out_offset_ = out.shape_[1] /param_.num_group * out.shape_[2] * out.shape_[3];
+      weight_offset_ = param_.num_filter / param_.num_group * data.shape_[1] / param_.num_group
+                       * param_.kernel[0] * param_.kernel[1];
+      CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc_), CUDNN_STATUS_SUCCESS);
+      #if CUDNN_MAJOR == 5
+      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
+                                          dtype_,
+                                          format_,
+                                          param_.num_filter / param_.num_group,
+                                          data.shape_[1] / param_.num_group,
+                                          param_.kernel[0],
+                                          param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+      #else
+      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
+                                          dtype_,
+                                          param_.num_filter / param_.num_group,
+                                          data.shape_[1] / param_.num_group,
+                                          param_.kernel[0],
+                                          param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+      #endif
+      CHECK_EQ(cudnnSetConvolution2dDescriptor(conv_desc_,
+                                               param_.pad[0],
+                                               param_.pad[1],
+                                               param_.stride[0],
+                                               param_.stride[1],
+                                               1,
+                                               1,
+                                               CUDNN_CROSS_CORRELATION), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnSetTensor4dDescriptorEx(in_desc_,
+                                            dtype_,
+                                            data.shape_[0],
+                                            data.shape_[1] / param_.num_group,
+                                            data.shape_[2],
+                                            data.shape_[3],
+                                            data.shape_[1] * data.shape_[2] * data.shape_[3],
+                                            data.shape_[2] * data.shape_[3],
+                                            data.shape_[3],
+                                            1), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnSetTensor4dDescriptorEx(out_desc_,
+                                            dtype_,
+                                            out.shape_[0],
+                                            out.shape_[1] / param_.num_group,
+                                            out.shape_[2],
+                                            out.shape_[3],
+                                            out.shape_[1] * out.shape_[2] * out.shape_[3],
+                                            out.shape_[2] * out.shape_[3],
+                                            out.shape_[3],
+                                            1), CUDNN_STATUS_SUCCESS);
+      if (!param_.no_bias) {
+        Tensor<gpu, 1, DType> bias = in_data[conv::kBias].get<gpu, 1, DType>(s);
+        bias_offset_ = bias.shape_[0] / param_.num_group;
+        CHECK_EQ(cudnnSetTensor4dDescriptor(bias_desc_,
+                                            CUDNN_TENSOR_NCHW,
+                                            dtype_,
+                                            1,
+                                            bias.shape_[0] / param_.num_group,
+                                            1,
+                                            1), CUDNN_STATUS_SUCCESS);
+      }
+
+      if (!param_.cudnn_tune) {
+        CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+        CHECK_EQ(cudnnGetConvolutionForwardAlgorithm(s->dnn_handle_,
+                 in_desc_,
+                 filter_desc_,
+                 conv_desc_,
+                 out_desc_,
+                 CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
+                 workspace_byte,
+                 &algo_), CUDNN_STATUS_SUCCESS);
+        CHECK_EQ(cudnnGetConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
+                 in_desc_,
+                 out_desc_,
+                 conv_desc_,
+                 filter_desc_,
+                 CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+                 workspace_byte,
+                 &back_algo_w_), CUDNN_STATUS_SUCCESS);
+        CHECK_EQ(cudnnGetConvolutionBackwardDataAlgorithm(s->dnn_handle_,
+                 filter_desc_,
+                 out_desc_,
+                 conv_desc_,
+                 in_desc_,
+                 CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
+                 workspace_byte,
+                 &back_algo_), CUDNN_STATUS_SUCCESS);
+        CHECK_EQ(cudnnGetConvolutionBackwardDataWorkspaceSize(s->dnn_handle_,
+                 filter_desc_,
+                 out_desc_,
+                 conv_desc_,
+                 in_desc_,
+                 back_algo_,
+                 &back_size), CUDNN_STATUS_SUCCESS);
+        CHECK_EQ(cudnnGetConvolutionBackwardFilterWorkspaceSize(s->dnn_handle_,
+                 in_desc_,
+                 out_desc_,
+                 conv_desc_,
+                 filter_desc_,
+                 back_algo_w_,
+                 &back_size_w), CUDNN_STATUS_SUCCESS);
+        backward_workspace_byte_ = std::max(back_size, back_size_w);
+        CHECK_EQ(cudnnGetConvolutionForwardWorkspaceSize(s->dnn_handle_,
+                 in_desc_,
+                 filter_desc_,
+                 conv_desc_,
+                 out_desc_,
+                 algo_,
+                 &forward_workspace_byte_), CUDNN_STATUS_SUCCESS);
+        forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
+        backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
+      }
+    }
+  }
+
   bool init_cudnn_;
   size_t forward_workspace_;
   size_t backward_workspace_;
@@ -213,7 +380,7 @@ class CuDNNConvolutionOp : public Operator {
   #endif
   ConvolutionParam param_;
 };
-#endif  // CUDNN
+#endif  // __CUDACC__ && CUDNN
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/cudnn_convolution.cc
+++ b/src/operator/cudnn_convolution.cc
@@ -104,17 +104,17 @@ void TuneCudnnConvolution(ConvolutionParam param,
   Engine::Get()->PushSync([=](RunContext rctx) {
     Stream<gpu> *s = rctx.get_stream<gpu>();
     CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
-    const int max_nalgo = 10;
-    int nalgo = max_nalgo;
+    const int kMaxAlgos = 10;
+    int nalgo = kMaxAlgos;
     int i;
 
-    cudnnConvolutionFwdAlgoPerf_t fwd_algo[max_nalgo];
+    cudnnConvolutionFwdAlgoPerf_t fwd_algo[kMaxAlgos];
     CHECK_EQ(cudnnFindConvolutionForwardAlgorithm(s->dnn_handle_,
              in_desc,
              filter_desc,
              conv_desc,
              out_desc,
-             max_nalgo,
+             kMaxAlgos,
              &nalgo,
              fwd_algo), CUDNN_STATUS_SUCCESS);
     i = 0;
@@ -129,13 +129,13 @@ void TuneCudnnConvolution(ConvolutionParam param,
       *algo = fwd_algo[i].algo;
     }
 
-    cudnnConvolutionBwdFilterAlgoPerf_t bwd_filter_algo[max_nalgo];
+    cudnnConvolutionBwdFilterAlgoPerf_t bwd_filter_algo[kMaxAlgos];
     CHECK_EQ(cudnnFindConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
              in_desc,
              out_desc,
              conv_desc,
              filter_desc,
-             max_nalgo,
+             kMaxAlgos,
              &nalgo,
              bwd_filter_algo), CUDNN_STATUS_SUCCESS);
     i = 0;
@@ -150,13 +150,13 @@ void TuneCudnnConvolution(ConvolutionParam param,
       *back_algo_w = bwd_filter_algo[i].algo;
     }
 
-    cudnnConvolutionBwdDataAlgoPerf_t bwd_data_algo[max_nalgo];
+    cudnnConvolutionBwdDataAlgoPerf_t bwd_data_algo[kMaxAlgos];
     CHECK_EQ(cudnnFindConvolutionBackwardDataAlgorithm(s->dnn_handle_,
              filter_desc,
              out_desc,
              conv_desc,
              in_desc,
-             max_nalgo,
+             kMaxAlgos,
              &nalgo,
              bwd_data_algo), CUDNN_STATUS_SUCCESS);
     i = 0;

--- a/src/operator/cudnn_convolution.cc
+++ b/src/operator/cudnn_convolution.cc
@@ -119,9 +119,9 @@ void TuneCudnnConvolution(ConvolutionParam param,
              fwd_algo), CUDNN_STATUS_SUCCESS);
     i = 0;
     while (i < nalgo
-           && fwd_algo[i].status != CUDNN_STATUS_SUCCESS
-           && param.cudnn_tune == conv::kLimited
-           && fwd_algo[i].memory > workspace_byte) ++i;
+           && (fwd_algo[i].status != CUDNN_STATUS_SUCCESS
+           || (param.cudnn_tune == conv::kLimited
+           && fwd_algo[i].memory > workspace_byte))) ++i;
     if (i == nalgo) {
       LOG(FATAL) << "Failed to find an convolution algorithm.";
     } else {
@@ -140,9 +140,9 @@ void TuneCudnnConvolution(ConvolutionParam param,
              bwd_filter_algo), CUDNN_STATUS_SUCCESS);
     i = 0;
     while (i < nalgo
-           && bwd_filter_algo[i].status != CUDNN_STATUS_SUCCESS
-           && param.cudnn_tune == conv::kLimited
-           && bwd_filter_algo[i].memory > workspace_byte) ++i;
+           && (bwd_filter_algo[i].status != CUDNN_STATUS_SUCCESS
+           || (param.cudnn_tune == conv::kLimited
+           && bwd_filter_algo[i].memory > workspace_byte))) ++i;
     if (i == nalgo) {
       LOG(FATAL) << "Failed to find an convolution algorithm.";
     } else {
@@ -161,9 +161,9 @@ void TuneCudnnConvolution(ConvolutionParam param,
              bwd_data_algo), CUDNN_STATUS_SUCCESS);
     i = 0;
     while (i < nalgo
-           && bwd_data_algo[i].status != CUDNN_STATUS_SUCCESS
-           && param.cudnn_tune == conv::kLimited
-           && bwd_data_algo[i].memory > workspace_byte) ++i;
+           && (bwd_data_algo[i].status != CUDNN_STATUS_SUCCESS
+           || (param.cudnn_tune == conv::kLimited
+           && bwd_data_algo[i].memory > workspace_byte))) ++i;
     if (i == nalgo) {
       LOG(FATAL) << "Failed to find an convolution algorithm.";
     } else {

--- a/src/operator/cudnn_convolution.cc
+++ b/src/operator/cudnn_convolution.cc
@@ -1,0 +1,257 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file cudnn_convolution.cc
+ * \brief
+ * \author Junyuan Xie
+*/
+#include "./cudnn_convolution-inl.h"
+#include <mxnet/base.h>
+#include <mxnet/ndarray.h>
+
+namespace mxnet {
+namespace op {
+template<typename DType>
+CuDNNConvolutionOp<DType>::CuDNNConvolutionOp(ConvolutionParam param,
+                                       std::vector<TShape> *in_shape,
+                                       std::vector<TShape> *out_shape,
+                                       Context ctx) {
+  using namespace mshadow;
+  this->param_ = param;
+  // convert MB to words
+  param_.workspace = (param_.workspace << 20) / sizeof(DType);
+  init_cudnn_ = false;
+  // TODO(xxx): fp16
+  dtype_ = mshadow::DataType<DType>::kCudnnFlag;
+
+  size_t expected = param_.no_bias ? 2 : 3;
+#if CUDNN_MAJOR == 5
+  format_ = CUDNN_TENSOR_NCHW;
+#endif
+  CHECK_EQ(in_shape->size(), expected);
+  CHECK_EQ(out_shape->size(), 1);
+
+  size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
+  size_t back_size = 0;
+  size_t back_size_w = 0;
+  TShape &x_shape = (*in_shape)[conv::kData];
+  TShape &y_shape = (*out_shape)[conv::kOut];
+  data_offset_ = x_shape[1] / param_.num_group * x_shape[2] * x_shape[3];
+  out_offset_ = y_shape[1] /param_.num_group * y_shape[2] * y_shape[3];
+  weight_offset_ = param_.num_filter / param_.num_group * x_shape[1] / param_.num_group
+                   * param_.kernel[0] * param_.kernel[1];
+  CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc_), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc_), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc_), CUDNN_STATUS_SUCCESS);
+#if CUDNN_MAJOR == 5
+  CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
+                                      dtype_,
+                                      format_,
+                                      param_.num_filter / param_.num_group,
+                                      x_shape[1] / param_.num_group,
+                                      param_.kernel[0],
+                                      param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+#else
+  CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
+                                      dtype_,
+                                      param_.num_filter / param_.num_group,
+                                      x_shape[1] / param_.num_group,
+                                      param_.kernel[0],
+                                      param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+#endif
+  CHECK_EQ(cudnnSetConvolution2dDescriptor(conv_desc_,
+                                           param_.pad[0],
+                                           param_.pad[1],
+                                           param_.stride[0],
+                                           param_.stride[1],
+                                           1,
+                                           1,
+                                           CUDNN_CROSS_CORRELATION), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnSetTensor4dDescriptorEx(in_desc_,
+                                        dtype_,
+                                        x_shape[0],
+                                        x_shape[1] / param_.num_group,
+                                        x_shape[2],
+                                        x_shape[3],
+                                        x_shape[1] * x_shape[2] * x_shape[3],
+                                        x_shape[2] * x_shape[3],
+                                        x_shape[3],
+                                        1), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnSetTensor4dDescriptorEx(out_desc_,
+                                        dtype_,
+                                        y_shape[0],
+                                        y_shape[1] / param_.num_group,
+                                        y_shape[2],
+                                        y_shape[3],
+                                        y_shape[1] * y_shape[2] * y_shape[3],
+                                        y_shape[2] * y_shape[3],
+                                        y_shape[3],
+                                        1), CUDNN_STATUS_SUCCESS);
+  if (!param_.no_bias) {
+    TShape bias_shape = (*in_shape)[conv::kBias];
+    bias_offset_ = bias_shape[0] / param_.num_group;
+    CHECK_EQ(cudnnSetTensor4dDescriptor(bias_desc_,
+                                        CUDNN_TENSOR_NCHW,
+                                        dtype_,
+                                        1,
+                                        bias_shape[0] / param_.num_group,
+                                        1,
+                                        1), CUDNN_STATUS_SUCCESS);
+  }
+
+  Engine::VarHandle var = Engine::Get()->NewVariable();
+  if (param.cudnn_tune == conv::kOff) {
+    Engine::Get()->PushSync([&](RunContext rctx) {
+      Stream<gpu> *s = rctx.get_stream<gpu>();
+      CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+      CHECK_EQ(cudnnGetConvolutionForwardAlgorithm(s->dnn_handle_,
+               in_desc_,
+               filter_desc_,
+               conv_desc_,
+               out_desc_,
+               CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
+               workspace_byte,
+               &algo_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnGetConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
+               in_desc_,
+               out_desc_,
+               conv_desc_,
+               filter_desc_,
+               CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+               workspace_byte,
+               &back_algo_w_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnGetConvolutionBackwardDataAlgorithm(s->dnn_handle_,
+               filter_desc_,
+               out_desc_,
+               conv_desc_,
+               in_desc_,
+               CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
+               workspace_byte,
+               &back_algo_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnGetConvolutionBackwardDataWorkspaceSize(s->dnn_handle_,
+               filter_desc_,
+               out_desc_,
+               conv_desc_,
+               in_desc_,
+               back_algo_,
+               &back_size), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnGetConvolutionBackwardFilterWorkspaceSize(s->dnn_handle_,
+               in_desc_,
+               out_desc_,
+               conv_desc_,
+               filter_desc_,
+               back_algo_w_,
+               &back_size_w), CUDNN_STATUS_SUCCESS);
+      backward_workspace_byte_ = std::max(back_size, back_size_w);
+      CHECK_EQ(cudnnGetConvolutionForwardWorkspaceSize(s->dnn_handle_,
+               in_desc_,
+               filter_desc_,
+               conv_desc_,
+               out_desc_,
+               algo_,
+               &forward_workspace_byte_), CUDNN_STATUS_SUCCESS);
+      forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
+      backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
+    }, ctx, {}, {var});
+  } else {
+    Engine::Get()->PushSync([&](RunContext rctx) {
+      Stream<gpu> *s = rctx.get_stream<gpu>();
+      CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+      const int max_nalgo = 10;
+      int nalgo = max_nalgo;
+      int i;
+
+      cudnnConvolutionFwdAlgoPerf_t fwd_algo[max_nalgo];
+      CHECK_EQ(cudnnFindConvolutionForwardAlgorithm(s->dnn_handle_,
+               in_desc_,
+               filter_desc_,
+               conv_desc_,
+               out_desc_,
+               max_nalgo,
+               &nalgo,
+               fwd_algo), CUDNN_STATUS_SUCCESS);
+      i = 0;
+      while (i < nalgo
+             && fwd_algo[i].status != CUDNN_STATUS_SUCCESS
+             && param.cudnn_tune == conv::kLimited
+             && fwd_algo[i].memory > workspace_byte) ++i;
+      if (i == nalgo) {
+        LOG(FATAL) << "Failed to find an convolution algorithm.";
+      } else {
+        forward_workspace_byte_ = fwd_algo[i].memory;
+        algo_ = fwd_algo[i].algo;
+        LOG(INFO) << "Selecting " << static_cast<int>(algo_) << " for forward.";
+      }
+
+      cudnnConvolutionBwdFilterAlgoPerf_t bwd_filter_algo[max_nalgo];
+      CHECK_EQ(cudnnFindConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
+               in_desc_,
+               out_desc_,
+               conv_desc_,
+               filter_desc_,
+               max_nalgo,
+               &nalgo,
+               bwd_filter_algo), CUDNN_STATUS_SUCCESS);
+      i = 0;
+      while (i < nalgo
+             && bwd_filter_algo[i].status != CUDNN_STATUS_SUCCESS
+             && param.cudnn_tune == conv::kLimited
+             && bwd_filter_algo[i].memory > workspace_byte) ++i;
+      if (i == nalgo) {
+        LOG(FATAL) << "Failed to find an convolution algorithm.";
+      } else {
+        backward_workspace_byte_ = bwd_filter_algo[i].memory;
+        back_algo_w_ = bwd_filter_algo[i].algo;
+        LOG(INFO) << "Selecting " << static_cast<int>(back_algo_w_) << " for backward filter.";
+      }
+
+      cudnnConvolutionBwdDataAlgoPerf_t bwd_data_algo[max_nalgo];
+      CHECK_EQ(cudnnFindConvolutionBackwardDataAlgorithm(s->dnn_handle_,
+               filter_desc_,
+               out_desc_,
+               conv_desc_,
+               in_desc_,
+               max_nalgo,
+               &nalgo,
+               bwd_data_algo), CUDNN_STATUS_SUCCESS);
+      i = 0;
+      while (i < nalgo
+             && bwd_data_algo[i].status != CUDNN_STATUS_SUCCESS
+             && param.cudnn_tune == conv::kLimited
+             && bwd_data_algo[i].memory > workspace_byte) ++i;
+      if (i == nalgo) {
+        LOG(FATAL) << "Failed to find an convolution algorithm.";
+      } else {
+        backward_workspace_byte_ = std::max(backward_workspace_byte_, bwd_data_algo[i].memory);
+        back_algo_ = bwd_data_algo[i].algo;
+        LOG(INFO) << "Selecting " << static_cast<int>(back_algo_) << " for backward data.";
+      }
+      
+      forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
+      backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
+    }, ctx, {}, {var});
+  }
+  Engine::Get()->WaitForVar(var);
+  Engine::Get()->DeleteVariable([](RunContext s) {}, ctx, var);
+  init_cudnn_ = true;
+}
+
+template<>
+CuDNNConvolutionOp<float>::CuDNNConvolutionOp(ConvolutionParam,
+                                                    std::vector<TShape>*,
+                                                    std::vector<TShape>*,
+                                                    Context);
+template<>
+CuDNNConvolutionOp<double>::CuDNNConvolutionOp(ConvolutionParam,
+                                                     std::vector<TShape>*,
+                                                     std::vector<TShape>*,
+                                                     Context);
+template<>
+CuDNNConvolutionOp<mshadow::half::half_t>::CuDNNConvolutionOp(ConvolutionParam,
+                                                                    std::vector<TShape>*,
+                                                                    std::vector<TShape>*,
+                                                                    Context);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/cudnn_convolution.cc
+++ b/src/operator/cudnn_convolution.cc
@@ -10,248 +10,176 @@
 
 namespace mxnet {
 namespace op {
-template<typename DType>
-CuDNNConvolutionOp<DType>::CuDNNConvolutionOp(ConvolutionParam param,
-                                       std::vector<TShape> *in_shape,
-                                       std::vector<TShape> *out_shape,
-                                       Context ctx) {
+#if MXNET_USE_CUDNN == 1
+void TuneCudnnConvolution(ConvolutionParam param,
+                          std::vector<TShape> *in_shape,
+                          std::vector<TShape> *out_shape,
+                          Context ctx,
+                          cudnnDataType_t dtype,
+                          cudnnConvolutionFwdAlgo_t *algo,
+                          cudnnConvolutionBwdDataAlgo_t *back_algo,
+                          cudnnConvolutionBwdFilterAlgo_t *back_algo_w,
+                          size_t *forward_workspace_byte,
+                          size_t *backward_workspace_byte) {
   using namespace mshadow;
-  this->param_ = param;
-  // convert MB to words
-  param_.workspace = (param_.workspace << 20) / sizeof(DType);
-  init_cudnn_ = false;
-  // TODO(xxx): fp16
-  dtype_ = mshadow::DataType<DType>::kCudnnFlag;
+  // convert MB to bytes
 
-  size_t expected = param_.no_bias ? 2 : 3;
+  size_t expected = param.no_bias ? 2 : 3;
 #if CUDNN_MAJOR == 5
-  format_ = CUDNN_TENSOR_NCHW;
+  cudnnTensorFormat_t format = CUDNN_TENSOR_NCHW;
 #endif
   CHECK_EQ(in_shape->size(), expected);
   CHECK_EQ(out_shape->size(), 1);
-
-  size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
-  size_t back_size = 0;
-  size_t back_size_w = 0;
   TShape &x_shape = (*in_shape)[conv::kData];
   TShape &y_shape = (*out_shape)[conv::kOut];
-  data_offset_ = x_shape[1] / param_.num_group * x_shape[2] * x_shape[3];
-  out_offset_ = y_shape[1] /param_.num_group * y_shape[2] * y_shape[3];
-  weight_offset_ = param_.num_filter / param_.num_group * x_shape[1] / param_.num_group
-                   * param_.kernel[0] * param_.kernel[1];
-  CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
-  CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
-  CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc_), CUDNN_STATUS_SUCCESS);
-  CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc_), CUDNN_STATUS_SUCCESS);
-  CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc_), CUDNN_STATUS_SUCCESS);
+
+
+  size_t workspace_byte = param.workspace << 20;
+  cudnnTensorDescriptor_t in_desc;
+  cudnnTensorDescriptor_t out_desc;
+  cudnnTensorDescriptor_t bias_desc;
+  cudnnFilterDescriptor_t filter_desc;
+  cudnnConvolutionDescriptor_t conv_desc;
+  CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc), CUDNN_STATUS_SUCCESS);
 #if CUDNN_MAJOR == 5
-  CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
-                                      dtype_,
-                                      format_,
-                                      param_.num_filter / param_.num_group,
-                                      x_shape[1] / param_.num_group,
-                                      param_.kernel[0],
-                                      param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc,
+                                      dtype,
+                                      format,
+                                      param.num_filter / param.num_group,
+                                      x_shape[1] / param.num_group,
+                                      param.kernel[0],
+                                      param.kernel[1]), CUDNN_STATUS_SUCCESS);
 #else
-  CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
-                                      dtype_,
-                                      param_.num_filter / param_.num_group,
-                                      x_shape[1] / param_.num_group,
-                                      param_.kernel[0],
-                                      param_.kernel[1]), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc,
+                                      dtype,
+                                      param.num_filter / param.num_group,
+                                      x_shape[1] / param.num_group,
+                                      param.kernel[0],
+                                      param.kernel[1]), CUDNN_STATUS_SUCCESS);
 #endif
-  CHECK_EQ(cudnnSetConvolution2dDescriptor(conv_desc_,
-                                           param_.pad[0],
-                                           param_.pad[1],
-                                           param_.stride[0],
-                                           param_.stride[1],
+  CHECK_EQ(cudnnSetConvolution2dDescriptor(conv_desc,
+                                           param.pad[0],
+                                           param.pad[1],
+                                           param.stride[0],
+                                           param.stride[1],
                                            1,
                                            1,
                                            CUDNN_CROSS_CORRELATION), CUDNN_STATUS_SUCCESS);
-  CHECK_EQ(cudnnSetTensor4dDescriptorEx(in_desc_,
-                                        dtype_,
+  CHECK_EQ(cudnnSetTensor4dDescriptorEx(in_desc,
+                                        dtype,
                                         x_shape[0],
-                                        x_shape[1] / param_.num_group,
+                                        x_shape[1] / param.num_group,
                                         x_shape[2],
                                         x_shape[3],
                                         x_shape[1] * x_shape[2] * x_shape[3],
                                         x_shape[2] * x_shape[3],
                                         x_shape[3],
                                         1), CUDNN_STATUS_SUCCESS);
-  CHECK_EQ(cudnnSetTensor4dDescriptorEx(out_desc_,
-                                        dtype_,
+  CHECK_EQ(cudnnSetTensor4dDescriptorEx(out_desc,
+                                        dtype,
                                         y_shape[0],
-                                        y_shape[1] / param_.num_group,
+                                        y_shape[1] / param.num_group,
                                         y_shape[2],
                                         y_shape[3],
                                         y_shape[1] * y_shape[2] * y_shape[3],
                                         y_shape[2] * y_shape[3],
                                         y_shape[3],
                                         1), CUDNN_STATUS_SUCCESS);
-  if (!param_.no_bias) {
+  if (!param.no_bias) {
     TShape bias_shape = (*in_shape)[conv::kBias];
-    bias_offset_ = bias_shape[0] / param_.num_group;
-    CHECK_EQ(cudnnSetTensor4dDescriptor(bias_desc_,
+    CHECK_EQ(cudnnSetTensor4dDescriptor(bias_desc,
                                         CUDNN_TENSOR_NCHW,
-                                        dtype_,
+                                        dtype,
                                         1,
-                                        bias_shape[0] / param_.num_group,
+                                        bias_shape[0] / param.num_group,
                                         1,
                                         1), CUDNN_STATUS_SUCCESS);
   }
 
   Engine::VarHandle var = Engine::Get()->NewVariable();
-  if (param.cudnn_tune == conv::kOff) {
-    Engine::Get()->PushSync([&](RunContext rctx) {
-      Stream<gpu> *s = rctx.get_stream<gpu>();
-      CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
-      CHECK_EQ(cudnnGetConvolutionForwardAlgorithm(s->dnn_handle_,
-               in_desc_,
-               filter_desc_,
-               conv_desc_,
-               out_desc_,
-               CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &algo_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
-               in_desc_,
-               out_desc_,
-               conv_desc_,
-               filter_desc_,
-               CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &back_algo_w_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardDataAlgorithm(s->dnn_handle_,
-               filter_desc_,
-               out_desc_,
-               conv_desc_,
-               in_desc_,
-               CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &back_algo_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardDataWorkspaceSize(s->dnn_handle_,
-               filter_desc_,
-               out_desc_,
-               conv_desc_,
-               in_desc_,
-               back_algo_,
-               &back_size), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardFilterWorkspaceSize(s->dnn_handle_,
-               in_desc_,
-               out_desc_,
-               conv_desc_,
-               filter_desc_,
-               back_algo_w_,
-               &back_size_w), CUDNN_STATUS_SUCCESS);
-      backward_workspace_byte_ = std::max(back_size, back_size_w);
-      CHECK_EQ(cudnnGetConvolutionForwardWorkspaceSize(s->dnn_handle_,
-               in_desc_,
-               filter_desc_,
-               conv_desc_,
-               out_desc_,
-               algo_,
-               &forward_workspace_byte_), CUDNN_STATUS_SUCCESS);
-      forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
-      backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
-    }, ctx, {}, {var});
-  } else {
-    Engine::Get()->PushSync([&](RunContext rctx) {
-      Stream<gpu> *s = rctx.get_stream<gpu>();
-      CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
-      const int max_nalgo = 10;
-      int nalgo = max_nalgo;
-      int i;
+  Engine::Get()->PushSync([=](RunContext rctx) {
+    Stream<gpu> *s = rctx.get_stream<gpu>();
+    CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+    const int max_nalgo = 10;
+    int nalgo = max_nalgo;
+    int i;
 
-      cudnnConvolutionFwdAlgoPerf_t fwd_algo[max_nalgo];
-      CHECK_EQ(cudnnFindConvolutionForwardAlgorithm(s->dnn_handle_,
-               in_desc_,
-               filter_desc_,
-               conv_desc_,
-               out_desc_,
-               max_nalgo,
-               &nalgo,
-               fwd_algo), CUDNN_STATUS_SUCCESS);
-      i = 0;
-      while (i < nalgo
-             && fwd_algo[i].status != CUDNN_STATUS_SUCCESS
-             && param.cudnn_tune == conv::kLimited
-             && fwd_algo[i].memory > workspace_byte) ++i;
-      if (i == nalgo) {
-        LOG(FATAL) << "Failed to find an convolution algorithm.";
-      } else {
-        forward_workspace_byte_ = fwd_algo[i].memory;
-        algo_ = fwd_algo[i].algo;
-        LOG(INFO) << "Selecting " << static_cast<int>(algo_) << " for forward.";
-      }
+    cudnnConvolutionFwdAlgoPerf_t fwd_algo[max_nalgo];
+    CHECK_EQ(cudnnFindConvolutionForwardAlgorithm(s->dnn_handle_,
+             in_desc,
+             filter_desc,
+             conv_desc,
+             out_desc,
+             max_nalgo,
+             &nalgo,
+             fwd_algo), CUDNN_STATUS_SUCCESS);
+    i = 0;
+    while (i < nalgo
+           && fwd_algo[i].status != CUDNN_STATUS_SUCCESS
+           && param.cudnn_tune == conv::kLimited
+           && fwd_algo[i].memory > workspace_byte) ++i;
+    if (i == nalgo) {
+      LOG(FATAL) << "Failed to find an convolution algorithm.";
+    } else {
+      *forward_workspace_byte = fwd_algo[i].memory;
+      *algo = fwd_algo[i].algo;
+    }
 
-      cudnnConvolutionBwdFilterAlgoPerf_t bwd_filter_algo[max_nalgo];
-      CHECK_EQ(cudnnFindConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
-               in_desc_,
-               out_desc_,
-               conv_desc_,
-               filter_desc_,
-               max_nalgo,
-               &nalgo,
-               bwd_filter_algo), CUDNN_STATUS_SUCCESS);
-      i = 0;
-      while (i < nalgo
-             && bwd_filter_algo[i].status != CUDNN_STATUS_SUCCESS
-             && param.cudnn_tune == conv::kLimited
-             && bwd_filter_algo[i].memory > workspace_byte) ++i;
-      if (i == nalgo) {
-        LOG(FATAL) << "Failed to find an convolution algorithm.";
-      } else {
-        backward_workspace_byte_ = bwd_filter_algo[i].memory;
-        back_algo_w_ = bwd_filter_algo[i].algo;
-        LOG(INFO) << "Selecting " << static_cast<int>(back_algo_w_) << " for backward filter.";
-      }
+    cudnnConvolutionBwdFilterAlgoPerf_t bwd_filter_algo[max_nalgo];
+    CHECK_EQ(cudnnFindConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
+             in_desc,
+             out_desc,
+             conv_desc,
+             filter_desc,
+             max_nalgo,
+             &nalgo,
+             bwd_filter_algo), CUDNN_STATUS_SUCCESS);
+    i = 0;
+    while (i < nalgo
+           && bwd_filter_algo[i].status != CUDNN_STATUS_SUCCESS
+           && param.cudnn_tune == conv::kLimited
+           && bwd_filter_algo[i].memory > workspace_byte) ++i;
+    if (i == nalgo) {
+      LOG(FATAL) << "Failed to find an convolution algorithm.";
+    } else {
+      *backward_workspace_byte = bwd_filter_algo[i].memory;
+      *back_algo_w = bwd_filter_algo[i].algo;
+    }
 
-      cudnnConvolutionBwdDataAlgoPerf_t bwd_data_algo[max_nalgo];
-      CHECK_EQ(cudnnFindConvolutionBackwardDataAlgorithm(s->dnn_handle_,
-               filter_desc_,
-               out_desc_,
-               conv_desc_,
-               in_desc_,
-               max_nalgo,
-               &nalgo,
-               bwd_data_algo), CUDNN_STATUS_SUCCESS);
-      i = 0;
-      while (i < nalgo
-             && bwd_data_algo[i].status != CUDNN_STATUS_SUCCESS
-             && param.cudnn_tune == conv::kLimited
-             && bwd_data_algo[i].memory > workspace_byte) ++i;
-      if (i == nalgo) {
-        LOG(FATAL) << "Failed to find an convolution algorithm.";
-      } else {
-        backward_workspace_byte_ = std::max(backward_workspace_byte_, bwd_data_algo[i].memory);
-        back_algo_ = bwd_data_algo[i].algo;
-        LOG(INFO) << "Selecting " << static_cast<int>(back_algo_) << " for backward data.";
-      }
-      
-      forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
-      backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
-    }, ctx, {}, {var});
-  }
+    cudnnConvolutionBwdDataAlgoPerf_t bwd_data_algo[max_nalgo];
+    CHECK_EQ(cudnnFindConvolutionBackwardDataAlgorithm(s->dnn_handle_,
+             filter_desc,
+             out_desc,
+             conv_desc,
+             in_desc,
+             max_nalgo,
+             &nalgo,
+             bwd_data_algo), CUDNN_STATUS_SUCCESS);
+    i = 0;
+    while (i < nalgo
+           && bwd_data_algo[i].status != CUDNN_STATUS_SUCCESS
+           && param.cudnn_tune == conv::kLimited
+           && bwd_data_algo[i].memory > workspace_byte) ++i;
+    if (i == nalgo) {
+      LOG(FATAL) << "Failed to find an convolution algorithm.";
+    } else {
+      *backward_workspace_byte = std::max(*backward_workspace_byte, bwd_data_algo[i].memory);
+      *back_algo = bwd_data_algo[i].algo;
+    }
+  }, ctx, {}, {var});
   Engine::Get()->WaitForVar(var);
   Engine::Get()->DeleteVariable([](RunContext s) {}, ctx, var);
-  init_cudnn_ = true;
+
+  CHECK_EQ(cudnnDestroyTensorDescriptor(in_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnDestroyTensorDescriptor(out_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnDestroyTensorDescriptor(bias_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnDestroyFilterDescriptor(filter_desc), CUDNN_STATUS_SUCCESS);
+  CHECK_EQ(cudnnDestroyConvolutionDescriptor(conv_desc), CUDNN_STATUS_SUCCESS);
 }
-
-template<>
-CuDNNConvolutionOp<float>::CuDNNConvolutionOp(ConvolutionParam,
-                                                    std::vector<TShape>*,
-                                                    std::vector<TShape>*,
-                                                    Context);
-template<>
-CuDNNConvolutionOp<double>::CuDNNConvolutionOp(ConvolutionParam,
-                                                     std::vector<TShape>*,
-                                                     std::vector<TShape>*,
-                                                     Context);
-template<>
-CuDNNConvolutionOp<mshadow::half::half_t>::CuDNNConvolutionOp(ConvolutionParam,
-                                                                    std::vector<TShape>*,
-                                                                    std::vector<TShape>*,
-                                                                    Context);
-
+#endif  // CUDNN
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/custom.cc
+++ b/src/operator/custom.cc
@@ -1,6 +1,6 @@
 /*!
  * Copyright (c) 2015 by Contributors
- * \file ndarray_op.cc
+ * \file custom.cc
  * \brief
  * \author Junyuan Xie
 */

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -791,7 +791,7 @@ void GraphExecutor::InitResources() {
   }
 }
 
-void GraphExecutor::InitOpNodes() {
+void GraphExecutor::InitOperators() {
   for (size_t i = 0; i < topo_order_.size(); ++i) {
     uint32_t nid = topo_order_[i];
     if (!op_nodes_[nid].activated) continue;
@@ -811,6 +811,15 @@ void GraphExecutor::InitOpNodes() {
           graph_.nodes[graph_.nodes[nid].backward_source_id].op.get(),
           op_nodes_[graph_.nodes[nid].backward_source_id].op));
     }
+  }
+}
+
+void GraphExecutor::InitCachedOps() {
+  for (size_t i = 0; i < topo_order_.size(); ++i) {
+    uint32_t nid = topo_order_[i];
+    if (!op_nodes_[nid].activated) continue;
+    if (graph_.nodes[nid].is_variable()) continue;
+    OpNode& op_node = op_nodes_[nid];
     bool allow_cache = true;
     for (StaticGraph::DataEntry e : graph_.nodes[nid].inputs) {
       DataEntryInfo& info = op_nodes_[e.source_id].outputs[e.index];

--- a/src/symbol/graph_executor.h
+++ b/src/symbol/graph_executor.h
@@ -64,9 +64,10 @@ class GraphExecutor : public Executor {
                     in_args, arg_grad_store, grad_req_type,
                     need_backward);
     this->InitDataEntryInfo(in_args, arg_grad_store, grad_req_type, aux_states);
+    this->InitOperators();
     this->InitDataEntryMemory();
     this->InitResources();
-    this->InitOpNodes();
+    this->InitCachedOps();
   }
 
  protected:
@@ -218,7 +219,9 @@ class GraphExecutor : public Executor {
   // initialize the internal resources for each op
   void InitResources();
   // initialize OpNode data structure
-  void InitOpNodes();
+  void InitOperators();
+  // initialize OpNode data structure
+  void InitCachedOps();
   // assign context to the graph, this will mutate the graph.
   void AssignContext(const Context default_ctx,
                      const std::map<std::string, Context>& ctx_map,


### PR DESCRIPTION
This indeed increases performance, by 30% with the following test:
```python

def check_speed(sym, ctx, scale=1.0, N=100):
    exe = sym.simple_bind(grad_req='write', **ctx)
    init = [np.random.normal(size=arr.shape, scale=scale) for arr in exe.arg_arrays]
    for arr, iarr in zip(exe.arg_arrays, init):
        arr[:] = iarr.astype(arr.dtype)

    # warm up
    exe.forward(is_train=True)
    exe.backward(exe.outputs[0])
    exe.outputs[0].wait_to_read()

    tic = time.time()
    for i in range(N):
        exe.forward(is_train=True)
        exe.backward(exe.outputs[0])
        exe.outputs[0].wait_to_read()
    return (time.time() - tic)*1.0/N


ctx_list = [{'ctx': mx.gpu(0), 'conv_data': (32, 64, 224, 224)}]
sym = mx.sym.Convolution(num_filter=64, kernel=(3,3), name='conv', cudnn_tune='fastest')
for ctx in ctx_list:
    print ctx, check_speed(sym, ctx, N=10)
sym = mx.sym.Convolution(num_filter=64, kernel=(3,3), name='conv', cudnn_tune='off')
for ctx in ctx_list:
    print ctx, check_speed(sym, ctx, N=10)

```