### PR TITLE
Fix path in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import
 import os
 import sys
 # need to use distutils.core for correct placement of cython dll
-from distutils.core import setup
+#from distutils.core import setup
+from setuptools import setup
 
 # We can not import `mxnet.info.py` in setup.py directly since mxnet/__init__.py
 # Will be invoked which introduces dependences
@@ -20,7 +21,7 @@ def config_cython():
     """Try to configure cython and retyurn cython configuration"""
     try:
         from Cython.Build import cythonize
-        from distutils.extension import Extension
+        from setuptools.extension import Extension
         if sys.version_info >= (3, 0):
             subdir = "_cy3"
         else:
@@ -48,7 +49,10 @@ setup(name='mxnet',
           'numpy',
       ],
       zip_safe=False,
-      packages=['mxnet', 'mxnet.module'],
+      packages=[
+          'mxnet', 'mxnet.module', 'mxnet._ctypes',
+          'mxnet._cy2', 'mxnet._cy3',
+          ],
       data_files=[('mxnet', [LIB_PATH[0]])],
       url='https://github.com/dmlc/mxnet',
       ext_modules=config_cython())


### PR DESCRIPTION
Seems that `distutils.core.setup` does not support `install_requires` etc. Changed it back to `setuptools`. Also fixed the cython path problem.