### PR TITLE
Add {valid, full} option for Pooling layer

### DIFF
--- a/src/operator/pooling-inl.h
+++ b/src/operator/pooling-inl.h
@@ -25,6 +25,7 @@ namespace pool_enum {
 enum PoolingOpInputs {kData};
 enum PoolingOpOutputs {kOut};
 enum PoolingOpType {kMaxPooling, kAvgPooling, kSumPooling};
+enum PoolingOpPadConventionType {kSame, kValid};
 }  // namespace pool_enum
 
 struct PoolingParam : public dmlc::Parameter<PoolingParam> {
@@ -32,6 +33,7 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
   TShape stride;
   TShape pad;
   int pool_type;
+  int pad_convention;
   bool global_pool;
   DMLC_DECLARE_PARAMETER(PoolingParam) {
     DMLC_DECLARE_FIELD(global_pool).set_default(false)
@@ -47,6 +49,11 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
     .add_enum("avg", pool_enum::kAvgPooling)
     .add_enum("sum", pool_enum::kSumPooling)
     .describe("Pooling type to be applied.");
+ 
+    DMLC_DECLARE_FIELD(pad_convention).set_default(pool_enum::kValid)
+    .add_enum("same", pool_enum::kSame)
+    .add_enum("valid", pool_enum::kValid)
+    .describe("Pooling convention to be applied.");
 
     int stride_shape[] = {1, 1};
     DMLC_DECLARE_FIELD(stride).set_default(TShape(stride_shape, stride_shape + 2))
@@ -199,8 +206,13 @@ class PoolingProp : public OperatorProperty {
         CHECK(param_.kernel[0] <= dshape[2] + 2 * param_.pad[0]
               && param_.kernel[1] <= dshape[3] + 2 * param_.pad[1])
             << "kernel size exceed input";
-        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
-        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
+        if (param_.pad_convention == pool_enum::kValid) {
+          oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
+          oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
+        } else {
+          oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
+          oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
+        }
       }
       out_shape->clear();
       out_shape->push_back(oshape);
@@ -215,9 +227,15 @@ class PoolingProp : public OperatorProperty {
         oshape[3] = 1;
         oshape[4] = 1;
       } else {
-        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
-        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
-        oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2];
+        if (param_.pool_type == pool_enum::kValid) {
+          oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
+          oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
+          oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2];
+        } else {
+          oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0]));
+          oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1]));
+          oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2]));
+        }
       }
 
       out_shape->clear();

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -98,6 +98,7 @@ def proto2script(proto_file):
             type_string = 'mx.symbol.Pooling'
             param = layer[i].pooling_param
             param_string = ''
+            param_string += "pad_convention='same', "
             if param.global_pooling == True:
                 # there must be a param `kernel` in a pooling layer
                 param_string += "global_pool=True, kernel=(1,1)"

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -98,7 +98,7 @@ def proto2script(proto_file):
             type_string = 'mx.symbol.Pooling'
             param = layer[i].pooling_param
             param_string = ''
-            param_string += "pad_convention='same', "
+            param_string += "pooling_convention='full', "
             if param.global_pooling == True:
                 # there must be a param `kernel` in a pooling layer
                 param_string += "global_pool=True, kernel=(1,1)"


### PR DESCRIPTION

Mxnet's pooling layer's output doesn't match Caffe's pooling's output, although Mxnet's convolution layer's output shape is same as Caffe. This issue will cause Googlenet from caffe convertor failing.

The following links shows pooling output size formula.
for caffe, 
https://github.com/BVLC/caffe/blob/master/src/caffe/layers/pooling_layer.cpp#L90
for mxnet, 
https://github.com/dmlc/mxnet/blob/master/src/operator/pooling-inl.h#L202

And please see #2999. @winstywang @ChenFengAndy

So I add two options for pooling layer {valid, same}. valid is for current mxnet's pooling output and for caffe, it uses same option
1) default pooling option is valid, same as current mxnet.
2) if model is from caffe, same option for pooling layer will be on.

Please give some comments. Thanks a lot.