### PR TITLE
CSS for docs: removing inherit for font properties on most elements.

### DIFF
--- a/docs/README
+++ b/docs/README
@@ -10,5 +10,5 @@ Install the required packages for Ubutun 14.04
 
 ```
 sudo apt-get install doxygen python-pip
-sudo pip install sphinx==1.3.5 CommonMark==0.5.4 breathe mock
+sudo pip install sphinx==1.3.5 CommonMark==0.5.4 breathe mock==1.0.1
 ```

--- a/docs/_static/mxnet.css
+++ b/docs/_static/mxnet.css
@@ -4,9 +4,6 @@ a, abbr, acronym, address, applet, big, blockquote, body, caption, cite, code, d
     padding: 0;
     border: 0;
     outline: 0;
-    font-weight: inherit;
-    font-style: inherit;
-    font-family: inherit;
     font-size: 100 %;
     vertical-align: baseline
 }


### PR DESCRIPTION
The current python API reference docs look like a giant wall of text because there's no font difference between the argument names and descriptions.  Removing these CSS overrides allows the browser default CSS rules for &lt;strong&gt; (bold-faced) and &lt;em&gt; (italics) to remain, making the API reference much easier to read.

Also, updating README: building docs needs mock==1.0.1.  Latest version of mock (2.0.0) fails.
