### PR TITLE
Add Img2vector tools

### DIFF
--- a/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/utils/Img2Vector.scala
+++ b/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/utils/Img2Vector.scala
@@ -1,0 +1,65 @@
+package ml.dmlc.mxnet.spark.utils
+
+import javax.imageio.ImageIO
+import java.awt.image.BufferedImage
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkConf
+import org.apache.spark.input._
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
+
+/**
+ * Convert image directory into Vectorized RDD 
+ * @author Yuance.Li
+ */
+object Img2Vector{
+  def getImgRGB(PDS: PortableDataStream, fullcolor: Boolean): Array[Double] = {
+    val img = ImageIO.read(PDS.open())
+    val R = ArrayBuffer[Double]()
+    val G = ArrayBuffer[Double]()
+    val B = ArrayBuffer[Double]()
+    val RGB = ArrayBuffer[Double]()
+    val w = img.getWidth
+    val h = img.getHeight
+    if (fullcolor) {
+      for (x <- 0 until w){
+        for (y <- 0 until h) {
+          val color = img.getRGB(w - x - 1, y) & 0xffffff
+          R += (color & 0xff0000) / 65536
+          G += (color & 0xff00) / 256
+          B += (color & 0xff)
+        }
+      }
+      RGB ++= R ++= G ++= B
+      RGB.toArray
+    } else {
+      for (x <- 0 until w) {
+        for (y <- 0 until h){
+          val color = img.getRGB(w - x - 1, y) & 0xffffff
+          R += (color & 0xff0000) / 65536 * 0.3
+          G += (color & 0xff00) / 256 * 0.59
+          B += (color & 0xff) * 0.11
+        }
+      }
+      val grayArr = new Array[Double](w * h)
+      for (i <- 0 until w * h) {
+        grayArr(i) = R(i) + G(i) + B(i)
+      }
+      grayArr
+    }
+  }
+
+  def getRGBArray(sc: SparkContext, path: String, fullcolor: Boolean = true): RDD[Array[Double]] = {
+    val rgbArray = sc.binaryFiles(path).map(_._2).map(getImgRGB(_, fullcolor))
+    rgbArray
+  }
+
+  def getRGBvector(sc: SparkContext, path: String, fullcolor: Boolean = true): RDD[Vector] = {
+    val rgbArray = sc.binaryFiles(path).map(_._2).map(getImgRGB(_, fullcolor))
+    val rgbVector = rgbArray.map(x => Vectors.dense(x))
+    rgbVector
+  }
+}

--- a/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/utils/RepIterator.scala
+++ b/scala-package/spark/src/main/scala/ml/dmlc/mxnet/spark/utils/RepIterator.scala
@@ -1,0 +1,37 @@
+package ml.dmlc.mxnet.spark.utils
+
+import java.io.IOException
+import scala.collection.Iterator
+
+/**
+ * Repeatable Iterator useful in mapPartitions
+ * @author Yuance.Li
+ */
+class RepIterator[T](iteratorInternal: Iterator[T], repetition: Int = 1) extends Iterator[T] {
+  assert(repetition > 0)
+  var counter = repetition - 1
+  var (currentIter, backupIter) = iteratorInternal.duplicate
+
+  override def hasNext: Boolean = {
+    currentIter.hasNext || counter > 0
+  }
+
+  override def next(): T = {
+    assert(hasNext)
+    if(currentIter.hasNext) {
+      currentIter.next()
+    } else if (counter > 0) {
+      counter = counter - 1
+      var iterTuple = backupIter.duplicate
+      currentIter = iterTuple._1
+      backupIter = iterTuple._2
+      currentIter.next()
+    } else {
+      throw new IOException("No element in this collection")
+    }
+  }
+}
+
+object RepIterator {
+  def apply[T](iteratorInternal: Iterator[T], repetition: Int = 1) = new RepIterator(iteratorInternal, repetition)
+}


### PR DESCRIPTION
Img2Vector tools could convert imgae directory into Vectorized RDD，for example：
Images stored in hdfs://namenode:9000/user/xxx/images/
>import ml.dmlc.mxnet.spark.utils.Img2Vector
>val sc = new SparkContext(conf)
>val imagesRDD = Img2Vector.getRGBArray(sc, "hdfs://namenode:9000/user/xxx/images/") 
