### PR TITLE
when set use_global_stats then do not use cudnn

### DIFF
--- a/src/operator/batch_norm-inl.h
+++ b/src/operator/batch_norm-inl.h
@@ -202,6 +202,7 @@ class BatchNormOp : public Operator {
       } else {
         Assign(gslope, req[batchnorm::kGamma], 0.0f);
       }
+      Assign(gbias, req[batchnorm::kBeta], sumall_except_dim<1>(grad));
       Assign(grad_in, req[batchnorm::kData], (grad * broadcast<1>(slope, data.shape_)) *
              broadcast<1>(
                  1.0f / F<mshadow_op::square_root>(moving_var + param_.eps), data.shape_));

--- a/src/operator/batch_norm.cu
+++ b/src/operator/batch_norm.cu
@@ -13,7 +13,11 @@ namespace op {
 template<>
 Operator *CreateOp<gpu>(BatchNormParam param) {
 #if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 5
-  return new CuDNNBatchNormOp(param);
+  if (!param.use_global_stats) {
+    return new CuDNNBatchNormOp(param);
+  } else {
+    return new BatchNormOp<gpu>(param);
+  }
 #else
   return new BatchNormOp<gpu>(param);
 #endif

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -727,7 +727,9 @@ def test_batchnorm_training():
 
         data = mx.symbol.Variable('data')
         test = mx.symbol.BatchNorm(data, fix_gamma=False)
+        check_numeric_gradient(test, [data_tmp, gamma, beta], [rolling_mean, rolling_std], numeric_eps=1e-3, check_eps=5e-2)
 
+        test = mx.symbol.BatchNorm(data, fix_gamma=False, use_global_stats=True)
         check_numeric_gradient(test, [data_tmp, gamma, beta], [rolling_mean, rolling_std], numeric_eps=1e-3, check_eps=5e-2)
 
 def test_convolution_grouping():
@@ -1137,7 +1139,6 @@ def test_flip():
 
 
 def test_stn():
-    import pdb
     np.set_printoptions(threshold=np.nan)
     num_filter = 2  # conv of loc net
     kernel = (3, 3)  # conv of loc net


### PR DESCRIPTION
the reason is some thing like https://github.com/dmlc/mxnet/pull/3270

because cudnn do not support `use_global_stats`(and we want cudnn do other calc like conv, pooling.), but this is very useful when transfer resnet to other task, which minibatch-size=1, such as detection, segmentation. 



