### PR TITLE
Fixed if statements regarding CPU usage in example/image-classification.

### DIFF
--- a/example/image-classification/train_cifar10.py
+++ b/example/image-classification/train_cifar10.py
@@ -10,7 +10,7 @@ parser.add_argument('--network', type=str, default='inception-bn-28-small',
 parser.add_argument('--data-dir', type=str, default='cifar10/',
                     help='the input data directory')
 parser.add_argument('--gpus', type=str, default='0',
-                    help='the gpus will be used, e.g "0,1,2,3"')
+                    help='the gpus will be used, e.g "0,1,2,3" or "None" to use cpu')
 parser.add_argument('--num-examples', type=int, default=60000,
                     help='the number of training examples')
 parser.add_argument('--batch-size', type=int, default=128,

--- a/example/image-classification/train_cifar10_mirroring.py
+++ b/example/image-classification/train_cifar10_mirroring.py
@@ -25,7 +25,7 @@ parser.add_argument('--network', type=str, default='inception-bn-28-small',
 parser.add_argument('--data-dir', type=str, default='cifar10/',
                     help='the input data directory')
 parser.add_argument('--gpus', type=str, default='0',
-                    help='the gpus will be used, e.g "0,1,2,3"')
+                    help='the gpus will be used, e.g "0,1,2,3" or "None" to use cpu')
 parser.add_argument('--num-examples', type=int, default=60000,
                     help='the number of training examples')
 parser.add_argument('--batch-size', type=int, default=128,

--- a/example/image-classification/train_cifar10_resnet.py
+++ b/example/image-classification/train_cifar10_resnet.py
@@ -50,7 +50,7 @@ parser = argparse.ArgumentParser(description='train an image classifer on cifar1
 parser.add_argument('--data-dir', type=str, default='cifar10/',
                     help='the input data directory')
 parser.add_argument('--gpus', type=str, default='0',
-                    help='the gpus will be used, e.g "0,1,2,3"')
+                    help='the gpus will be used, e.g "0,1,2,3" or "None" to use cpu')
 parser.add_argument('--num-examples', type=int, default=50000,
                     help='the number of training examples')
 parser.add_argument('--batch-size', type=int, default=128,
@@ -330,7 +330,7 @@ def fit(args, network, data_loader, batch_end_callback=None):
     (train, val) = data_loader(args, kv)
 
     # train
-    devs = mx.cpu() if args.gpus is None else [
+    devs = mx.cpu() if args.gpus == 'None' else [
         mx.gpu(int(i)) for i in args.gpus.split(',')]
 
     epoch_size = args.num_examples / args.batch_size
@@ -344,7 +344,7 @@ def fit(args, network, data_loader, batch_end_callback=None):
 
     # disable kvstore for single device
     if 'local' in kv.type and (
-            args.gpus is None or len(args.gpus.split(',')) is 1):
+            args.gpus == 'None' or len(args.gpus.split(',')) is 1):
         kv = None
 
     model = mx.model.FeedForward(

--- a/example/image-classification/train_imagenet.py
+++ b/example/image-classification/train_imagenet.py
@@ -31,7 +31,7 @@ parser.add_argument('--load-epoch', type=int,
 parser.add_argument('--batch-size', type=int, default=32,
                     help='the batch size')
 parser.add_argument('--gpus', type=str, default='0',
-                    help='the gpus will be used, e.g "0,1,2,3"')
+                    help='the gpus will be used, e.g "0,1,2,3" or "None" to use cpu')
 parser.add_argument('--kv-store', type=str, default='local',
                     help='the kvstore type')
 parser.add_argument('--num-examples', type=int, default=1281167,

--- a/example/image-classification/train_mnist.R
+++ b/example/image-classification/train_mnist.R
@@ -90,7 +90,7 @@ parse_args <- function() {
     parser$add_argument('--data-dir', type='character', default='mnist/',
                         help='the input data directory')
     parser$add_argument('--gpus', type='character',
-                        help='the gpus will be used, e.g "0,1,2,3"')
+                        help='the gpus will be used, e.g "0,1,2,3" or "None" to use cpu')
     parser$add_argument('--batch-size', type='integer', default=128,
                         help='the batch size')
     parser$add_argument('--lr', type='double', default=.1,

--- a/example/image-classification/train_mnist.py
+++ b/example/image-classification/train_mnist.py
@@ -111,7 +111,7 @@ def parse_args():
     parser.add_argument('--data-dir', type=str, default='mnist/',
                         help='the input data directory')
     parser.add_argument('--gpus', type=str,
-                        help='the gpus will be used, e.g "0,1,2,3"')
+                        help='the gpus will be used, e.g "0,1,2,3" or "None" to use cpu')
     parser.add_argument('--num-examples', type=int, default=60000,
                         help='the number of training examples')
     parser.add_argument('--batch-size', type=int, default=128,

--- a/example/image-classification/train_model.py
+++ b/example/image-classification/train_model.py
@@ -47,7 +47,7 @@ def fit(args, network, data_loader, batch_end_callback=None):
     (train, val) = data_loader(args, kv)
 
     # train
-    devs = mx.cpu() if args.gpus is None else [
+    devs = mx.cpu() if args.gpus == 'None' else [
         mx.gpu(int(i)) for i in args.gpus.split(',')]
 
     epoch_size = args.num_examples / args.batch_size
@@ -66,7 +66,7 @@ def fit(args, network, data_loader, batch_end_callback=None):
 
     # disable kvstore for single device
     if 'local' in kv.type and (
-            args.gpus is None or len(args.gpus.split(',')) is 1):
+            args.gpus == 'None' or len(args.gpus.split(',')) is 1):
         kv = None
 
     model = mx.model.FeedForward(


### PR DESCRIPTION
When trying to run some examples via my CPU, I got the following error:

```
$ python train_cifar10.py  --gpus None
2016-07-02 21:48:03,114 Node[0] start with arguments Namespace(batch_size=128, data_dir='cifar10/', gpus='None', kv_store='local', load_epoch=None, lr=0.05, l
r_factor=1, lr_factor_epoch=1, model_prefix=None, network='inception-bn-28-small', num_epochs=20, num_examples=60000, save_model_prefix=None)
[21:48:03] src/io/iter_image_recordio.cc:211: ImageRecordIOParser: cifar10/train.rec, use 3 threads for decoding..
[21:48:03] src/io/./iter_normalize.h:103: Load mean image from cifar10/mean.bin
[21:48:03] src/io/iter_image_recordio.cc:211: ImageRecordIOParser: cifar10/test.rec, use 3 threads for decoding..
[21:48:03] src/io/./iter_normalize.h:103: Load mean image from cifar10/mean.bin
Traceback (most recent call last):
  File "train_cifar10.py", line 81, in <module>
    train_model.fit(args, net, get_iterator)
  File "/home/andyandy/git/mxnet/example/image-classification/train_model.py", line 51, in fit
    mx.gpu(int(i)) for i in args.gpus.split(',')]
ValueError: invalid literal for int() with base 10: 'None
```

This is because the argument parser assumes`str` (i.e. string) type:

```
parser.add_argument('--gpus', type=str, ...
```

So the if statement was invalid:
```
if 'local' in kv.type and (
-            args.gpus is None or len(args.gpus.split(',')) is 1):
+            args.gpus == 'None' or len(args.gpus.split(',')) is 1):
    kv = None
    ...
```