### PR TITLE
PS node recovery support

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1103,6 +1103,8 @@ MXNET_DLL int MXDataIterGetLabel(DataIterHandle handle,
 MXNET_DLL int MXInitPSEnv(mx_uint num_vars,
                           const char **keys,
                           const char **vals);
+
+
 /*!
  * \brief Create a kvstore
  * \param type the type of KVStore
@@ -1278,6 +1280,21 @@ MXNET_DLL int MXKVStoreRunServer(KVStoreHandle handle,
 MXNET_DLL int MXKVStoreSendCommmandToServers(KVStoreHandle handle,
                                              int cmd_id,
                                              const char* cmd_body);
+
+/**
+ * \brief Get the number of ps dead node(s) specified by {node_id}
+ *
+ * \param handle handle to the KVStore
+ * \param node_id Can be a node group or a single node.
+ *                kScheduler = 1, kServerGroup = 2, kWorkerGroup = 4
+ * \param number Ouptut number of dead nodes
+ * \param timeout_sec A node fails to send heartbeart in {timeout_sec} seconds
+ *                    will be presumed as 'dead'
+ */
+MXNET_DLL int MXKVStoreGetDeadNodeNum(KVStoreHandle handle,
+                                      const int node_id,
+                                      int *number,
+                                      const int timeout_sec = 60);
 
 /**
  * \brief Create a RecordIO writer object

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1248,6 +1248,16 @@ MXNET_DLL int MXKVStoreIsSchedulerNode(int *ret);
 MXNET_DLL int MXKVStoreBarrier(KVStoreHandle handle);
 
 /**
+ * \brief whether to do barrier when finalize
+ *
+ * \param handle handle to the KVStore
+ * \param barrier_before_exit whether to do barrier when kvstore finalize
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXKVStoreSetBarrierBeforeExit(KVStoreHandle handle,
+                                            const int barrier_before_exit);
+
+/**
  * \brief the prototype of a server controller
  * \param head the head of the command
  * \param body the body of the command
@@ -1291,7 +1301,7 @@ MXNET_DLL int MXKVStoreSendCommmandToServers(KVStoreHandle handle,
  * \param timeout_sec A node fails to send heartbeart in {timeout_sec} seconds
  *                    will be presumed as 'dead'
  */
-MXNET_DLL int MXKVStoreGetDeadNodeNum(KVStoreHandle handle,
+MXNET_DLL int MXKVStoreGetNumDeadNode(KVStoreHandle handle,
                                       const int node_id,
                                       int *number,
                                       const int timeout_sec = 60);

--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -223,6 +223,18 @@ class KVStore {
   }
 
   /*!
+   * \return the number of dead node(s) specified by {node_id}
+   * \param node_id can be a node group or a single node
+   * \param timeout a node fails to send heartbeart in {timeout} seconds
+   *        will be presumed as 'dead'
+   *
+   * Always return 0 when type == "local"
+   */
+  virtual int get_dead_num(int node_id, int timeout = 60) const {
+    return 0;
+  }
+
+  /*!
    * \brief global barrier among all worker machines
    *
    * But note that, this functions only blocks the main thread of workers until

--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <string>
 #include <functional>
+#include <atomic>
 #include "./ndarray.h"
 #if MXNET_USE_DIST_KVSTORE
 #include "ps/ps.h"
@@ -190,6 +191,14 @@ class KVStore {
 #endif  // MXNET_USE_DIST_KVSTORE
   }
 
+  void set_barrier_before_exit(const bool barrier_before_exit) {
+#if MXNET_USE_DIST_KVSTORE
+    if (!IsWorkerNode()) LOG(FATAL) << "barrier_before_exit takes effect only on worker nodes";
+    barrier_before_exit_ = barrier_before_exit;
+#else
+    LOG(FATAL) << "compile with USE_DIST_KVSTORE=1 to enable barrier";
+#endif
+  }
 
   /**
    * \return whether or not this process is a scheduler node.
@@ -230,7 +239,7 @@ class KVStore {
    *
    * Always return 0 when type == "local"
    */
-  virtual int get_dead_num(int node_id, int timeout = 60) const {
+  virtual int get_num_dead_node(int node_id, int timeout = 60) const {
     return 0;
   }
 
@@ -286,6 +295,11 @@ class KVStore {
    * \brief the kvstore type
    */
   std::string type_;
+
+  /**
+   * \brief whether to do barrier when finalize
+   */
+  std::atomic<bool> barrier_before_exit_{true};
 };
 
 }  // namespace mxnet

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
@@ -8,6 +8,12 @@ import org.slf4j.{LoggerFactory, Logger}
  * @author Yizhi Liu
  */
 object KVStore {
+
+  // group id of scheduler/server/worker
+  val GROUP_NODE_SCHEDULER = 1
+  val GROUP_NODE_SERVER = 2
+  val GROUP_NODE_WORKER = 4
+
   /**
    * Create a new KVStore. <br />
    * <b>
@@ -210,6 +216,12 @@ class KVStore(private[mxnet] val handle: KVStoreHandle) {
    */
   def barrier() {
     checkCall(_LIB.mxKVStoreBarrier(handle))
+  }
+
+  def numDeadNode(nodeId: Int): Int = {
+    val number = new RefInt
+    checkCall(_LIB.mxKVStoreGetDeadNodeNum(handle, nodeId, number))
+    number.value
   }
 
   /**

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
@@ -214,14 +214,23 @@ class KVStore(private[mxnet] val handle: KVStoreHandle) {
    * pulling, we can place a barrier to guarantee that the initialization is
    * finished.
    */
-  def barrier() {
+  def barrier(): Unit = {
     checkCall(_LIB.mxKVStoreBarrier(handle))
   }
 
   def numDeadNode(nodeId: Int): Int = {
     val number = new RefInt
-    checkCall(_LIB.mxKVStoreGetDeadNodeNum(handle, nodeId, number))
+    checkCall(_LIB.mxKVStoreGetNumDeadNode(handle, nodeId, number))
     number.value
+  }
+
+  /**
+   * Whether to do barrier when the kvstore finalizes
+   * @param barrierBeforeExit
+   */
+  def setBarrierBeforeExit(barrierBeforeExit: Boolean): Unit = {
+    val flag: Int = if (barrierBeforeExit) 1 else 0
+    checkCall(_LIB.mxKVStoreSetBarrierBeforeExit(handle, flag))
   }
 
   /**

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStoreServer.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStoreServer.scala
@@ -33,14 +33,57 @@ class KVStoreServer(private val kvStore: KVStore) {
 }
 
 object KVStoreServer {
-  // Start server/scheduler according to env variables
-  def start(): Unit = {
+  private val logger: Logger = LoggerFactory.getLogger(classOf[KVStoreServer])
+  /**
+   * Start server/scheduler according to env variables
+   * @param dieIfOthersGoOut When this argument is set to true,
+   *                         a daemon thread will start to periodically check
+   *                         whether scheduler (server side) or servers (scheduler side)
+   *                         are dead. If so, die itself.
+   *                         This could be useful for running mxnet on distributed data platform,
+   *                         where you do not know which node your application runs on
+   *                         and in such situation
+   *                         you want others die automatically once some of the nodes goes out.
+   */
+  def start(dieIfOthersGoOut: Boolean = false): Unit = {
     val isWorker = new RefInt
     checkCall(_LIB.mxKVStoreIsWorkerNode(isWorker))
     require(isWorker.value == 0, "cannot start kv-store server on worker node")
     val kvStore = KVStore.create("dist")
+    val daemonThread: Option[Thread] =
+      if (dieIfOthersGoOut) {
+        val daemon = new Runnable {
+          override def run(): Unit = {
+            var running = true
+            while (running) {
+              try {
+                Thread.sleep(10000L)
+                val numDeadService = kvStore.numDeadNode(
+                  KVStore.GROUP_NODE_SCHEDULER + KVStore.GROUP_NODE_SERVER)
+                if (numDeadService > 0) {
+                  logger.error(s"Detect $numDeadService dead node(s). Shutdown now.")
+                  System.exit(1)
+                }
+              } catch {
+                case e: InterruptedException => running = false
+              }
+            }
+          }
+        }
+        val t = new Thread(daemon)
+        t.setDaemon(true)
+        t.start()
+        Option(t)
+      } else {
+        None
+      }
     val server = new KVStoreServer(kvStore)
     server.run()
+    daemonThread.foreach(t => {
+      t.interrupt()
+      t.join()
+    })
+    kvStore.dispose()
   }
 
   def init(env: Map[String, String]): Unit = {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -78,7 +78,7 @@ class LibInfo {
   // KVStore Server
   @native def mxInitPSEnv(keys: Array[String], values: Array[String]): Int
   @native def mxKVStoreRunServer(handle: KVStoreHandle, controller: KVServerControllerCallback): Int
-  @native def mxKVStoreGetDeadNodeNum(handle: KVStoreHandle, nodeId: Int, number: RefInt): Int
+  @native def mxKVStoreGetNumDeadNode(handle: KVStoreHandle, nodeId: Int, number: RefInt): Int
 
   // KVStore
   @native def mxKVStoreCreate(name: String, handle: KVStoreHandleRef): Int
@@ -104,6 +104,7 @@ class LibInfo {
   @native def mxKVStoreBarrier(handle: KVStoreHandle): Int
   @native def mxKVStoreGetGroupSize(handle: KVStoreHandle, size: RefInt): Int
   @native def mxKVStoreGetRank(handle: KVStoreHandle, size: RefInt): Int
+  @native def mxKVStoreSetBarrierBeforeExit(handle: KVStoreHandle, doBarrier: Int): Int
   @native def mxKVStoreFree(handle: KVStoreHandle): Int
 
   // DataIter Funcs

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/LibInfo.scala
@@ -78,6 +78,7 @@ class LibInfo {
   // KVStore Server
   @native def mxInitPSEnv(keys: Array[String], values: Array[String]): Int
   @native def mxKVStoreRunServer(handle: KVStoreHandle, controller: KVServerControllerCallback): Int
+  @native def mxKVStoreGetDeadNodeNum(handle: KVStoreHandle, nodeId: Int, number: RefInt): Int
 
   // KVStore
   @native def mxKVStoreCreate(name: String, handle: KVStoreHandleRef): Int

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -596,14 +596,20 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreGetRank
   return ret;
 }
 
-JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreGetDeadNodeNum
+JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreGetNumDeadNode
   (JNIEnv * env, jobject obj, jlong kvStorePtr, jint nodeId, jobject numberRef) {
   int number;
-  int ret = MXKVStoreGetDeadNodeNum(reinterpret_cast<KVStoreHandle>(kvStorePtr),
+  int ret = MXKVStoreGetNumDeadNode(reinterpret_cast<KVStoreHandle>(kvStorePtr),
                                     static_cast<const int>(nodeId),
                                     &number);
   SetIntField(env, numberRef, number);
   return ret;
+}
+
+JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreSetBarrierBeforeExit
+  (JNIEnv * env, jobject obj, jlong kvStorePtr, jint doBarrier) {
+  return MXKVStoreSetBarrierBeforeExit(reinterpret_cast<KVStoreHandle>(kvStorePtr),
+                                       static_cast<const int>(doBarrier));
 }
 
 JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreFree

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -596,6 +596,16 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreGetRank
   return ret;
 }
 
+JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreGetDeadNodeNum
+  (JNIEnv * env, jobject obj, jlong kvStorePtr, jint nodeId, jobject numberRef) {
+  int number;
+  int ret = MXKVStoreGetDeadNodeNum(reinterpret_cast<KVStoreHandle>(kvStorePtr),
+                                    static_cast<const int>(nodeId),
+                                    &number);
+  SetIntField(env, numberRef, number);
+  return ret;
+}
+
 JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreFree
   (JNIEnv * env, jobject obj, jlong ptr) {
   return MXKVStoreFree(reinterpret_cast<KVStoreHandle>(ptr));

--- a/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/MXNet.scala
+++ b/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/MXNet.scala
@@ -3,7 +3,6 @@ package ml.dmlc.mxnet.spark
 import ml.dmlc.mxnet._
 import ml.dmlc.mxnet.optimizer.SGD
 import ml.dmlc.mxnet.spark.io.LabeledPointIter
-import org.apache.spark.{SparkFiles, SparkContext}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
 import org.slf4j.{Logger, LoggerFactory}
@@ -62,6 +61,16 @@ class MXNet extends Serializable {
   }
 
   /**
+   * The application (including parameter scheduler & servers)
+   * will exist if it hasn't received heart beat for over timeout seconds
+   * @param timeout timeout in seconds
+   */
+  def setTimeout(timeout: Int): this.type = {
+    params.timeout = timeout
+    this
+  }
+
+  /**
    * These jars are required by the KVStores at runtime.
    * They will be uploaded and distributed to each node automatically
    * @param jars jars required by the KVStore at runtime.
@@ -99,7 +108,8 @@ class MXNet extends Serializable {
     logger.info("Starting scheduler on {}:{}", schedulerIP, schedulerPort)
     val scheduler = new ParameterServer(params.runtimeClasspath, role = "scheduler",
       rootUri = schedulerIP, rootPort = schedulerPort,
-      numServer = params.numServer, numWorker = params.numWorker, java = params.javabin)
+      numServer = params.numServer, numWorker = params.numWorker,
+      timeout = params.timeout, java = params.javabin)
     require(scheduler.startProcess(), "Failed to start ps scheduler process")
 
     sc.parallelize(1 to params.numServer, params.numServer).foreachPartition { p =>
@@ -109,6 +119,7 @@ class MXNet extends Serializable {
         rootUri = schedulerIP, rootPort = schedulerPort,
         numServer = params.numServer,
         numWorker = params.numWorker,
+        timeout = params.timeout,
         java = params.javabin)
       require(server.startProcess(), "Failed to start ps server process")
     }

--- a/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/MXNetParams.scala
+++ b/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/MXNetParams.scala
@@ -39,7 +39,7 @@ private[mxnet] class MXNetParams extends Serializable {
   var dataName: String = "data"
   var labelName: String = "label"
 
-  var timeout: Int = 0
+  var timeout: Int = 300
 
   // jars on executors for running mxnet application
   var jars: Array[String] = null

--- a/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/MXNetParams.scala
+++ b/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/MXNetParams.scala
@@ -39,6 +39,8 @@ private[mxnet] class MXNetParams extends Serializable {
   var dataName: String = "data"
   var labelName: String = "label"
 
+  var timeout: Int = 0
+
   // jars on executors for running mxnet application
   var jars: Array[String] = null
   def runtimeClasspath: String = {

--- a/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/ParameterServer.scala
+++ b/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/ParameterServer.scala
@@ -25,7 +25,7 @@ object ParameterServer {
       KVStoreServer.init(buildEnv(
         cmdLine.role, cmdLine.rootUri, cmdLine.rootPort,
         cmdLine.numServer, cmdLine.numWorker))
-      KVStoreServer.start()
+      KVStoreServer.start(dieIfOthersGoOutTimeout = cmdLine.timeout)
     } catch {
       case e: Throwable =>
         logger.error(e.getMessage, e)
@@ -55,6 +55,8 @@ object ParameterServer {
     val numServer: Int = 1
     @Option(name = "--num-worker", usage = "PS worker number")
     val numWorker: Int = 1
+    @Option(name = "--timeout", usage = "PS go out timeout")
+    val timeout: Int = 0
 
     def checkArguments(): Unit = {
       require(role != null, "Undefined role")
@@ -72,6 +74,7 @@ class ParameterServer(private val classpath: String,
                       private val rootPort: Int,
                       private val numServer: Int = 1,
                       private val numWorker: Int = 1,
+                      private val timeout: Int = 0,
                       private val java: String = "java",
                       private val jvmOpts: String = "") {
   private val logger: Logger = LoggerFactory.getLogger(classOf[ParameterServer])
@@ -106,7 +109,7 @@ class ParameterServer(private val classpath: String,
     val cp = if (classpath == null) "" else s"-cp $classpath"
     val cmd = s"$java $jvmOpts $cp $runningClass " +
       s"--role=$role --root-uri=$rootUri --root-port=$rootPort " +
-      s"--num-server=$numServer --num-worker=$numWorker"
+      s"--num-server=$numServer --num-worker=$numWorker --timeout=$timeout"
     logger.info(s"Start process: $cmd")
     try {
       val childProcess = Runtime.getRuntime.exec(cmd)

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1351,6 +1351,15 @@ int MXKVStoreGetType(KVStoreHandle handle,
   API_END();
 }
 
+int MXKVStoreGetDeadNodeNum(KVStoreHandle handle,
+                            const int node_id,
+                            int *number,
+                            const int timeout_sec) {
+  API_BEGIN();
+  *number = static_cast<KVStore*>(handle)->get_dead_num(node_id, timeout_sec);
+  API_END();
+}
+
 struct MXRecordIOContext {
   dmlc::RecordIOWriter *writer;
   dmlc::RecordIOReader *reader;

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1292,6 +1292,13 @@ int MXKVStoreBarrier(KVStoreHandle handle) {
   API_END();
 }
 
+int MXKVStoreSetBarrierBeforeExit(KVStoreHandle handle,
+                                  const int barrier_before_exit) {
+  API_BEGIN();
+  static_cast<KVStore*>(handle)->set_barrier_before_exit(barrier_before_exit);
+  API_END();
+}
+
 int MXInitPSEnv(mx_uint num_vars,
                 const char **keys,
                 const char **vals) {
@@ -1351,12 +1358,12 @@ int MXKVStoreGetType(KVStoreHandle handle,
   API_END();
 }
 
-int MXKVStoreGetDeadNodeNum(KVStoreHandle handle,
+int MXKVStoreGetNumDeadNode(KVStoreHandle handle,
                             const int node_id,
                             int *number,
                             const int timeout_sec) {
   API_BEGIN();
-  *number = static_cast<KVStore*>(handle)->get_dead_num(node_id, timeout_sec);
+  *number = static_cast<KVStore*>(handle)->get_num_dead_node(node_id, timeout_sec);
   API_END();
 }
 

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -164,6 +164,17 @@ class KVStoreDist : public KVStoreDevice {
 
   int get_rank() const override { return ps::MyRank(); }
 
+  int get_dead_num(int node_id, int timeout) const override {
+    int number = 0;
+    auto dead_nodes = ps::Postoffice::Get()->GetDeadNodes(timeout);
+    const auto& watch_nodes = ps::Postoffice::Get()->GetNodeIDs(node_id);
+    std::unordered_set<int> watch_set(watch_nodes.begin(), watch_nodes.end());
+    for (int r : dead_nodes) {
+      if (watch_set.find(r) != watch_set.end()) number++;
+    }
+    return number;
+  }
+
   void RunServer(const Controller& controller) override {
     CHECK(!IsWorkerNode());
     if (IsServerNode()) {

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -197,7 +197,10 @@ class KVStoreDist : public KVStoreDevice {
     }
     if (server_) server_->Run();
     ps::Finalize();
-    if (server_) delete server_; server_ = nullptr;
+    if (server_) {
+      delete server_;
+    }
+    server_ = nullptr;
   }
 
  private:


### PR DESCRIPTION
* When a worker node died and restarts, it can join the cluster again. This PR https://github.com/dmlc/ps-lite/pull/59 need to be merged first
*  Timeout for ps scheduler and servers for *Spark*. PS scheduler and servers are started in a spawned process. But when something goes wrong, e.g., workers, servers or the scheduler crash, they will have no chance to stop themselves. I think the simplest way to solve this problem is to set a timeout T, if the scheduler/server does not receive any message in T seconds, stop itself.

Related to https://github.com/dmlc/mxnet/issues/2268