### PR TITLE
fix batch norm

### DIFF
--- a/src/operator/batch_norm-inl.h
+++ b/src/operator/batch_norm-inl.h
@@ -89,7 +89,7 @@ class BatchNormOp : public Operator {
     Tensor<xpu, 1> moving_mean = aux_states[batchnorm::kMovingMean].get<xpu, 1, real_t>(s);
     Tensor<xpu, 1> moving_var = aux_states[batchnorm::kMovingVar].get<xpu, 1, real_t>(s);
 
-    if (ctx.is_train && param_.fix_gamma) slope = 1.f;
+    if (param_.fix_gamma) slope = 1.f;
 
     // whether use global statistics
     if (ctx.is_train && !param_.use_global_stats) {
@@ -152,6 +152,8 @@ class BatchNormOp : public Operator {
     // update moving avg
     Tensor<xpu, 1> moving_mean = aux_states[batchnorm::kMovingMean].get<xpu, 1, real_t>(s);
     Tensor<xpu, 1> moving_var = aux_states[batchnorm::kMovingVar].get<xpu, 1, real_t>(s);
+
+    if (param_.fix_gamma) slope = 1.f;
 
     if (ctx.is_train && !param_.use_global_stats) {
       // get requested temp space

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -99,7 +99,7 @@ class CuDNNBatchNormOp : public Operator {
       .get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
     float a = 1.0f, b = 0.0f;
 
-    if (ctx.is_train && param_.fix_gamma) gamma = 1.f;
+    if (param_.fix_gamma) gamma = 1.f;
 
     if (ctx.is_train) {
       Tensor<gpu, 1> save_mean =
@@ -175,6 +175,9 @@ class CuDNNBatchNormOp : public Operator {
     float b = 0.0f;
     float b_add = 1.0f;
     CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+
+    if (param_.fix_gamma) gamma = 1.f;
+
 #if CUDNN_VERSION >= 4007
     CHECK_EQ(cudnnBatchNormalizationBackward(s->dnn_handle_,
                                              CUDNN_BATCHNORM_SPATIAL,


### PR DESCRIPTION
@winstywang @antinucleon @tornadomeet 
Current master doesn't set gamma to 1 during testing, in order to accommodate old models introduced before fix_gamma was introduced and set to true by default.

However this creates another problem as kvstore_local keeps a internal copy of all the weights so resetting to 1 inside bn is ignored and overwritten by kv's internal copy. As a result weight decay decreases gamma to 0 during training.

This PR fix this by resetting gamma whenever BN::Forward/Backward is called. However this invalidates all models trained before Dec 5 2015.

My suggestion is to merge this when we release 1.0 and explain this to the users in transition guide as well as provide a converter that set fix_gamma to false in .json symbols.