### PR TITLE
add code to make mxnet do conv as caffe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,11 @@ if(USE_DIST_KVSTORE)
 	include_directories(SYSTEM ${pslite_INCLUDE_DIR})
 endif()
 
+if(CAFFE_CONV_COMPATIABLE)
+	add_definitions(-DCAFFE_CONV_COMPATIABLE)
+endif()
+
+
 # ---[ Linter target
 if(MSVC)
   find_package(PythonInterp 2)

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ ifneq ($(ADD_CFLAGS), NONE)
 	CFLAGS += $(ADD_CFLAGS)
 endif
 
+ifeq ($(CAFFE_CONV_COMPATIABLE), 1)
+	CFLAGS += -DCAFFE_CONV_COMPATIABLE
+endif
+
 ifneq ($(ADD_LDFLAGS), NONE)
 	LDFLAGS += $(ADD_LDFLAGS)
 endif

--- a/make/config.mk
+++ b/make/config.mk
@@ -88,7 +88,7 @@ endif
 USE_DIST_KVSTORE = 0
 
 # whether or not to keep the conv and pooling output same as caffe's
-CAFFE_CONV_COMPATIABLE = 1
+CAFFE_CONV_COMPATIABLE = 0
 
 # whether or not allow to read and write HDFS directly. If yes, then hadoop is
 # required

--- a/make/config.mk
+++ b/make/config.mk
@@ -87,6 +87,9 @@ endif
 # whether or not to enable multi-machine supporting
 USE_DIST_KVSTORE = 0
 
+# whether or not to keep the conv and pooling output same as caffe's
+CAFFE_CONV_COMPATIABLE = 1
+
 # whether or not allow to read and write HDFS directly. If yes, then hadoop is
 # required
 USE_HDFS = 0

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -370,7 +370,7 @@ class ConvolutionProp : public OperatorProperty {
             && ksize_x <= dshape[3] + 2 * param_.pad[1])
           << "kernel size exceed input";
       (*out_shape)[conv::kOut][1] = param_.num_filter;
-#ifndef CAFFE_CONV_COMPATIABLE	  
+#ifndef CAFFE_CONV_COMPATIABLE
       (*out_shape)[conv::kOut][2] = (dshape[2] + 2 * param_.pad[0] -
           (param_.dilate[0] * (ksize_y - 1) + 1)) / param_.stride[0] + 1;
       (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] -
@@ -380,8 +380,7 @@ class ConvolutionProp : public OperatorProperty {
           (param_.dilate[0] * (ksize_y - 1) + 1)) / param_.stride[0])) + 1;
       (*out_shape)[conv::kOut][3] =  static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] -
           (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1])) + 1;
-	  
-#endif		  
+#endif
       return true;
     } else if (param_.kernel.ndim() == 3) {
       // 3d conv

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -376,10 +376,10 @@ class ConvolutionProp : public OperatorProperty {
       (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] -
           (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1] + 1;
 #else
-      (*out_shape)[conv::kOut][2] = static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] -
-          (param_.dilate[0] * (ksize_y - 1) + 1)) / param_.stride[0])) + 1;
-      (*out_shape)[conv::kOut][3] =  static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] -
-          (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1])) + 1;
+      (*out_shape)[conv::kOut][2] = static_cast<int>(ceil(static_cast<float>(dshape[2] +
+        2 * param_.pad[0] - (param_.dilate[0] * (ksize_y - 1) + 1)) / param_.stride[0])) + 1;
+      (*out_shape)[conv::kOut][3] =  static_cast<int>(ceil(static_cast<float>(dshape[3] +
+        2 * param_.pad[1] - (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1])) + 1;
 #endif
       return true;
     } else if (param_.kernel.ndim() == 3) {

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -370,10 +370,18 @@ class ConvolutionProp : public OperatorProperty {
             && ksize_x <= dshape[3] + 2 * param_.pad[1])
           << "kernel size exceed input";
       (*out_shape)[conv::kOut][1] = param_.num_filter;
+#ifndef CAFFE_CONV_COMPATIABLE	  
       (*out_shape)[conv::kOut][2] = (dshape[2] + 2 * param_.pad[0] -
           (param_.dilate[0] * (ksize_y - 1) + 1)) / param_.stride[0] + 1;
       (*out_shape)[conv::kOut][3] = (dshape[3] + 2 * param_.pad[1] -
           (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1] + 1;
+#else
+      (*out_shape)[conv::kOut][2] = static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] -
+          (param_.dilate[0] * (ksize_y - 1) + 1)) / param_.stride[0])) + 1;
+      (*out_shape)[conv::kOut][3] =  static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] -
+          (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1])) + 1;
+	  
+#endif		  
       return true;
     } else if (param_.kernel.ndim() == 3) {
       // 3d conv

--- a/src/operator/pooling-inl.h
+++ b/src/operator/pooling-inl.h
@@ -198,8 +198,14 @@ class PoolingProp : public OperatorProperty {
         CHECK(param_.kernel[0] <= dshape[2] + 2 * param_.pad[0]
               && param_.kernel[1] <= dshape[3] + 2 * param_.pad[1])
             << "kernel size exceed input";
+#ifndef CAFFE_CONV_COMPATIABLE		
         oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
         oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
+#else
+        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
+        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
+
+#endif		
       }
       out_shape->clear();
       out_shape->push_back(oshape);
@@ -214,9 +220,15 @@ class PoolingProp : public OperatorProperty {
         oshape[3] = 1;
         oshape[4] = 1;
       } else {
+#ifndef CAFFE_CONV_COMPATIABLE			  
         oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
         oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
         oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2];
+#else
+        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
+        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
+        oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2]));
+#endif		
       }
       out_shape->clear();
       out_shape->push_back(oshape);

