### PR TITLE
allow custom metric to have ignore labels

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -351,7 +351,7 @@ class CustomMetric(EvalMetric):
                 self.num_inst += 1
 
 # pylint: disable=invalid-name
-def np(numpy_feval, name=None, allow_extra_outputs=False):
+def np(numpy_feval, name=None, allow_extra_outputs=False, use_ignore=False, ignore_label=-1):
     """Create a customized metric from numpy function.
 
     Parameters
@@ -367,7 +367,10 @@ def np(numpy_feval, name=None, allow_extra_outputs=False):
     """
     def feval(label, pred):
         """Internal eval function."""
-        return numpy_feval(label, pred)
+        if use_ignore:
+            return numpy_feval(label, pred, ignore_label)
+        else:
+            return numpy_feval(label, pred)
     feval.__name__ = numpy_feval.__name__
     return CustomMetric(feval, name, allow_extra_outputs)
 # pylint: enable=invalid-name


### PR DESCRIPTION
I want to avoid evaluating on the ignored_labels I use at the softmaxoutput layer. Since the custom metric is called at mx.metric.np, i need to pass the ignore labels through it.

