### PR TITLE
move mnist dataset download link to web-data

### DIFF
--- a/example/image-classification/train_mnist.R
+++ b/example/image-classification/train_mnist.R
@@ -8,7 +8,9 @@ download_ <- function(data_dir) {
         (!file.exists('train-labels-idx1-ubyte')) ||
         (!file.exists('t10k-images-idx3-ubyte')) ||
         (!file.exists('t10k-labels-idx1-ubyte'))) {
-        download.file(url='http://data.dmlc.ml/mxnet/data/mnist.zip',
+        #download.file(url='http://data.dmlc.ml/mxnet/data/mnist.zip',
+        #              destfile='mnist.zip', method='wget')
+        download.file(url='https://github.com/dmlc/web-data/raw/master/mxnet/example/mnist.zip',
                       destfile='mnist.zip', method='wget')
         unzip("mnist.zip")
         file.remove("mnist.zip")

--- a/example/image-classification/train_mnist.py
+++ b/example/image-classification/train_mnist.py
@@ -12,7 +12,8 @@ def _download(data_dir):
        (not os.path.exists('train-labels-idx1-ubyte')) or \
        (not os.path.exists('t10k-images-idx3-ubyte')) or \
        (not os.path.exists('t10k-labels-idx1-ubyte')):
-        os.system("wget http://data.dmlc.ml/mxnet/data/mnist.zip")
+        #os.system("wget http://data.dmlc.ml/mxnet/data/mnist.zip")
+        os.system("wget https://github.com/dmlc/web-data/raw/master/mxnet/example/mnist.zip")
         os.system("unzip -u mnist.zip; rm mnist.zip")
     os.chdir("..")
 


### PR DESCRIPTION
in the `train_mnist` example, move  mnist dataset download link to web-data since data.dmlc.ml is not reachable.  cifar10.zip is too large to be put on web-data (exceed 100MB limit), will find another place.