### PR TITLE
[EXEC] More generic segment training api

### DIFF
--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -176,7 +176,8 @@ class Module(BaseModule):
                     if cache_arr is not arr:
                         cache_arr.copyto(arr)
                 else:
-                    assert allow_missing
+                    if not allow_missing:
+                        raise RuntimeError("%s is not presented" % name)
                     if initializer != None:
                         initializer(name, arr)
             else:


### PR DESCRIPTION
@piiswrong @sxjscience 

This won't improve perf of general CNN training, but enables a logic to improve perf on nets with small ops. Currently InitOpSegs initializes segments that will be launched in a wave