### PR TITLE
[RFC/WIP] RTC without NVRTC

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1381,6 +1381,14 @@ MXNET_DLL int MXRtcCreate(char* name, mx_uint num_input, mx_uint num_output,
                           char* kernel, RtcHandle *out);
 
 /**
+ * \brief Create a MXRtc oject from a pointer to a CuModule
+ */
+MXNET_DLL int MXRtcCreateEx(char* name, mx_uint num_input, mx_uint num_output,
+                            char** input_names, char** output_names,
+                            NDArrayHandle* inputs, NDArrayHandle* outputs,
+                            char* ptx, RtcHandle *out);
+
+/**
  * \brief Run cuda kernel
 */
 MXNET_DLL int MXRtcPush(RtcHandle handle, mx_uint num_input, mx_uint num_output,

--- a/include/mxnet/mxrtc.h
+++ b/include/mxnet/mxrtc.h
@@ -46,11 +46,12 @@ class MXRtc {
    * \param input list input ndarrays and their name.
    * \param output list of output ndarrays and their name.
    * \param ptx cuda module.
+   * \param not_used for overload resolution.
    */
   MXRtc(const std::string& name,
         std::vector<std::pair<std::string, NDArray> > const& input,
         std::vector<std::pair<std::string, NDArray> > const& output,
-        char* ptx);
+        char* ptx, int /*not_used*/);
   /*!
    * \brief launch a kernel with the engine.
    * \param input list of input ndarray.

--- a/include/mxnet/mxrtc.h
+++ b/include/mxnet/mxrtc.h
@@ -40,6 +40,18 @@ class MXRtc {
         std::vector<std::pair<std::string, NDArray> > const& output,
         const std::string& kernel);
   /*!
+   * \brief Build a new kernel from provided ptx code.
+   *
+   * \param name name of the kernel function.
+   * \param input list input ndarrays and their name.
+   * \param output list of output ndarrays and their name.
+   * \param ptx cuda module.
+   */
+  MXRtc(const std::string& name,
+        std::vector<std::pair<std::string, NDArray> > const& input,
+        std::vector<std::pair<std::string, NDArray> > const& output,
+        char* ptx);
+  /*!
    * \brief launch a kernel with the engine.
    * \param input list of input ndarray.
    * \param output list of output ndarray.

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1482,6 +1482,28 @@ int MXRtcCreate(char* name, mx_uint num_input, mx_uint num_output,
   API_END();
 }
 
+int MXRtcCreateEx(char* name, mx_uint num_input, mx_uint num_output,
+                  char** input_names, char** output_names,
+                  NDArrayHandle* inputs, NDArrayHandle* outputs,
+                  char* ptx, RtcHandle *out) {
+  API_BEGIN();
+#if (MXNET_USE_CUDA)
+  std::vector<std::pair<std::string, NDArray> > input, output;
+  for (mx_uint i = 0; i < num_input; ++i) {
+    input.push_back(std::pair<std::string, NDArray>(input_names[i],
+                                                    *reinterpret_cast<NDArray*>(inputs[i])));
+  }
+  for (mx_uint i = 0; i < num_output; ++i) {
+    output.push_back(std::pair<std::string, NDArray>(output_names[i],
+                                                     *reinterpret_cast<NDArray*>(outputs[i])));
+  }
+  MXRtc *rtc = new MXRtc(name, input, output, ptx, 0);
+  *out = reinterpret_cast<RtcHandle>(rtc);
+#else
+  LOG(FATAL) << "Need to compile with USE_CUDA=1 for MXRtc.";
+#endif  // (MXNET_USE_CUDA)
+  API_END();
+}
 int MXRtcPush(RtcHandle handle, mx_uint num_input, mx_uint num_output,
               NDArrayHandle* inputs, NDArrayHandle* outputs,
               mx_uint gridDimX,

--- a/src/common/mxrtc.cc
+++ b/src/common/mxrtc.cc
@@ -32,7 +32,7 @@ MXRtc::MXRtc(const std::string& name,
 MXRtc::MXRtc(const std::string& name,
              std::vector<std::pair<std::string, NDArray> > const& input,
              std::vector<std::pair<std::string, NDArray> > const& output,
-             char* ptx) {
+             char* ptx, int /*not used*/) {
     name_ = name;
     num_input_ = input.size();
     num_output_ = output.size();


### PR DESCRIPTION
I am working on using the experimental GPU codegen for Julia (https://github.com/JuliaGPU/julia & https://github.com/JuliaGPU/CUDAnative) to create kernels for MXNet.
For that purpose I need to insert the CuModule directly and thus bypass NVRTC.