### PR TITLE
Update model.py

### DIFF
--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -304,6 +304,7 @@ def _train_multi_device(symbol, ctx, arg_names, param_names, aux_names,
             name_value = eval_metric.get_name_value()
             for name, value in name_value:
                 logger.info('Epoch[%d] Validation-%s=%f', epoch, name, value)
+            eval_data.reset()
     # end of all epochs
     return
 


### PR DESCRIPTION
adding `eval_data.reset()` at the end of evaluation session to avoid training session being skipped when eval_data and train_data are the same data.