--- a/src/operator/pooling-inl.h
+++ b/src/operator/pooling-inl.h
@@ -198,14 +198,15 @@ class PoolingProp : public OperatorProperty {
         CHECK(param_.kernel[0] <= dshape[2] + 2 * param_.pad[0]
               && param_.kernel[1] <= dshape[3] + 2 * param_.pad[1])
             << "kernel size exceed input";
-#ifndef CAFFE_CONV_COMPATIABLE		
+#ifndef CAFFE_CONV_COMPATIABLE
         oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
         oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
 #else
-        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
-        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
-
-#endif		
+        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 
+           2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
+        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 
+           2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
+#endif
       }
       out_shape->clear();
       out_shape->push_back(oshape);
@@ -220,15 +221,18 @@ class PoolingProp : public OperatorProperty {
         oshape[3] = 1;
         oshape[4] = 1;
       } else {
-#ifndef CAFFE_CONV_COMPATIABLE			  
+#ifndef CAFFE_CONV_COMPATIABLE
         oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
         oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
         oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2];
 #else
-        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
-        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
-        oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2]));
-#endif		
+        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 
+          2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
+        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 
+          2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
+        oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[4] + 
+          2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2]));
+#endif
       }
       out_shape->clear();
       out_shape->push_back(oshape);

--- a/src/operator/pooling-inl.h
+++ b/src/operator/pooling-inl.h
@@ -197,15 +197,17 @@ class PoolingProp : public OperatorProperty {
       } else {
         CHECK(param_.kernel[0] <= dshape[2] + 2 * param_.pad[0]
               && param_.kernel[1] <= dshape[3] + 2 * param_.pad[1])
-            << "kernel size exceed input";
+              << "kernel size exceed input";
 #ifndef CAFFE_CONV_COMPATIABLE
-        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
-        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
+        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] -
+          param_.kernel[0]) / param_.stride[0];
+        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] -
+          param_.kernel[1]) / param_.stride[1];
 #else
-        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 
-           2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
-        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 
-           2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
+        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] +
+          2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
+        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] +
+          2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
 #endif
       }
       out_shape->clear();
@@ -222,15 +224,18 @@ class PoolingProp : public OperatorProperty {
         oshape[4] = 1;
       } else {
 #ifndef CAFFE_CONV_COMPATIABLE
-        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
-        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
-        oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2];
+        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] -
+          param_.kernel[0]) / param_.stride[0];
+        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] -
+          param_.kernel[1]) / param_.stride[1];
+        oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] -
+          param_.kernel[2]) / param_.stride[2];
 #else
-        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 
+        oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] +
           2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
-        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 
+        oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] +
           2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
-        oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[4] + 
+        oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[4] +
           2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2]));
 #endif
       }


### PR DESCRIPTION
This is to fix #2997 : Under CPU model, convert Caffe model to MXNET using convert tool failed 
added code to processing the calculating the boundary in same way as caffe
This feature is turn off by default in config.mk and cmake file. 
To make mxnet do conv is the same way as caffe:
change 
CAFFE_CONV_COMPATIABLE = 0 
to 
CAFFE_CONV_COMPATIABLE = 1

If will fix the error reported during model convert and make the converted caffe model run correctly under mxnet. 
