### PR TITLE
add cudnn off option in Convolution

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -38,6 +38,7 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
   uint64_t workspace;
   bool no_bias;
   int cudnn_tune;
+  bool cudnn_off;
   DMLC_DECLARE_PARAMETER(ConvolutionParam) {
     int shape[] = {1, 1};
     DMLC_DECLARE_FIELD(kernel).describe("convolution kernel size: (y, x) or (d, y, x)");
@@ -67,6 +68,8 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
               "Leads to higher startup time but may give better speed."
               "auto tune is turned off by default."
               "Set environment varialbe MXNET_CUDNN_AUTOTUNE_DEFAULT=1 to turn on by default.");
+    DMLC_DECLARE_FIELD(cudnn_off).set_default(false)
+    .describe("Turn off cudnn.");
   }
 };
 

--- a/src/operator/convolution.cu
+++ b/src/operator/convolution.cu
@@ -20,7 +20,7 @@ Operator* CreateOp<gpu>(ConvolutionParam param, int dtype,
                         Context ctx) {
   Operator *op = NULL;
 #if MXNET_USE_CUDNN == 1
-  if (param.dilate[0] == 1 && param.dilate[1] == 1) {
+  if (param.dilate[0] == 1 && param.dilate[1] == 1 && !param.cudnn_off) {
     MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
       op = new CuDNNConvolutionOp<DType>(param, in_shape, out_shape, ctx);
     })


### PR DESCRIPTION
some times the cudnn Convolution have some bug. etc when kernel=(10,300) cudnn is crash.
so add option can turn off it.