### PR TITLE
Do not decay gamma by default

### DIFF
--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -159,7 +159,7 @@ class Optimizer(object):
         """
         self.wd_mult = {}
         for n in self.idx2name.values():
-            if not (n.endswith('_weight') or n.endswith('_gamma')):
+            if not n.endswith('_weight'):
                 self.wd_mult[n] = 0.0
         if self.sym is not None:
             attr = self.sym.list_attr(recursive=True)


### PR DESCRIPTION
BN currently has fix_gamma=true by default and gamma is decayed by default.
As a result gamma will get smaller and smaller during training.
Remove decay gamma should fix this.
@mavenlin @antinucleon 