### PR TITLE
disable SSE for arm hardware e.g. Raspberry Pi

### DIFF
--- a/make/config.mk
+++ b/make/config.mk
@@ -81,10 +81,10 @@ USE_STATIC_MKL = NONE
 endif
 
 #----------------------------
-# Settings for power arch
+# Settings for power and arm arch
 #----------------------------
 ARCH := $(shell uname -a)
-ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
+ifneq (,$(filter $(ARCH), armv6l armv7l powerpc64le ppc64le))
 	USE_SSE=0
 else
 	USE_SSE=1


### PR DESCRIPTION
SSE must be disabled on ARM hardware for the build to succeed. With these modifications I was able to build and use mxnet on an armhf CPU.