### PR TITLE
MKLdnn Integration Patch to improve issue #2986(call for cpu performance)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,13 @@ ifeq ($(USE_CUDNN), 1)
 	LDFLAGS += -lcudnn
 endif
 
+ifeq ($(USE_MKLDNN),1)
+	CFLAGS += -DMXNET_USE_MKLDNN=1 -I$(MKLDNN_ROOT)/include
+	LDFLAGS += -L$(MKLDNN_ROOT)/lib/ -liomp5 -lmklml_gnu -lmklml_intel
+else
+	CFLAGS += -DMXNET_USE_MKLDNN=0
+endif
+
 ifeq ($(USE_THREADED_ENGINE), 1)
 	CFLAGS += -DMXNET_USE_THREADED_ENGINE
 endif

--- a/make/config.mk
+++ b/make/config.mk
@@ -51,6 +51,12 @@ USE_CUDNN = 0
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 USE_NVRTC = 0
 
+# whether use MKLDNN library
+USE_MKLDNN = 0
+
+# MKLDNN root library
+MKLDNN_ROOT = NONE
+
 # whether use opencv during compilation
 # you can disable it, however, you will not able to use
 # imbin iterator

--- a/src/operator/activation-inl.h
+++ b/src/operator/activation-inl.h
@@ -144,11 +144,11 @@ class ActivationProp : public OperatorProperty {
     const std::vector<int> &out_grad,
     const std::vector<int> &in_data,
     const std::vector<int> &out_data) const override {
-#if MXNET_USE_CUDNN == 1
+#if (MXNET_USE_CUDNN == 1) || (MXNET_USE_MKLDNN == 1)
     return {out_grad[activation::kOut], out_data[activation::kOut], in_data[activation::kData]};
 #else
     return {out_grad[activation::kOut], out_data[activation::kOut]};
-#endif  // MXNET_USE_CUDNN
+#endif  // MXNET_USE_CUDNN or MXNET_USE_MKLDNN
   }
 
   std::vector<std::pair<int, void*> > BackwardInplaceOption(

--- a/src/operator/batch_norm.cc
+++ b/src/operator/batch_norm.cc
@@ -6,12 +6,19 @@
 */
 
 #include "./batch_norm-inl.h"
+#if MXNET_USE_MKLDNN == 1
+#include "./mkldnn/mkldnn_batch_norm-inl.h"
+#endif
 
 namespace mxnet {
 namespace op {
 template<>
 Operator *CreateOp<cpu>(BatchNormParam param) {
+#if MXNET_USE_MKLDNN == 1
+  return new MKLBatchNormOp<float>(param);
+#else
   return new BatchNormOp<cpu>(param);
+#endif
 }
 
 Operator *BatchNormProp::CreateOperator(Context ctx) const {

--- a/src/operator/convolution.cc
+++ b/src/operator/convolution.cc
@@ -6,6 +6,9 @@
 */
 
 #include "./convolution-inl.h"
+#if MXNET_USE_MKLDNN == 1
+#include "./mkldnn/mkldnn_convolution-inl.h"
+#endif
 
 namespace mxnet {
 namespace op {
@@ -15,9 +18,15 @@ Operator* CreateOp<cpu>(ConvolutionParam param, int dtype,
                         std::vector<TShape> *out_shape,
                         Context ctx) {
   Operator *op = NULL;
+#if MXNET_USE_MKLDNN == 1
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new MKLDNNConvolutionOp<DType>(param);
+  })
+#else
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
     op = new ConvolutionOp<cpu, DType>(param);
   })
+#endif
   return op;
 }
 

--- a/src/operator/fully_connected-inl.h
+++ b/src/operator/fully_connected-inl.h
@@ -15,7 +15,6 @@
 #include <utility>
 #include "./operator_common.h"
 
-
 namespace mxnet {
 namespace op {
 
@@ -56,6 +55,9 @@ class FullyConnectedOp : public Operator {
                        const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     using namespace mshadow::expr;
+#ifdef PRINT_LAYER_TIME
+    double start_time = dmlc::GetTime();
+#endif
     if (req[fullc::kOut] == kNullOp) return;
     CHECK_EQ(req[fullc::kOut], kWriteTo);
     size_t expected = param_.no_bias ? 2 : 3;
@@ -82,6 +84,10 @@ class FullyConnectedOp : public Operator {
       Tensor<xpu, 1, DType> bias = in_data[fullc::kBias].get<xpu, 1, DType>(s);
       out += repmat(bias, data.size(0));
     }
+#ifdef PRINT_LAYER_TIME
+    double end_time = dmlc::GetTime();
+    LOG(INFO)<< "forward FC" << (end_time-start_time) << " s";
+#endif
   }
 
   virtual void Backward(const OpContext &ctx,

--- a/src/operator/lrn.cc
+++ b/src/operator/lrn.cc
@@ -9,12 +9,20 @@
 #if MXNET_USE_CUDNN == 1
 #include "./cudnn_lrn-inl.h"
 #endif
+#if MXNET_USE_MKLDNN == 1
+#include "./mkldnn/mkldnn_lrn-inl.h"
+#endif
+
 
 namespace mxnet {
 namespace op {
 template<>
 Operator* CreateOp<cpu>(LRNParam param) {
+#if MXNET_USE_MKLDNN == 1
+  return new MKLDNNLocalResponseNormOp<real_t>(param);
+#else
   return new LocalResponseNormOp<cpu>(param);
+#endif
 }
 
 Operator* LocalResponseNormProp::CreateOperator(Context ctx) const {

--- a/src/operator/mkldnn/README.md
+++ b/src/operator/mkldnn/README.md
@@ -1,7 +1,7 @@
 # MKLDNN PLUGIN
 
-MKLDNN is one intel released library to accelerate Deep Neural Network (DNN) applications on Intel architecture.
-This README shows users how to setup mxnet with MKLDNN accerlation.
+MKLDNN is one INTEL released library to accelerate Deep Neural Network (DNN) applications on Intel architecture.
+This README shows users how to setup mxnet with MKLDNN library.
 
 ## prepare MKLDNN Minimal Library
 ```

--- a/src/operator/mkldnn/README.md
+++ b/src/operator/mkldnn/README.md
@@ -1,0 +1,31 @@
+# MKLDNN PLUGIN
+
+MKLDNN is one intel released library to accelerate Deep Neural Network (DNN) applications on Intel architecture.
+This README shows users how to setup mxnet with MKLDNN accerlation.
+
+## prepare MKLDNN Minimal Library
+```
+  cd <MXNET ROOTDIR>
+  mkdir -p ./external/mkl
+  wget https://github.com/intel/caffe/releases/download/self_containted_MKLGOLD/mklml_lnx_2017.0.0.20160801.tgz
+  mv mklml_lnx_2017.0.0.20160801.tgz ./external/mkl
+  cd external/mkl
+  tar zxvf mklml_lnx_2017.0.0.20160801.tgz
+  cd <MXNET ROOTDIR> 
+```
+
+## update config.mk
+```
+  USE_MKLDNN = 1 # set USE_MKLDNN on
+  MKLDNN_ROOT = <MXNET ROOTDIR>/external/mkl/mklml_lnx_2017.0.0.20160801 # set MKLDNN ROOT PATH
+```
+
+## update LD_LIBRARY_PATH
+```
+  export LD_LIBRARY_PATH=<MXNET ROOTDIR>/external/mkl/mklml_lnx_2017.0.0.20160801/lib:$LD_LIBRARY_PATH
+```
+
+## build mxnet
+```
+  make -j8
+```

--- a/src/operator/mkldnn/mkldnn_ReLU-inl.h
+++ b/src/operator/mkldnn/mkldnn_ReLU-inl.h
@@ -1,0 +1,167 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_ReLU-inl.h
+ * \brief
+ * \author Ji Jiang
+*/
+
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_RELU_INL_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_RELU_INL_H_
+#include <algorithm>
+#include <vector>
+#include "../activation-inl.h"
+#include "mkldnn_memory-inl.h"
+namespace mxnet {
+namespace op {
+
+template <typename DType> class MKLDNNReLUOp : public Operator {
+ public:
+  explicit MKLDNNReLUOp(ActivationParam p)
+      : init_mkldnn_(false),
+        reluFwd_(NULL),
+        reluBwd_(NULL),
+        fwd_out_data_(new MKLData<DType>()),
+        fwd_in_data_(new MKLData<DType>()),
+        bwd_in_diff_(new MKLData<DType>()),
+        bwd_out_diff_(new MKLData<DType>()) {
+    param_ = p;
+    if (param_.act_type != activation::kReLU)
+      LOG(FATAL) << "mkldnn only support this activation type";
+  }
+
+  ~MKLDNNReLUOp() {
+    dnnDelete<DType>(reluFwd_);
+    dnnDelete<DType>(reluBwd_);
+  }
+
+  virtual void Forward(const OpContext &ctx, const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 1);
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+
+    if (!init_mkldnn_) {
+      this->Init(s, in_data, out_data);
+    }
+
+    relu_res_[dnnResourceSrc] =
+        reinterpret_cast<void *>(in_data[activation::kData].dptr_);
+    relu_res_[dnnResourceDst] =
+        reinterpret_cast<void *>(out_data[activation::kOut].dptr_);
+    CHECK_EQ(dnnExecute<DType>(reluFwd_, relu_res_), E_SUCCESS);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(out_grad.size(), 1);
+    CHECK(in_data.size() == 1 && in_grad.size() == 1);
+    CHECK_EQ(req.size(), 1);
+
+    relu_res_[dnnResourceDiffDst] =
+        reinterpret_cast<void *>(out_grad[activation::kOut].dptr_);
+    relu_res_[dnnResourceDiffSrc] =
+        reinterpret_cast<void *>(in_grad[activation::kData].dptr_);
+    CHECK_EQ(dnnExecute<DType>(reluBwd_, relu_res_), E_SUCCESS);
+  }
+
+ private:
+  inline void Init(mshadow::Stream<cpu> *s, const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 1);
+    if (!init_mkldnn_) {
+      init_mkldnn_ = true;
+
+      Tensor<cpu, 4, DType> data;
+      Tensor<cpu, 4, DType> out;
+
+      Shape<4> dshape;
+      index_t size_left = in_data[activation::kData].Size();
+      for (int i = 0; i < 3; ++i) {
+        if (i < in_data[activation::kData].ndim()) {
+          dshape[i] = in_data[activation::kData].shape_[i];
+        } else {
+          dshape[i] = 1;
+        }
+        size_left /= dshape[i];
+      }
+      dshape[3] = size_left;
+      data =
+          in_data[activation::kData].get_with_shape<cpu, 4, DType>(dshape, s);
+      out = out_data[activation::kOut].get_with_shape<cpu, 4, DType>(dshape, s);
+
+      size_t src_sizes[4], src_strides[4];
+      size_t dst_sizes[4], dst_strides[4];
+
+      size_t dim = 4;
+
+      const size_t input_batch_size = data.size(0);
+      const size_t input_channels = data.size(1);
+      const size_t input_height = data.size(2);
+      const size_t input_width = data.size(3);
+
+      const size_t output_batch_size = out.size(0);
+      const size_t output_channels = out.size(1);
+      const size_t output_height = out.size(2);
+      const size_t output_width = out.size(3);
+
+      src_sizes[0] = input_width;
+      src_sizes[1] = input_height;
+      src_sizes[2] = input_channels;
+      src_sizes[3] = input_batch_size;
+      src_strides[0] = 1;
+      src_strides[1] = src_sizes[0];
+      src_strides[2] = src_sizes[0] * src_sizes[1];
+      src_strides[3] = src_sizes[0] * src_sizes[1] * src_sizes[2];
+      dst_sizes[0] = output_width;
+      dst_sizes[1] = output_height;
+      dst_sizes[2] = output_channels;
+      dst_sizes[3] = output_batch_size;
+      dst_strides[0] = 1;
+      dst_strides[1] = dst_sizes[0];
+      dst_strides[2] = dst_sizes[0] * dst_sizes[1];
+      dst_strides[3] = dst_sizes[0] * dst_sizes[1] * dst_sizes[2];
+
+      fwd_in_data_->create_user_layout(dim, src_sizes, src_strides);
+      fwd_out_data_->create_user_layout(dim, dst_sizes, dst_strides);
+      bwd_in_diff_->create_user_layout(dim, src_sizes, src_strides);
+      bwd_out_diff_->create_user_layout(dim, dst_sizes, dst_strides);
+
+      dnnPrimitiveAttributes_t attributes = NULL;
+      CHECK_EQ(dnnPrimitiveAttributesCreate<DType>(&attributes), E_SUCCESS);
+
+      CHECK_EQ(dnnReLUCreateForward<DType>(&reluFwd_, attributes,
+                                           fwd_in_data_->layout_usr, 0.0f),
+               E_SUCCESS);
+      CHECK_EQ(dnnReLUCreateBackward<DType>(&reluBwd_, attributes,
+                                            bwd_in_diff_->layout_usr,
+                                            fwd_in_data_->layout_usr, 0.0f),
+               E_SUCCESS);
+    }
+  }
+
+  bool init_mkldnn_;
+  dnnPrimitive_t reluFwd_, reluBwd_;
+  std::shared_ptr<MKLData<DType>> fwd_out_data_, fwd_in_data_;
+  std::shared_ptr<MKLData<DType>> bwd_in_diff_, bwd_out_diff_;
+  ActivationParam param_;
+  void *relu_res_[dnnResourceNumber];
+};  // class MKLDNNReLUOp
+}   // namespace op
+}   // namespace mxnet
+
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_RELU_INL_H_

--- a/src/operator/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/mkldnn/mkldnn_batch_norm-inl.h
@@ -1,0 +1,312 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_batch_norm-inl.h
+ * \brief
+ * \author Chen, Xiaoming
+*/
+
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_BATCH_NORM_INL_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_BATCH_NORM_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include <memory>
+#include "dmlc/timer.h"
+#include "../operator_common.h"
+#include "../mshadow_op.h"
+#include "./mkldnn_cppwrapper.h"
+#include "./mkldnn_memory-inl.h"
+#include "mkl_service.h"
+
+using namespace std;
+
+namespace mxnet {
+namespace op {
+#if MXNET_USE_MKLDNN == 1
+
+template <typename DType> class MKLBatchNormOp : public Operator {
+ public:
+  explicit MKLBatchNormOp(BatchNormParam param)
+      : param_(param),
+        fwd_in_data_(new MKLData<DType>()),
+        fwd_out_data_(new MKLData<DType>()),
+        bwd_in_diff_(new MKLData<DType>()),
+        bwd_out_diff_(new MKLData<DType>()),
+        batchNormFwd_(NULL),
+        batchNormBwdData_(NULL),
+        batchNormBwdScaleShift_(NULL) {
+    init_mkl_ = false;
+  }
+
+  ~MKLBatchNormOp() {
+    dnnDelete<DType>(batchNormFwd_);
+    dnnDelete<DType>(batchNormBwdData_);
+    dnnDelete<DType>(batchNormBwdScaleShift_);
+  }
+
+  virtual void Forward(const OpContext &ctx, const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_states) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 3);
+    CHECK_EQ(aux_states.size(), 2);
+    // CHECK_EQ(!(ctx.is_train && !param_.use_global_stats), false)
+    //     <<"MKL does not support batch norm global stats";
+    if (ctx.is_train) {
+      CHECK_EQ(out_data.size(), 3);
+      CHECK_EQ(req.size(), 3);
+    } else {
+      CHECK_GE(out_data.size(), 1);
+      CHECK_GE(req.size(), 1);
+      CHECK_EQ(req[batchnorm::kOut], kWriteTo);
+    }
+
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+    if (!init_mkl_) {
+      Init(ctx, s, in_data, out_data);
+    }
+
+    Tensor<cpu, 4> data;
+    Tensor<cpu, 4> out;
+    if (in_data[batchnorm::kData].ndim() == 2) {
+      Shape<4> dshape = Shape4(in_data[batchnorm::kData].shape_[0],
+                               in_data[batchnorm::kData].shape_[1], 1, 1);
+      data =
+          in_data[batchnorm::kData].get_with_shape<cpu, 4, real_t>(dshape, s);
+      out = out_data[batchnorm::kOut].get_with_shape<cpu, 4, real_t>(dshape, s);
+    } else {
+      data = in_data[batchnorm::kData].get<cpu, 4, real_t>(s);
+      out = out_data[batchnorm::kOut].get<cpu, 4, real_t>(s);
+    }
+    Tensor<cpu, 1> slope = in_data[batchnorm::kGamma].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> bias = in_data[batchnorm::kBeta].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> moving_mean = aux_states[batchnorm::kMovingMean].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> moving_var = aux_states[batchnorm::kMovingVar].get<cpu, 1, real_t>(s);
+    // yandai removes is_train
+    // if (ctx.is_train && param_.fix_gamma) {
+    if (param_.fix_gamma) {
+      slope = 1.0f;
+    }
+
+    if (ctx.is_train && !param_.use_global_stats) {
+      Tensor<cpu, 1> mean = out_data[batchnorm::kMean].get<cpu, 1, real_t>(s);
+      Tensor<cpu, 1> var = out_data[batchnorm::kVar].get<cpu, 1, real_t>(s);
+      CHECK(req[batchnorm::kMean] == kNullOp || req[batchnorm::kMean] == kWriteTo);
+      CHECK(req[batchnorm::kVar] == kNullOp || req[batchnorm::kVar] == kWriteTo);
+      // The first three steps must be enforced.
+      const real_t scale = static_cast<real_t>(in_data[batchnorm::kData].shape_[1]) /
+          static_cast<real_t>(in_data[batchnorm::kData].shape_.Size());
+      mean = scale * sumall_except_dim<1>(data);
+      var = scale * sumall_except_dim<1>(F<mshadow_op::square>(
+          data - broadcast<1>(mean, data.shape_)));
+      const size_t input_channels = data.size(1);
+      for (int i = 0; i < input_channels; i++) {
+        scaleShift_buffer_[i] = slope[i];
+        scaleShift_buffer_[input_channels + i] = bias[i];
+      }
+
+      void *res_BatchNorm[dnnResourceNumber];
+      res_BatchNorm[dnnResourceSrc] = data.dptr_;
+      res_BatchNorm[dnnResourceWorkspace] = workspace_buffer_;
+      res_BatchNorm[dnnResourceScaleShift] = scaleShift_buffer_;
+      res_BatchNorm[dnnResourceDst] =
+          reinterpret_cast<void *>(fwd_out_data_->set_output_ptr(out.dptr_));
+      dnnError_t status = dnnExecute<DType>(batchNormFwd_, res_BatchNorm);
+      CHECK_EQ(status, E_SUCCESS) << "batch norm execute failure with status "
+                                  << status;
+
+      fwd_out_data_->get_output_ptr(out.dptr_);
+    } else {
+      Assign(out, req[batchnorm::kOut], broadcast<1>(slope /
+                                          F<mshadow_op::square_root>(moving_var + param_.eps),
+                                          data.shape_) * data +
+             broadcast<1>(bias - (slope * moving_mean) /
+                          F<mshadow_op::square_root>(moving_var + param_.eps), data.shape_));
+    }
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_states) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(out_grad.size(), 1);
+    CHECK_EQ(in_data.size(), 3);
+    CHECK_EQ(out_data.size(), 3);
+    CHECK_EQ(in_grad.size(), 3);
+    //  <<"MKL does not support batch norm global stats";
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+    Tensor<cpu, 4> data, grad, grad_in;
+    if (in_data[batchnorm::kData].ndim() == 2) {
+      Shape<4> dshape = Shape4(out_grad[batchnorm::kOut].shape_[0],
+                               out_grad[batchnorm::kOut].shape_[1], 1, 1);
+      data =
+          in_data[batchnorm::kData].get_with_shape<cpu, 4, real_t>(dshape, s);
+      grad =
+          out_grad[batchnorm::kOut].get_with_shape<cpu, 4, real_t>(dshape, s);
+      grad_in =
+          in_grad[batchnorm::kData].get_with_shape<cpu, 4, real_t>(dshape, s);
+    } else {
+      data = in_data[batchnorm::kData].get<cpu, 4, real_t>(s);
+      grad = out_grad[batchnorm::kOut].get<cpu, 4, real_t>(s);
+      grad_in = in_grad[batchnorm::kData].get<cpu, 4, real_t>(s);
+    }
+
+    Tensor<cpu, 1> gslope = in_grad[batchnorm::kGamma].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> gbias = in_grad[batchnorm::kBeta].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> mean = out_data[batchnorm::kMean].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> var = out_data[batchnorm::kVar].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> moving_mean = aux_states[batchnorm::kMovingMean].get<cpu, 1, real_t>(s);
+    Tensor<cpu, 1> moving_var = aux_states[batchnorm::kMovingVar].get<cpu, 1, real_t>(s);
+
+    moving_mean = moving_mean * param_.momentum + mean * (1 - param_.momentum);
+    moving_var = moving_var * param_.momentum + var * (1 - param_.momentum);
+    dnnError_t e;
+    void *BatchNorm_res[dnnResourceNumber];
+    BatchNorm_res[dnnResourceSrc] = data.dptr_;
+    BatchNorm_res[dnnResourceWorkspace] = workspace_buffer_;
+    BatchNorm_res[dnnResourceScaleShift] = scaleShift_buffer_;
+
+    BatchNorm_res[dnnResourceDiffDst] =
+        bwd_out_diff_->get_converted_prv(grad.dptr_, false);
+    BatchNorm_res[dnnResourceDiffSrc] =
+        bwd_in_diff_->set_output_ptr(grad_in.dptr_);
+    e = dnnExecute<DType>(batchNormBwdData_, BatchNorm_res);
+    CHECK_EQ(e, E_SUCCESS);
+    bwd_in_diff_->get_output_ptr(grad_in.dptr_);
+
+    void *BatchNormBwdScaleShift_res[dnnResourceNumber];
+    BatchNormBwdScaleShift_res[dnnResourceSrc] = data.dptr_;
+    BatchNormBwdScaleShift_res[dnnResourceWorkspace] = workspace_buffer_;
+    BatchNormBwdScaleShift_res[dnnResourceDiffScaleShift] = scaleShift_buffer_;
+    BatchNormBwdScaleShift_res[dnnResourceDiffDst] =
+        BatchNorm_res[dnnResourceDiffDst];
+    e = dnnExecute<DType>(batchNormBwdScaleShift_, BatchNormBwdScaleShift_res);
+    CHECK_EQ(e, E_SUCCESS);
+
+    const size_t input_channels = data.size(1);
+    for (int i = 0; i < input_channels; i++) {
+      gslope[i] = scaleShift_buffer_[i];
+      gbias[i] = scaleShift_buffer_[i + input_channels];
+    }
+  }
+
+ private:
+  inline void Init(const OpContext &ctx, mshadow::Stream<cpu> *s,
+                   const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    if (!init_mkl_) {
+      init_mkl_ = true;
+      dnnError_t status = E_SUCCESS;
+
+      Tensor<cpu, 4> data;
+      Tensor<cpu, 4> out;
+      if (in_data[batchnorm::kData].ndim() == 2) {
+        Shape<4> dshape = Shape4(in_data[batchnorm::kData].shape_[0],
+                                 in_data[batchnorm::kData].shape_[1], 1, 1);
+        data =
+            in_data[batchnorm::kData].get_with_shape<cpu, 4, real_t>(dshape, s);
+        out =
+            out_data[batchnorm::kOut].get_with_shape<cpu, 4, real_t>(dshape, s);
+      } else {
+        data = in_data[batchnorm::kData].get<cpu, 4, real_t>(s);
+        out = out_data[batchnorm::kOut].get<cpu, 4, real_t>(s);
+      }
+      Tensor<cpu, 1> slope = in_data[batchnorm::kGamma].get<cpu, 1, real_t>(s);
+      Tensor<cpu, 1> bias = in_data[batchnorm::kBeta].get<cpu, 1, real_t>(s);
+      if (ctx.is_train && param_.fix_gamma) {
+        slope = 1.0f;
+      }
+
+      size_t dim = 4, sizes[4], strides[4];
+      const size_t batch_size = data.size(0);
+      const size_t input_channels = data.size(1);
+      const size_t input_height = data.size(2);
+      const size_t input_width = data.size(3);
+      sizes[0] = input_width;
+      sizes[1] = input_height;
+      sizes[2] = input_channels;
+      sizes[3] = batch_size;
+      strides[0] = 1;
+      strides[1] = sizes[0];
+      strides[2] = sizes[0] * sizes[1];
+      strides[3] = sizes[0] * sizes[1] * sizes[2];
+
+      status = dnnLayoutCreate<DType>(&layout_usr_, dim, sizes, strides);
+      CHECK_EQ(status, E_SUCCESS) << "create user layout failure with status "
+                                  << status;
+
+      fwd_in_data_->create_user_layout(dim, sizes, strides);
+      fwd_out_data_->create_user_layout(dim, sizes, strides);
+      bwd_in_diff_->create_user_layout(dim, sizes, strides);
+      bwd_out_diff_->create_user_layout(dim, sizes, strides);
+
+      workspace_buffer_ = NULL;
+      scaleShift_buffer_ = NULL;
+
+      status = dnnBatchNormalizationCreateForward<DType>(
+          &batchNormFwd_, NULL, layout_usr_, param_.eps);
+      CHECK_EQ(status, E_SUCCESS)
+          << "create forward batch norm failure with status " << status;
+
+      fwd_out_data_->create_internal_layout(batchNormFwd_, dnnResourceDst);
+      bwd_in_diff_->create_internal_layout(batchNormFwd_, dnnResourceDst);
+      bwd_out_diff_->create_internal_layout(batchNormFwd_, dnnResourceSrc);
+
+      status = dnnBatchNormalizationCreateBackwardData<DType>(
+          &batchNormBwdData_, NULL, bwd_in_diff_->layout_int, param_.eps);
+      CHECK_EQ(status, E_SUCCESS);
+
+      status = dnnBatchNormalizationCreateBackwardScaleShift<DType>(
+          &batchNormBwdScaleShift_, NULL, bwd_in_diff_->layout_int, param_.eps);
+
+      dnnLayout_t lt_workspace_buffer = NULL;
+      status = dnnLayoutCreateFromPrimitive<DType>(
+          &lt_workspace_buffer, batchNormFwd_, dnnResourceWorkspace);
+      status = dnnAllocateBuffer<DType>(
+          reinterpret_cast<void **>(&workspace_buffer_), lt_workspace_buffer);
+      dnnLayoutDelete<DType>(lt_workspace_buffer);
+
+      dnnLayout_t lt_scaleShift_buffer = NULL;
+      status = dnnLayoutCreateFromPrimitive<DType>(
+          &lt_scaleShift_buffer, batchNormFwd_, dnnResourceScaleShift);
+      CHECK_EQ(status, E_SUCCESS);
+      status = dnnAllocateBuffer<DType>(
+          reinterpret_cast<void **>(&scaleShift_buffer_), lt_scaleShift_buffer);
+      CHECK_EQ(status, E_SUCCESS);
+      dnnLayoutDelete<DType>(lt_scaleShift_buffer);
+
+      for (int i = 0; i < input_channels; i++) {
+        scaleShift_buffer_[i] = slope[i];
+        scaleShift_buffer_[input_channels + i] = bias[i];
+      }
+    }
+  }
+
+  bool init_mkl_;
+  BatchNormParam param_;
+  shared_ptr<MKLData<DType>> fwd_in_data_;
+  shared_ptr<MKLData<DType>> fwd_out_data_;
+  shared_ptr<MKLData<DType>> bwd_in_diff_;
+  shared_ptr<MKLData<DType>> bwd_out_diff_;
+  dnnPrimitive_t batchNormFwd_, batchNormBwdData_, batchNormBwdScaleShift_;
+  DType *workspace_buffer_;
+  DType *scaleShift_buffer_;
+  dnnLayout_t layout_usr_;
+};  // class MKLBatchNormOp
+#endif
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_BATCH_NORM_INL_H_

--- a/src/operator/mkldnn/mkldnn_convolution-inl.h
+++ b/src/operator/mkldnn/mkldnn_convolution-inl.h
@@ -1,0 +1,374 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_convolution-inl.h
+ * \brief
+ * \author Chen, Xiaoming
+*/
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_CONVOLUTION_INL_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_CONVOLUTION_INL_H_
+
+#include <dmlc/timer.h>
+#include <string>
+#include <iostream>
+#include <vector>
+#include <memory>
+#include "mkl_service.h"
+#include "../convolution-inl.h"
+#include "./mkldnn_memory-inl.h"
+#include "./mkldnn_cppwrapper.h"
+namespace mxnet {
+namespace op {
+#if MXNET_USE_MKLDNN == 1
+static int getMKLBuildDate() {
+  static int build = 0;
+  if (build == 0) {
+    MKLVersion v;
+    mkl_get_version(&v);
+    build = atoi(v.Build);
+  }
+  return build;
+}
+
+template <typename DType> class MKLDNNConvolutionOp : public Operator {
+ public:
+  explicit MKLDNNConvolutionOp(ConvolutionParam param)
+      : param_(param),
+        fwd_in_data_(new MKLData<DType>()),
+        fwd_out_data_(new MKLData<DType>()),
+        fwd_filter_data_(new MKLData<DType>()),
+        fwd_bias_data_(new MKLData<DType>()),
+        convolutionFwd_(NULL),
+        bwdd_in_diff_(new MKLData<DType>()),
+        bwdd_out_diff_(new MKLData<DType>()),
+        bwdd_filter_data_(new MKLData<DType>()),
+        bwdf_in_data_(new MKLData<DType>()),
+        bwdf_out_diff_(new MKLData<DType>()),
+        bwdf_filter_diff_(new MKLData<DType>()),
+        bwdb_out_diff_(new MKLData<DType>()),
+        bwdb_bias_diff_(new MKLData<DType>()),
+        convolutionBwdData_(NULL),
+        convolutionBwdFilter_(NULL),
+        convolutionBwdBias_(NULL) {
+    init_mkl_ = false;
+    algo_ = dnnAlgorithmConvolutionDirect;
+  }
+
+  ~MKLDNNConvolutionOp() {
+    dnnDelete<DType>(convolutionBwdBias_);
+    dnnDelete<DType>(convolutionBwdFilter_);
+    dnnDelete<DType>(convolutionBwdData_);
+    dnnDelete<DType>(convolutionFwd_);
+  }
+
+  virtual void Forward(const OpContext &ctx, const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(req[conv::kOut], kWriteTo);
+    CHECK_EQ(out_data.size(), 1);
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+    if (param_.kernel.ndim() > 2) {
+      LOG(FATAL) << "Volume convolution is not implmented in mkldnn";
+    }
+
+    Tensor<cpu, 4, DType> data = in_data[conv::kData].get<cpu, 4, DType>(s);
+    Shape<3> wmat_shape =
+        Shape3(param_.num_group, param_.num_filter / param_.num_group,
+               data.shape_[1] / param_.num_group * param_.kernel[0] *
+                   param_.kernel[1]);
+    Tensor<cpu, 3, DType> wmat =
+        in_data[conv::kWeight].get_with_shape<cpu, 3, DType>(wmat_shape, s);
+    Tensor<cpu, 1, DType> bias;
+    if (!param_.no_bias) {
+      bias = in_data[conv::kBias].get<cpu, 1, DType>(s);
+    }
+    Tensor<cpu, 4, DType> out = out_data[conv::kOut].get<cpu, 4, DType>(s);
+
+    void *res_convolutionFwd[dnnResourceNumber];
+    if (!init_mkl_) {
+      Init(s, in_data, out_data);
+    }
+
+    res_convolutionFwd[dnnResourceSrc] =
+        fwd_in_data_->get_converted_prv(data.dptr_, false);
+
+    res_convolutionFwd[dnnResourceFilter] =
+        fwd_filter_data_->get_converted_prv(wmat.dptr_, false);
+    if (!param_.no_bias) {
+      res_convolutionFwd[dnnResourceBias] =
+          fwd_bias_data_->get_converted_prv(bias.dptr_, false);
+    } else {
+      res_convolutionFwd[dnnResourceBias] = NULL;
+    }
+    res_convolutionFwd[dnnResourceDst] =
+        reinterpret_cast<void *>(fwd_out_data_->set_output_ptr(out.dptr_));
+    dnnError_t status = dnnExecute<DType>(convolutionFwd_, res_convolutionFwd);
+    CHECK_EQ(status, E_SUCCESS) << "execute forward fail with status" << status;
+    fwd_out_data_->get_output_ptr(out.dptr_);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    dnnError_t status = E_SUCCESS;
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+    if (!init_mkl_) {
+      Init(s, in_data, out_data);
+    }
+
+    if (param_.kernel.ndim() > 2) {
+      LOG(FATAL) << "Volume convolution is not implmented in mkldnn";
+    }
+    size_t expected = param_.no_bias == 0 ? 3 : 2;
+    CHECK_EQ(out_grad.size(), 1);
+    CHECK(in_data.size() == expected && in_grad.size() == expected);
+    CHECK_EQ(req.size(), expected);
+    CHECK_EQ(in_data[conv::kWeight].CheckContiguous(), true);
+
+    DType *grad_ptr = NULL;
+    DType *wmat_ptr = NULL;
+    DType *gwmat_ptr = NULL;
+    DType *data_ptr = NULL;
+    DType *gdata_ptr = NULL;
+
+    Tensor<cpu, 4, DType> data = in_data[conv::kData].get<cpu, 4, DType>(s);
+    Shape<3> wmat_shape =
+        Shape3(param_.num_group, param_.num_filter / param_.num_group,
+               data.shape_[1] / param_.num_group * param_.kernel[0] *
+                   param_.kernel[1]);
+    Tensor<cpu, 3, DType> wmat =
+        in_data[conv::kWeight].get_with_shape<cpu, 3, DType>(wmat_shape, s);
+    Tensor<cpu, 4, DType> grad = out_grad[conv::kOut].get<cpu, 4, DType>(s);
+    Tensor<cpu, 4, DType> gdata = in_grad[conv::kData].get<cpu, 4, DType>(s);
+    Tensor<cpu, 3, DType> gwmat =
+        in_grad[conv::kWeight].get_with_shape<cpu, 3, DType>(wmat_shape, s);
+
+    grad_ptr = grad.dptr_;
+    wmat_ptr = wmat.dptr_;
+    gwmat_ptr = gwmat.dptr_;
+    data_ptr = data.dptr_;
+    gdata_ptr = gdata.dptr_;
+
+    // avoid input layer's gradient calculation for MKLDNN
+    if (!((gdata.shape_[1] == 3) || (gdata.shape_[1] == 1))) {
+      void *res_convolutionBwdData[dnnResourceNumber];
+      res_convolutionBwdData[dnnResourceDiffDst] =
+          bwdd_out_diff_->get_converted_prv(grad_ptr, false);
+      res_convolutionBwdData[dnnResourceFilter] =
+          bwdd_filter_data_->get_converted_prv(wmat_ptr, false);
+      res_convolutionBwdData[dnnResourceDiffSrc] =
+          reinterpret_cast<void *>(bwdd_in_diff_->set_output_ptr(gdata_ptr));
+      status = dnnExecute<DType>(convolutionBwdData_, res_convolutionBwdData);
+      CHECK_EQ(status, E_SUCCESS) << "Backward Data conv failed with status "
+                                  << status;
+      bwdd_in_diff_->get_output_ptr(gdata_ptr);
+    }
+
+    void *res_convolutionBwdFilter[dnnResourceNumber];
+    if (dnnLayoutCompare<DType>(bwdf_out_diff_->layout_int,
+                                bwdd_out_diff_->layout_int)) {
+      res_convolutionBwdFilter[dnnResourceDiffDst] =
+          bwdd_out_diff_->get_converted_prv(grad_ptr, true);
+    } else {
+      res_convolutionBwdFilter[dnnResourceDiffDst] =
+          bwdf_out_diff_->get_converted_prv(grad_ptr, false);
+    }
+    if (dnnLayoutCompare<DType>(fwd_in_data_->layout_int,
+                                bwdf_in_data_->layout_int)) {
+      res_convolutionBwdFilter[dnnResourceSrc] =
+          fwd_in_data_->get_converted_prv(data_ptr, true);
+    } else {
+      res_convolutionBwdFilter[dnnResourceSrc] =
+          bwdf_in_data_->get_converted_prv(data_ptr, false);
+    }
+    res_convolutionBwdFilter[dnnResourceDiffFilter] =
+        reinterpret_cast<void *>(bwdf_filter_diff_->set_output_ptr(gwmat_ptr));
+    status = dnnExecute<DType>(convolutionBwdFilter_, res_convolutionBwdFilter);
+    CHECK_EQ(status, E_SUCCESS) << "Backward Filter conv failed with status "
+                                << status;
+    bwdf_filter_diff_->get_output_ptr(gwmat_ptr);
+
+    if (!param_.no_bias) {
+      Tensor<cpu, 1, DType> gbias = in_grad[conv::kBias].get<cpu, 1, DType>(s);
+      void *res_convolutionBwdBias[dnnResourceNumber];
+      if (dnnLayoutCompare<DType>(bwdb_out_diff_->layout_int,
+                                  bwdd_out_diff_->layout_int)) {
+        res_convolutionBwdBias[dnnResourceDiffDst] =
+            bwdd_out_diff_->get_converted_prv(grad_ptr, true);
+      } else if (dnnLayoutCompare<DType>(bwdb_out_diff_->layout_int,
+                                         bwdf_out_diff_->layout_int)) {
+        res_convolutionBwdBias[dnnResourceDiffDst] =
+            bwdf_out_diff_->get_converted_prv(grad_ptr, true);
+      } else {
+        res_convolutionBwdBias[dnnResourceDiffDst] =
+            bwdb_out_diff_->get_converted_prv(grad_ptr, false);
+      }
+      res_convolutionBwdBias[dnnResourceDiffBias] = reinterpret_cast<void *>(
+          bwdb_bias_diff_->set_output_ptr(gbias.dptr_));
+      status = dnnExecute<DType>(convolutionBwdBias_, res_convolutionBwdBias);
+      CHECK_EQ(status, E_SUCCESS) << "Backward Bias conv failed with status "
+                                  << status;
+      bwdb_bias_diff_->get_output_ptr(gbias.dptr_);
+    }
+  }
+
+ private:
+  inline void Init(mshadow::Stream<cpu> *s, const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    if (!init_mkl_) {
+      init_mkl_ = true;
+      dnnError_t status = E_SUCCESS;
+
+      Tensor<cpu, 4, DType> data = in_data[conv::kData].get<cpu, 4, DType>(s);
+      Tensor<cpu, 4, DType> out = out_data[conv::kOut].get<cpu, 4, DType>(s);
+
+      const size_t batch_size = data.size(0);
+      const size_t input_channels = data.size(1);
+      const size_t input_height = data.size(2);
+      const size_t input_width = data.size(3);
+      const size_t output_channels = param_.num_filter;
+      const size_t output_height = out.size(2);
+      const size_t output_width = out.size(3);
+      const size_t group_number = param_.num_group;
+      const size_t kernel_height = param_.kernel[0];
+      const size_t kernel_width = param_.kernel[1];
+      size_t dimension = 4;
+
+      const size_t idata_sizes[4] = { input_width, input_height, input_channels,
+                                      batch_size };
+      const size_t idata_strides[4] = {
+        1, input_width, input_width * input_height,
+        input_width * input_height * input_channels};
+
+      size_t g_mkl2017 = group_number;
+      size_t f_dimension = dimension + (group_number != 1);
+      if (getMKLBuildDate() < 20160701) {
+        g_mkl2017 = 1;
+        f_dimension = dimension;
+      }
+      const size_t fdata_sizes[5] = {kernel_width, kernel_height,
+                                      input_channels / group_number,
+                                      output_channels / g_mkl2017, g_mkl2017};
+      const size_t fdata_strides[5] = {
+        1, kernel_width, kernel_width * kernel_height,
+        kernel_width * kernel_height * input_channels / group_number,
+        kernel_width * kernel_height * input_channels / group_number *
+            output_channels / group_number
+      };
+
+      const size_t bias_sizes[1] = {output_channels};
+      const size_t bias_strides[1] = {1};
+
+      const size_t odata_sizes[4] = {output_width, output_height,
+                                      output_channels, batch_size};
+      const size_t odata_strides[4] = {
+        1, output_width, output_width * output_height,
+        output_width * output_height * output_channels};
+
+      size_t convolutionStrides[2] = { param_.stride[1], param_.stride[0] };
+      int inputOffset[2] = {static_cast<int>(-param_.pad[1]), static_cast<int>(-param_.pad[0])};
+
+      // forward setup
+      if (!param_.no_bias) {
+        status = dnnGroupsConvolutionCreateForwardBias<DType>(
+            &convolutionFwd_, NULL, algo_, group_number, dimension, idata_sizes,
+            odata_sizes, fdata_sizes, convolutionStrides, inputOffset,
+            dnnBorderZeros);
+      } else {
+        status = dnnGroupsConvolutionCreateForward<DType>(
+            &convolutionFwd_, NULL, algo_, group_number, dimension, idata_sizes,
+            odata_sizes, fdata_sizes, convolutionStrides, inputOffset,
+            dnnBorderZeros);
+      }
+      CHECK_EQ(status, E_SUCCESS) << "status" << status;
+
+      fwd_in_data_->create_layouts(convolutionFwd_, dnnResourceSrc, dimension,
+                                   idata_sizes, idata_strides);
+      fwd_out_data_->create_layouts(convolutionFwd_, dnnResourceDst, dimension,
+                                    odata_sizes, odata_strides);
+      fwd_filter_data_->create_layouts(convolutionFwd_, dnnResourceFilter,
+                                       f_dimension, fdata_sizes, fdata_strides);
+      if (!param_.no_bias) {
+        fwd_bias_data_->create_layouts(convolutionFwd_, dnnResourceBias, 1,
+                                       bias_sizes, bias_strides);
+      }
+
+      // backward data
+      status = dnnGroupsConvolutionCreateBackwardData<DType>(
+          &convolutionBwdData_, NULL, algo_, group_number, dimension,
+          idata_sizes, odata_sizes, fdata_sizes, convolutionStrides,
+          inputOffset, dnnBorderZeros);
+      CHECK_EQ(status, E_SUCCESS)
+          << "Failed dnnConvolutionCreateBackwardData with status " << status
+          << "\n";
+
+      bwdd_in_diff_->create_layouts(convolutionBwdData_, dnnResourceDiffSrc,
+                                    dimension, idata_sizes, idata_strides);
+      bwdd_out_diff_->create_layouts(convolutionBwdData_, dnnResourceDiffDst,
+                                     dimension, odata_sizes, odata_strides);
+      bwdd_filter_data_->create_layouts(convolutionBwdData_, dnnResourceFilter,
+                                        f_dimension, fdata_sizes,
+                                        fdata_strides);
+
+      // backward filter
+      status = dnnGroupsConvolutionCreateBackwardFilter<DType>(
+          &convolutionBwdFilter_, NULL, algo_, group_number, dimension,
+          idata_sizes, odata_sizes, fdata_sizes, convolutionStrides,
+          inputOffset, dnnBorderZeros);
+      CHECK_EQ(status, E_SUCCESS)
+          << "Failed dnnConvolutionCreateBackwardFilter with status " << status
+          << "\n";
+
+      bwdf_in_data_->create_layouts(convolutionBwdFilter_, dnnResourceSrc,
+                                    dimension, idata_sizes, idata_strides);
+      bwdf_out_diff_->create_layouts(convolutionBwdFilter_, dnnResourceDiffDst,
+                                     dimension, odata_sizes, odata_strides);
+      bwdf_filter_diff_->create_layouts(convolutionBwdFilter_,
+                                        dnnResourceDiffFilter, f_dimension,
+                                        fdata_sizes, fdata_strides);
+
+      // backward bias
+      if (!param_.no_bias) {
+        status = dnnGroupsConvolutionCreateBackwardBias<DType>(
+            &convolutionBwdBias_, NULL, algo_, group_number, dimension,
+            odata_sizes);
+        CHECK_EQ(status, E_SUCCESS)
+            << "Failed dnnConvolutionCreateBackwardBias with status " << status
+            << "\n";
+
+        bwdb_out_diff_->create_layouts(convolutionBwdBias_, dnnResourceDiffDst,
+                                       dimension, odata_sizes, odata_strides);
+        bwdb_bias_diff_->create_layouts(convolutionBwdBias_,
+                                        dnnResourceDiffBias, 1, bias_sizes,
+                                        bias_strides);
+      }
+    }
+  }
+
+  bool init_mkl_;
+  dnnAlgorithm_t algo_;
+  ConvolutionParam param_;
+  std::shared_ptr<MKLData<DType>> fwd_in_data_, fwd_out_data_, fwd_filter_data_,
+      fwd_bias_data_;
+  dnnPrimitive_t convolutionFwd_;
+  std::shared_ptr<MKLData<DType>> bwdd_in_diff_, bwdd_out_diff_,
+      bwdd_filter_data_;
+  std::shared_ptr<MKLData<DType>> bwdf_in_data_, bwdf_out_diff_,
+      bwdf_filter_diff_;
+  std::shared_ptr<MKLData<DType>> bwdb_out_diff_, bwdb_bias_diff_;
+  dnnPrimitive_t convolutionBwdData_, convolutionBwdFilter_,
+      convolutionBwdBias_;
+};
+#endif
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_CONVOLUTION_INL_H_

--- a/src/operator/mkldnn/mkldnn_cppwrapper.h
+++ b/src/operator/mkldnn/mkldnn_cppwrapper.h
@@ -1,0 +1,1015 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_cppwrapper.h
+ * \brief
+ * \author yandai
+*/
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_CPPWRAPPER_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_CPPWRAPPER_H_
+
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <mshadow/base.h>
+#include <dmlc/logging.h>
+
+#include "mkl_dnn_types.h"
+#include "mkl_dnn.h"
+#include "mkl_version.h"
+
+#if (__INTEL_MKL__ < 2017) || (__INTEL_MKL_BUILD_DATE <= 20160311)
+#error \
+    : Unsupported MKL DNN API.
+#endif
+
+template <typename DType>
+inline dnnError_t dnnPoolingCreateBackward(
+    dnnPrimitive_t* pPooling, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t op, const dnnLayout_t srcLayout, const size_t kernelSize[],
+    const size_t kernelStride[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnPoolingCreateBackward<double>(
+    dnnPrimitive_t* pPooling, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t op, const dnnLayout_t srcLayout, const size_t kernelSize[],
+    const size_t kernelStride[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnPoolingCreateBackward_F64(pPooling, attributes, op, srcLayout,
+                                      kernelSize, kernelStride, inputOffset,
+                                      borderType);
+}
+template <>
+inline dnnError_t dnnPoolingCreateBackward<float>(
+    dnnPrimitive_t* pPooling, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t op, const dnnLayout_t srcLayout, const size_t kernelSize[],
+    const size_t kernelStride[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnPoolingCreateBackward_F32(pPooling, attributes, op, srcLayout,
+                                      kernelSize, kernelStride, inputOffset,
+                                      borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnPrimitiveGetAttributes(
+    dnnPrimitive_t primitive, dnnPrimitiveAttributes_t* attributes) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnPrimitiveGetAttributes<double>(
+    dnnPrimitive_t primitive, dnnPrimitiveAttributes_t* attributes) {
+  return dnnPrimitiveGetAttributes_F64(primitive, attributes);
+}
+template <>
+inline dnnError_t dnnPrimitiveGetAttributes<float>(
+    dnnPrimitive_t primitive, dnnPrimitiveAttributes_t* attributes) {
+  return dnnPrimitiveGetAttributes_F32(primitive, attributes);
+}
+
+template <typename DType>
+inline dnnError_t dnnLayoutDelete(dnnLayout_t layout) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <> inline dnnError_t dnnLayoutDelete<double>(dnnLayout_t layout) {
+  return dnnLayoutDelete_F64(layout);
+}
+template <> inline dnnError_t dnnLayoutDelete<float>(dnnLayout_t layout) {
+  return dnnLayoutDelete_F32(layout);
+}
+
+template <typename DType>
+inline dnnError_t dnnLRNCreateForward(dnnPrimitive_t* pLrn,
+                                      dnnPrimitiveAttributes_t attributes,
+                                      const dnnLayout_t dataLayout,
+                                      size_t kernel_size, DType alpha,
+                                      DType beta, DType k) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnLRNCreateForward<double>(
+    dnnPrimitive_t* pLrn, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, size_t kernel_size, double alpha, double beta,
+    double k) {
+  return dnnLRNCreateForward_F64(pLrn, attributes, dataLayout, kernel_size,
+                                 alpha, beta, k);
+}
+template <>
+inline dnnError_t dnnLRNCreateForward<float>(
+    dnnPrimitive_t* pLrn, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, size_t kernel_size, float alpha, float beta,
+    float k) {
+  return dnnLRNCreateForward_F32(pLrn, attributes, dataLayout, kernel_size,
+                                 alpha, beta, k);
+}
+
+template <typename DType>
+inline dnnError_t dnnPoolingCreateForward(
+    dnnPrimitive_t* pPooling, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t op, const dnnLayout_t srcLayout, const size_t kernelSize[],
+    const size_t kernelStride[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnPoolingCreateForward<float>(
+    dnnPrimitive_t* pPooling, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t op, const dnnLayout_t srcLayout, const size_t kernelSize[],
+    const size_t kernelStride[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnPoolingCreateForward_F32(pPooling, attributes, op, srcLayout,
+                                     kernelSize, kernelStride, inputOffset,
+                                     borderType);
+}
+template <>
+inline dnnError_t dnnPoolingCreateForward<double>(
+    dnnPrimitive_t* pPooling, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t op, const dnnLayout_t srcLayout, const size_t kernelSize[],
+    const size_t kernelStride[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnPoolingCreateForward_F64(pPooling, attributes, op, srcLayout,
+                                     kernelSize, kernelStride, inputOffset,
+                                     borderType);
+}
+
+template <typename DType>
+inline int dnnLayoutCompare(const dnnLayout_t l1, const dnnLayout_t l2) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline int dnnLayoutCompare<double>(const dnnLayout_t l1,
+                                    const dnnLayout_t l2) {
+  return dnnLayoutCompare_F64(l1, l2);
+}
+template <>
+inline int dnnLayoutCompare<float>(const dnnLayout_t l1, const dnnLayout_t l2) {
+  return dnnLayoutCompare_F32(l1, l2);
+}
+
+template <typename DType>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardData(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardData<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateBackwardData_F64(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardData<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateBackwardData_F32(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnReLUCreateBackward(dnnPrimitive_t* pRelu,
+                                        dnnPrimitiveAttributes_t attributes,
+                                        const dnnLayout_t diffLayout,
+                                        const dnnLayout_t dataLayout,
+                                        DType negativeSlope) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnReLUCreateBackward<float>(
+    dnnPrimitive_t* pRelu, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t diffLayout, const dnnLayout_t dataLayout,
+    float negativeSlope) {
+  return dnnReLUCreateBackward_F32(pRelu, attributes, diffLayout, dataLayout,
+                                   negativeSlope);
+}
+template <>
+inline dnnError_t dnnReLUCreateBackward<double>(
+    dnnPrimitive_t* pRelu, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t diffLayout, const dnnLayout_t dataLayout,
+    double negativeSlope) {
+  return dnnReLUCreateBackward_F64(pRelu, attributes, diffLayout, dataLayout,
+                                   negativeSlope);
+}
+
+template <typename DType>
+inline dnnError_t dnnConcatCreate(dnnPrimitive_t* pConcat,
+                                  dnnPrimitiveAttributes_t attributes,
+                                  const size_t nSrcTensors, dnnLayout_t* src) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConcatCreate<float>(dnnPrimitive_t* pConcat,
+                                         dnnPrimitiveAttributes_t attributes,
+                                         const size_t nSrcTensors,
+                                         dnnLayout_t* src) {
+  return dnnConcatCreate_F32(pConcat, attributes, nSrcTensors, src);
+}
+template <>
+inline dnnError_t dnnConcatCreate<double>(dnnPrimitive_t* pConcat,
+                                          dnnPrimitiveAttributes_t attributes,
+                                          const size_t nSrcTensors,
+                                          dnnLayout_t* src) {
+  return dnnConcatCreate_F64(pConcat, attributes, nSrcTensors, src);
+}
+
+template <typename DType>
+inline dnnError_t dnnAllocateBuffer(void** pPtr, dnnLayout_t layout) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnAllocateBuffer<double>(void** pPtr, dnnLayout_t layout) {
+  return dnnAllocateBuffer_F64(pPtr, layout);
+}
+template <>
+inline dnnError_t dnnAllocateBuffer<float>(void** pPtr, dnnLayout_t layout) {
+  return dnnAllocateBuffer_F32(pPtr, layout);
+}
+
+template <typename DType>
+inline dnnError_t dnnConvolutionCreateForwardBias(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConvolutionCreateForwardBias<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateForwardBias_F64(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnConvolutionCreateForwardBias<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateForwardBias_F32(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnInnerProductCreateBackwardFilter(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnInnerProductCreateBackwardFilter<double>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateBackwardFilter_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+template <>
+inline dnnError_t dnnInnerProductCreateBackwardFilter<float>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateBackwardFilter_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+template <typename DType>
+inline dnnError_t dnnSumCreate(dnnPrimitive_t* pSum,
+                               dnnPrimitiveAttributes_t attributes,
+                               const size_t nSummands, dnnLayout_t layout,
+                               DType* coefficients) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnSumCreate<double>(dnnPrimitive_t* pSum,
+                                       dnnPrimitiveAttributes_t attributes,
+                                       const size_t nSummands,
+                                       dnnLayout_t layout,
+                                       double* coefficients) {
+  return dnnSumCreate_F64(pSum, attributes, nSummands, layout, coefficients);
+}
+template <>
+inline dnnError_t dnnSumCreate<float>(dnnPrimitive_t* pSum,
+                                      dnnPrimitiveAttributes_t attributes,
+                                      const size_t nSummands,
+                                      dnnLayout_t layout, float* coefficients) {
+  return dnnSumCreate_F32(pSum, attributes, nSummands, layout, coefficients);
+}
+
+template <typename DType>
+inline dnnError_t dnnConversionExecute(dnnPrimitive_t conversion, void* from,
+                                       void* to) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConversionExecute<double>(dnnPrimitive_t conversion,
+                                               void* from, void* to) {
+  return dnnConversionExecute_F64(conversion, from, to);
+}
+template <>
+inline dnnError_t dnnConversionExecute<float>(dnnPrimitive_t conversion,
+                                              void* from, void* to) {
+  return dnnConversionExecute_F32(conversion, from, to);
+}
+
+template <typename DType>
+inline dnnError_t dnnGroupsConvolutionCreateForwardBias(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateForwardBias<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateForwardBias_F64(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateForwardBias<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateForwardBias_F32(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnGroupsConvolutionCreateForward(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateForward<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateForward_F32(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateForward<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateForward_F64(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnLayoutCreate(dnnLayout_t* pLayout, size_t dimension,
+                                  const size_t size[], const size_t strides[]) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnLayoutCreate<double>(dnnLayout_t* pLayout,
+                                          size_t dimension, const size_t size[],
+                                          const size_t strides[]) {
+  return dnnLayoutCreate_F64(pLayout, dimension, size, strides);
+}
+template <>
+inline dnnError_t dnnLayoutCreate<float>(dnnLayout_t* pLayout, size_t dimension,
+                                         const size_t size[],
+                                         const size_t strides[]) {
+  return dnnLayoutCreate_F32(pLayout, dimension, size, strides);
+}
+
+template <typename DType>
+inline dnnError_t dnnPrimitiveAttributesDestroy(
+    dnnPrimitiveAttributes_t attributes) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnPrimitiveAttributesDestroy<double>(
+    dnnPrimitiveAttributes_t attributes) {
+  return dnnPrimitiveAttributesDestroy_F64(attributes);
+}
+template <>
+inline dnnError_t dnnPrimitiveAttributesDestroy<float>(
+    dnnPrimitiveAttributes_t attributes) {
+  return dnnPrimitiveAttributesDestroy_F32(attributes);
+}
+
+template <typename DType>
+inline dnnError_t dnnScaleCreate(dnnPrimitive_t* pScale,
+                                 dnnPrimitiveAttributes_t attributes,
+                                 const dnnLayout_t dataLayout, DType alpha) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnScaleCreate<float>(dnnPrimitive_t* pScale,
+                                        dnnPrimitiveAttributes_t attributes,
+                                        const dnnLayout_t dataLayout,
+                                        float alpha) {
+  return dnnScaleCreate_F32(pScale, attributes, dataLayout, alpha);
+}
+template <>
+inline dnnError_t dnnScaleCreate<double>(dnnPrimitive_t* pScale,
+                                         dnnPrimitiveAttributes_t attributes,
+                                         const dnnLayout_t dataLayout,
+                                         double alpha) {
+  return dnnScaleCreate_F64(pScale, attributes, dataLayout, alpha);
+}
+
+template <typename DType>
+inline dnnError_t dnnExecute(dnnPrimitive_t primitive, void* resources[]) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnExecute<double>(dnnPrimitive_t primitive,
+                                     void* resources[]) {
+  return dnnExecute_F64(primitive, resources);
+}
+template <>
+inline dnnError_t dnnExecute<float>(dnnPrimitive_t primitive,
+                                    void* resources[]) {
+  return dnnExecute_F32(primitive, resources);
+}
+
+template <typename DType>
+inline dnnError_t dnnInnerProductCreateBackwardBias(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t dstSize[]) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnInnerProductCreateBackwardBias<float>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t dstSize[]) {
+  return dnnInnerProductCreateBackwardBias_F32(pInnerProduct, attributes,
+                                               dimensions, dstSize);
+}
+template <>
+inline dnnError_t dnnInnerProductCreateBackwardBias<double>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t dstSize[]) {
+  return dnnInnerProductCreateBackwardBias_F64(pInnerProduct, attributes,
+                                               dimensions, dstSize);
+}
+
+template <typename DType>
+inline dnnError_t dnnInnerProductCreateBackwardData(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnInnerProductCreateBackwardData<double>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateBackwardData_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+template <>
+inline dnnError_t dnnInnerProductCreateBackwardData<float>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateBackwardData_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+template <typename DType>
+inline dnnError_t dnnInnerProductCreateForwardBias(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnInnerProductCreateForwardBias<float>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateForwardBias_F32(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+template <>
+inline dnnError_t dnnInnerProductCreateForwardBias<double>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateForwardBias_F64(
+      pInnerProduct, attributes, dimensions, srcSize, outputChannels);
+}
+
+template <typename DType>
+inline dnnError_t dnnConvolutionCreateForward(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConvolutionCreateForward<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateForward_F32(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnConvolutionCreateForward<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateForward_F64(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnConvolutionCreateBackwardBias(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t dstSize[]) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConvolutionCreateBackwardBias<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t dstSize[]) {
+  return dnnConvolutionCreateBackwardBias_F32(pConvolution, attributes,
+                                              algorithm, dimension, dstSize);
+}
+template <>
+inline dnnError_t dnnConvolutionCreateBackwardBias<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t dstSize[]) {
+  return dnnConvolutionCreateBackwardBias_F64(pConvolution, attributes,
+                                              algorithm, dimension, dstSize);
+}
+
+template <typename DType>
+inline dnnError_t dnnPrimitiveAttributesCreate(
+    dnnPrimitiveAttributes_t* attributes) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnPrimitiveAttributesCreate<float>(
+    dnnPrimitiveAttributes_t* attributes) {
+  return dnnPrimitiveAttributesCreate_F32(attributes);
+}
+template <>
+inline dnnError_t dnnPrimitiveAttributesCreate<double>(
+    dnnPrimitiveAttributes_t* attributes) {
+  return dnnPrimitiveAttributesCreate_F64(attributes);
+}
+
+template <typename DType>
+inline dnnError_t dnnInnerProductCreateForward(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnInnerProductCreateForward<float>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateForward_F32(pInnerProduct, attributes, dimensions,
+                                          srcSize, outputChannels);
+}
+template <>
+inline dnnError_t dnnInnerProductCreateForward<double>(
+    dnnPrimitive_t* pInnerProduct, dnnPrimitiveAttributes_t attributes,
+    size_t dimensions, const size_t srcSize[], size_t outputChannels) {
+  return dnnInnerProductCreateForward_F64(pInnerProduct, attributes, dimensions,
+                                          srcSize, outputChannels);
+}
+
+template <typename DType>
+inline dnnError_t dnnBatchNormalizationCreateBackwardData(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, DType eps) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnBatchNormalizationCreateBackwardData<double>(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, double eps) {
+  return dnnBatchNormalizationCreateBackwardData_F64(
+      pBatchNormalization, attributes, dataLayout, eps);
+}
+template <>
+inline dnnError_t dnnBatchNormalizationCreateBackwardData<float>(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, float eps) {
+  return dnnBatchNormalizationCreateBackwardData_F32(
+      pBatchNormalization, attributes, dataLayout, eps);
+}
+
+template <typename DType> inline dnnError_t dnnReleaseBuffer(void* ptr) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <> inline dnnError_t dnnReleaseBuffer<double>(void* ptr) {
+  return dnnReleaseBuffer_F64(ptr);
+}
+template <> inline dnnError_t dnnReleaseBuffer<float>(void* ptr) {
+  return dnnReleaseBuffer_F32(ptr);
+}
+
+template <typename DType>
+inline dnnError_t dnnSplitCreate(dnnPrimitive_t* pSplit,
+                                 dnnPrimitiveAttributes_t attributes,
+                                 const size_t nDstTensors, dnnLayout_t layout,
+                                 size_t dstChannelSize[]) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnSplitCreate<float>(dnnPrimitive_t* pSplit,
+                                        dnnPrimitiveAttributes_t attributes,
+                                        const size_t nDstTensors,
+                                        dnnLayout_t layout,
+                                        size_t dstChannelSize[]) {
+  return dnnSplitCreate_F32(pSplit, attributes, nDstTensors, layout,
+                            dstChannelSize);
+}
+template <>
+inline dnnError_t dnnSplitCreate<double>(dnnPrimitive_t* pSplit,
+                                         dnnPrimitiveAttributes_t attributes,
+                                         const size_t nDstTensors,
+                                         dnnLayout_t layout,
+                                         size_t dstChannelSize[]) {
+  return dnnSplitCreate_F64(pSplit, attributes, nDstTensors, layout,
+                            dstChannelSize);
+}
+
+template <typename DType>
+inline dnnError_t dnnConvolutionCreateBackwardFilter(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConvolutionCreateBackwardFilter<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateBackwardFilter_F64(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnConvolutionCreateBackwardFilter<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateBackwardFilter_F32(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnLRNCreateBackward(dnnPrimitive_t* pLrn,
+                                       dnnPrimitiveAttributes_t attributes,
+                                       const dnnLayout_t diffLayout,
+                                       const dnnLayout_t dataLayout,
+                                       size_t kernel_size, DType alpha,
+                                       DType beta, DType k) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnLRNCreateBackward<double>(
+    dnnPrimitive_t* pLrn, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t diffLayout, const dnnLayout_t dataLayout,
+    size_t kernel_size, double alpha, double beta, double k) {
+  return dnnLRNCreateBackward_F64(pLrn, attributes, diffLayout, dataLayout,
+                                  kernel_size, alpha, beta, k);
+}
+template <>
+inline dnnError_t dnnLRNCreateBackward<float>(
+    dnnPrimitive_t* pLrn, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t diffLayout, const dnnLayout_t dataLayout,
+    size_t kernel_size, float alpha, float beta, float k) {
+  return dnnLRNCreateBackward_F32(pLrn, attributes, diffLayout, dataLayout,
+                                  kernel_size, alpha, beta, k);
+}
+
+template <typename DType>
+inline dnnError_t dnnBatchNormalizationCreateForward(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, DType eps) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnBatchNormalizationCreateForward<float>(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, float eps) {
+  return dnnBatchNormalizationCreateForward_F32(pBatchNormalization, attributes,
+                                                dataLayout, eps);
+}
+template <>
+inline dnnError_t dnnBatchNormalizationCreateForward<double>(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, double eps) {
+  return dnnBatchNormalizationCreateForward_F64(pBatchNormalization, attributes,
+                                                dataLayout, eps);
+}
+
+template <typename DType>
+inline size_t dnnLayoutGetMemorySize(const dnnLayout_t layout) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline size_t dnnLayoutGetMemorySize<float>(const dnnLayout_t layout) {
+  return dnnLayoutGetMemorySize_F32(layout);
+}
+template <>
+inline size_t dnnLayoutGetMemorySize<double>(const dnnLayout_t layout) {
+  return dnnLayoutGetMemorySize_F64(layout);
+}
+
+template <typename DType>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardBias(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t dstSize[]) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardBias<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t dstSize[]) {
+  return dnnGroupsConvolutionCreateBackwardBias_F32(
+      pConvolution, attributes, algorithm, groups, dimension, dstSize);
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardBias<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t dstSize[]) {
+  return dnnGroupsConvolutionCreateBackwardBias_F64(
+      pConvolution, attributes, algorithm, groups, dimension, dstSize);
+}
+
+template <typename DType>
+inline dnnError_t dnnExecuteAsync(dnnPrimitive_t primitive, void* resources[]) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnExecuteAsync<double>(dnnPrimitive_t primitive,
+                                          void* resources[]) {
+  return dnnExecuteAsync_F64(primitive, resources);
+}
+template <>
+inline dnnError_t dnnExecuteAsync<float>(dnnPrimitive_t primitive,
+                                         void* resources[]) {
+  return dnnExecuteAsync_F32(primitive, resources);
+}
+
+template <typename DType>
+inline dnnError_t dnnWaitFor(dnnPrimitive_t primitive) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <> inline dnnError_t dnnWaitFor<double>(dnnPrimitive_t primitive) {
+  return dnnWaitFor_F64(primitive);
+}
+template <> inline dnnError_t dnnWaitFor<float>(dnnPrimitive_t primitive) {
+  return dnnWaitFor_F32(primitive);
+}
+
+template <typename DType>
+inline dnnError_t dnnReLUCreateForward(dnnPrimitive_t* pRelu,
+                                       dnnPrimitiveAttributes_t attributes,
+                                       const dnnLayout_t dataLayout,
+                                       DType negativeSlope) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnReLUCreateForward<double>(
+    dnnPrimitive_t* pRelu, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, double negativeSlope) {
+  return dnnReLUCreateForward_F64(pRelu, attributes, dataLayout, negativeSlope);
+}
+template <>
+inline dnnError_t dnnReLUCreateForward<float>(
+    dnnPrimitive_t* pRelu, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, float negativeSlope) {
+  return dnnReLUCreateForward_F32(pRelu, attributes, dataLayout, negativeSlope);
+}
+
+template <typename DType>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardFilter(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardFilter<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateBackwardFilter_F64(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnGroupsConvolutionCreateBackwardFilter<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t groups, size_t dimension,
+    const size_t srcSize[], const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnGroupsConvolutionCreateBackwardFilter_F32(
+      pConvolution, attributes, algorithm, groups, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnDelete(dnnPrimitive_t primitive) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <> inline dnnError_t dnnDelete<float>(dnnPrimitive_t primitive) {
+  return dnnDelete_F32(primitive);
+}
+template <> inline dnnError_t dnnDelete<double>(dnnPrimitive_t primitive) {
+  return dnnDelete_F64(primitive);
+}
+
+template <typename DType>
+inline dnnError_t dnnConvolutionCreateBackwardData(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConvolutionCreateBackwardData<double>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateBackwardData_F64(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+template <>
+inline dnnError_t dnnConvolutionCreateBackwardData<float>(
+    dnnPrimitive_t* pConvolution, dnnPrimitiveAttributes_t attributes,
+    dnnAlgorithm_t algorithm, size_t dimension, const size_t srcSize[],
+    const size_t dstSize[], const size_t filterSize[],
+    const size_t convolutionStrides[], const int inputOffset[],
+    const dnnBorder_t borderType) {
+  return dnnConvolutionCreateBackwardData_F32(
+      pConvolution, attributes, algorithm, dimension, srcSize, dstSize,
+      filterSize, convolutionStrides, inputOffset, borderType);
+}
+
+template <typename DType>
+inline dnnError_t dnnBatchNormalizationCreateBackwardScaleShift(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, DType eps) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnBatchNormalizationCreateBackwardScaleShift<double>(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, double eps) {
+  return dnnBatchNormalizationCreateBackwardScaleShift_F64(
+      pBatchNormalization, attributes, dataLayout, eps);
+}
+template <>
+inline dnnError_t dnnBatchNormalizationCreateBackwardScaleShift<float>(
+    dnnPrimitive_t* pBatchNormalization, dnnPrimitiveAttributes_t attributes,
+    const dnnLayout_t dataLayout, float eps) {
+  return dnnBatchNormalizationCreateBackwardScaleShift_F32(
+      pBatchNormalization, attributes, dataLayout, eps);
+}
+
+template <typename DType>
+inline dnnError_t dnnLayoutCreateFromPrimitive(dnnLayout_t* pLayout,
+                                               const dnnPrimitive_t primitive,
+                                               dnnResourceType_t type) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnLayoutCreateFromPrimitive<double>(
+    dnnLayout_t* pLayout, const dnnPrimitive_t primitive,
+    dnnResourceType_t type) {
+  return dnnLayoutCreateFromPrimitive_F64(pLayout, primitive, type);
+}
+template <>
+inline dnnError_t dnnLayoutCreateFromPrimitive<float>(
+    dnnLayout_t* pLayout, const dnnPrimitive_t primitive,
+    dnnResourceType_t type) {
+  return dnnLayoutCreateFromPrimitive_F32(pLayout, primitive, type);
+}
+
+template <typename DType>
+inline dnnError_t dnnConversionCreate(dnnPrimitive_t* pConversion,
+                                      const dnnLayout_t from,
+                                      const dnnLayout_t to) {
+  LOG(FATAL) << "unsupported type in mkl dnn";
+  return E_UNIMPLEMENTED;
+}
+template <>
+inline dnnError_t dnnConversionCreate<double>(dnnPrimitive_t* pConversion,
+                                              const dnnLayout_t from,
+                                              const dnnLayout_t to) {
+  return dnnConversionCreate_F64(pConversion, from, to);
+}
+template <>
+inline dnnError_t dnnConversionCreate<float>(dnnPrimitive_t* pConversion,
+                                             const dnnLayout_t from,
+                                             const dnnLayout_t to) {
+  return dnnConversionCreate_F32(pConversion, from, to);
+}
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_CPPWRAPPER_H_

--- a/src/operator/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/mkldnn/mkldnn_fully_connected-inl.h
@@ -1,0 +1,204 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_fully_connected-inl.h
+ * \brief
+ * \author Ji Jiang
+*/
+
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_FULLY_CONNECTED_INL_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_FULLY_CONNECTED_INL_H_
+#include <algorithm>
+#include <vector>
+#include "../activation-inl.h"
+#include "mkldnn_memory-inl.h"
+namespace mxnet {
+namespace op {
+
+template <typename DType> class MKLDNNFullyConnectedOp : public Operator {
+ public:
+  explicit MKLDNNFullyConnectedOp(FullyConnectedParam p)
+      : init_mkldnn_(false),
+        fully_connected_Fwd_(NULL),
+        fully_connected_BwdData_(NULL),
+        fully_connected_BwdFilter_(NULL),
+        fully_connected_BwdBias_(NULL),
+        fwd_out_data_(new MKLData<DType>()),
+        fwd_in_data_(new MKLData<DType>()),
+        bwd_in_diff_(new MKLData<DType>()),
+        bwd_out_diff_(new MKLData<DType>()) {
+    param_ = p;
+  }
+
+  ~MKLDNNFullyConnectedOp() {
+    dnnDelete<DType>(fully_connected_Fwd_);
+    dnnDelete<DType>(fully_connected_BwdData_);
+    dnnDelete<DType>(fully_connected_BwdFilter_);
+    dnnDelete<DType>(fully_connected_BwdBias_);
+  }
+
+  virtual void Forward(const OpContext &ctx, const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+
+    if (req[fullc::kOut] == kNullOp) return;
+    CHECK_EQ(req[fullc::kOut], kWriteTo);
+    size_t expected = param_.no_bias ? 2 : 3;
+    CHECK_EQ(in_data.size(), expected);
+    CHECK_EQ(out_data.size(), 1);
+
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+
+    if (!init_mkldnn_) {
+      this->Init(s, in_data, out_data);
+    }
+
+    fully_connected_res_[dnnResourceSrc] =
+        reinterpret_cast<void *>(in_data[fullc::kData].dptr_);
+    fully_connected_res_[dnnResourceDst] =
+        reinterpret_cast<void *>(out_data[fullc::kOut].dptr_);
+    fully_connected_res_[dnnResourceFilter] =
+        reinterpret_cast<void *>(in_data[fullc::kWeight].dptr_);
+    if (!param_.no_bias) {
+      fully_connected_res_[dnnResourceBias] =
+          reinterpret_cast<void *>(in_data[fullc::kBias].dptr_);
+    }
+
+    CHECK_EQ(dnnExecute<DType>(fully_connected_Fwd_, fully_connected_res_),
+             E_SUCCESS);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+
+    CHECK_EQ(out_grad.size(), 1);
+    size_t expected = param_.no_bias ? 2 : 3;
+    CHECK(in_data.size() == expected && in_grad.size() == expected);
+    CHECK_EQ(req.size(), expected);
+
+    fully_connected_res_[dnnResourceSrc] =
+        reinterpret_cast<void *>(in_data[fullc::kData].dptr_);
+    fully_connected_res_[dnnResourceFilter] =
+        reinterpret_cast<void *>(in_data[fullc::kWeight].dptr_);
+
+    fully_connected_res_[dnnResourceDiffDst] =
+        reinterpret_cast<void *>(out_grad[fullc::kOut].dptr_);
+    fully_connected_res_[dnnResourceDiffSrc] =
+        reinterpret_cast<void *>(in_grad[fullc::kData].dptr_);
+    fully_connected_res_[dnnResourceDiffFilter] =
+        reinterpret_cast<void *>(in_grad[fullc::kWeight].dptr_);
+
+    if (!param_.no_bias) {
+      fully_connected_res_[dnnResourceDiffBias] =
+          reinterpret_cast<void *>(in_grad[fullc::kBias].dptr_);
+    }
+    CHECK_EQ(
+        dnnExecute<DType>(fully_connected_BwdFilter_, fully_connected_res_),
+        E_SUCCESS);
+    if (!param_.no_bias) {
+      CHECK_EQ(
+          dnnExecute<DType>(fully_connected_BwdBias_, fully_connected_res_),
+          E_SUCCESS);
+    }
+    CHECK_EQ(dnnExecute<DType>(fully_connected_BwdData_, fully_connected_res_),
+             E_SUCCESS);
+  }
+
+ private:
+  inline void Init(mshadow::Stream<cpu> *s, const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    size_t expected = param_.no_bias ? 2 : 3;
+    CHECK_EQ(in_data.size(), expected);
+    CHECK_EQ(out_data.size(), 1);
+    if (!init_mkldnn_) {
+      init_mkldnn_ = true;
+
+      const TShape &ishape = in_data[fullc::kData].shape_;
+      const TShape &oshape = out_data[fullc::kOut].shape_;
+
+      Tensor<cpu, 4, DType> data;
+      Tensor<cpu, 4, DType> out;
+
+      Shape4(in_data[fullc::kData].shape_[0], in_data[fullc::kData].shape_[1],
+             1, 1);
+
+      Shape<4> dshape =
+          Shape4(ishape[0], ishape.ProdShape(1, ishape.ndim()), 1, 1);
+      Shape<4> odshape =
+          Shape4(oshape[0], oshape.ProdShape(1, oshape.ndim()), 1, 1);
+
+      data = in_data[fullc::kData].get_with_shape<cpu, 4, DType>(dshape, s);
+      out = out_data[fullc::kOut].get_with_shape<cpu, 4, DType>(odshape, s);
+
+      size_t src_sizes[4];
+      size_t dst_sizes[2];
+
+      size_t dim = 4;
+
+      const size_t input_batch_size = data.size(0);
+      const size_t input_channels = data.size(1);
+      const size_t input_height = data.size(2);
+      const size_t input_width = data.size(3);
+
+      const size_t output_batch_size = out.size(0);
+      const size_t output_channels = out.size(1);
+
+      src_sizes[0] = input_width;
+      src_sizes[1] = input_height;
+      src_sizes[2] = input_channels;
+      src_sizes[3] = input_batch_size;
+
+      dst_sizes[0] = output_channels;
+      dst_sizes[1] = output_batch_size;
+
+      dnnPrimitiveAttributes_t attributes = NULL;
+      CHECK_EQ(dnnPrimitiveAttributesCreate<DType>(&attributes), E_SUCCESS);
+      if (!param_.no_bias) {
+        CHECK_EQ(dnnInnerProductCreateForwardBias<DType>(
+                     &fully_connected_Fwd_, attributes, dim, src_sizes,
+                     output_channels),
+                 E_SUCCESS);
+      } else {
+        CHECK_EQ(dnnInnerProductCreateForward<DType>(&fully_connected_Fwd_,
+                                                     attributes, dim, src_sizes,
+                                                     output_channels),
+                 E_SUCCESS);
+      }
+      CHECK_EQ(dnnInnerProductCreateBackwardData<DType>(
+                   &fully_connected_BwdData_, attributes, dim, src_sizes,
+                   output_channels),
+               E_SUCCESS);
+      CHECK_EQ(dnnInnerProductCreateBackwardFilter<DType>(
+                   &fully_connected_BwdFilter_, attributes, dim, src_sizes,
+                   output_channels),
+               E_SUCCESS);
+      if (!param_.no_bias) {
+        CHECK_EQ(dnnInnerProductCreateBackwardBias<DType>(
+                     &fully_connected_BwdBias_, attributes, 2, dst_sizes),
+                 E_SUCCESS);
+      }
+    }
+  }
+
+  bool init_mkldnn_;
+  dnnPrimitive_t fully_connected_Fwd_, fully_connected_BwdData_,
+      fully_connected_BwdFilter_, fully_connected_BwdBias_;
+  std::shared_ptr<MKLData<DType>> fwd_out_data_, fwd_in_data_;
+  std::shared_ptr<MKLData<DType>> bwd_in_diff_, bwd_out_diff_;
+  FullyConnectedParam param_;
+  void *fully_connected_res_[dnnResourceNumber];
+};  // class MKLDNNFullyConnectedOp
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_FULLY_CONNECTED_INL_H_

--- a/src/operator/mkldnn/mkldnn_lrn-inl.h
+++ b/src/operator/mkldnn/mkldnn_lrn-inl.h
@@ -1,0 +1,171 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_lrn-inl.h
+ * \brief
+ * \author Ji Jiang
+*/
+
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_LRN_INL_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_LRN_INL_H_
+#include <algorithm>
+#include <vector>
+#include "../lrn-inl.h"
+#include "mkldnn_memory-inl.h"
+
+namespace mxnet {
+namespace op {
+
+template <typename DType> class MKLDNNLocalResponseNormOp : public Operator {
+ public:
+  explicit MKLDNNLocalResponseNormOp(LRNParam p)
+      : init_mkldnn_(false),
+        lrnFwd_(NULL),
+        lrnBwd_(NULL),
+        fwd_out_data_(new MKLData<DType>()),
+        fwd_in_data_(new MKLData<DType>()),
+        bwd_in_diff_(new MKLData<DType>()),
+        bwd_out_diff_(new MKLData<DType>()) {
+    param_ = p;
+  }
+
+  ~MKLDNNLocalResponseNormOp() {
+    dnnDelete<DType>(lrnFwd_);
+    dnnDelete<DType>(lrnBwd_);
+    dnnReleaseBuffer<DType>(lrn_res_[dnnResourceWorkspace]);
+  }
+
+  virtual void Forward(const OpContext &ctx, const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+
+    // TODO(xxx): Test with gradient chceker
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 2);
+    // CHECK_EQ(req.size(), 2);
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+
+    if (!init_mkldnn_) {
+      this->Init(s, in_data, out_data);
+    }
+
+    lrn_res_[dnnResourceSrc] =
+        reinterpret_cast<void *>(in_data[lrn_enum::kData].dptr_);
+    lrn_res_[dnnResourceDst] =
+        reinterpret_cast<void *>(out_data[lrn_enum::kOut].dptr_);
+
+    CHECK_EQ(dnnExecute<DType>(lrnFwd_, lrn_res_), E_SUCCESS);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+
+    CHECK_EQ(out_grad.size(), 1);
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 2);
+
+    lrn_res_[dnnResourceDiffDst] =
+        reinterpret_cast<void *>(out_grad[lrn_enum::kOut].dptr_);
+    lrn_res_[dnnResourceDiffSrc] =
+        reinterpret_cast<void *>(in_grad[lrn_enum::kData].dptr_);
+
+    CHECK_EQ(dnnExecute<DType>(lrnBwd_, lrn_res_), E_SUCCESS);
+  }
+
+ private:
+  inline void Init(mshadow::Stream<cpu> *s, const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 2);
+    if (!init_mkldnn_) {
+      init_mkldnn_ = true;
+
+      Tensor<cpu, 4> data = in_data[lrn_enum::kData].get<cpu, 4, DType>(s);
+      Tensor<cpu, 4> out = out_data[lrn_enum::kOut].get<cpu, 4, DType>(s);
+
+      size_t src_sizes[4], src_strides[4];
+      size_t dst_sizes[4], dst_strides[4];
+      size_t dim = 4;
+
+      const size_t input_batch_size = data.size(0);
+      const size_t input_channels = data.size(1);
+      const size_t input_height = data.size(2);
+      const size_t input_width = data.size(3);
+
+      const size_t output_batch_size = out.size(0);
+      const size_t output_channels = out.size(1);
+      const size_t output_height = out.size(2);
+      const size_t output_width = out.size(3);
+
+      src_sizes[0] = input_width;
+      src_sizes[1] = input_height;
+      src_sizes[2] = input_channels;
+      src_sizes[3] = input_batch_size;
+      src_strides[0] = 1;
+      src_strides[1] = src_sizes[0];
+      src_strides[2] = src_sizes[0] * src_sizes[1];
+      src_strides[3] = src_sizes[0] * src_sizes[1] * src_sizes[2];
+      dst_sizes[0] = output_width;
+      dst_sizes[1] = output_height;
+      dst_sizes[2] = output_channels;
+      dst_sizes[3] = output_batch_size;
+      dst_strides[0] = 1;
+      dst_strides[1] = dst_sizes[0];
+      dst_strides[2] = dst_sizes[0] * dst_sizes[1];
+      dst_strides[3] = dst_sizes[0] * dst_sizes[1] * dst_sizes[2];
+
+      float alpha = param_.alpha;
+      float beta = param_.beta;
+      float knorm = param_.knorm;
+      size_t nsize = (size_t) param_.nsize;
+
+      fwd_in_data_->create_user_layout(dim, src_sizes, src_strides);
+      fwd_out_data_->create_user_layout(dim, dst_sizes, dst_strides);
+      bwd_in_diff_->create_user_layout(dim, src_sizes, src_strides);
+      bwd_out_diff_->create_user_layout(dim, dst_sizes, dst_strides);
+
+      dnnPrimitiveAttributes_t attributes = NULL;
+      CHECK_EQ(dnnPrimitiveAttributesCreate<DType>(&attributes), E_SUCCESS);
+
+      CHECK_EQ(dnnLRNCreateForward<DType>(
+                   &lrnFwd_, attributes, fwd_in_data_->layout_usr, nsize, alpha,
+                   beta, knorm),
+               E_SUCCESS);
+      CHECK_EQ(dnnLRNCreateBackward<DType>(
+                   &lrnBwd_, attributes, bwd_in_diff_->layout_usr,
+                   fwd_in_data_->layout_usr, nsize, alpha, beta, knorm),
+               E_SUCCESS);
+
+      CHECK_EQ(dnnLayoutCreateFromPrimitive<DType>(&workspace_, lrnFwd_,
+                                                   dnnResourceWorkspace),
+               E_SUCCESS);
+      CHECK_EQ(dnnAllocateBuffer<DType>(
+                   reinterpret_cast<void **>(&lrn_res_[dnnResourceWorkspace]), workspace_),
+               E_SUCCESS);
+    }
+  }
+
+  int count = 0;
+  int count1 = 0;
+  dnnLayout_t workspace_;
+  bool init_mkldnn_;
+  dnnPrimitive_t lrnFwd_, lrnBwd_;
+  std::shared_ptr<MKLData<DType>> fwd_out_data_, fwd_in_data_;
+  std::shared_ptr<MKLData<DType>> bwd_in_diff_, bwd_out_diff_;
+  LRNParam param_;
+  void *lrn_res_[dnnResourceNumber];
+};  // class MKLDNNLocalResponseNormOp
+}   // namespace op
+}   // namespace mxnet
+
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_LRN_INL_H_

--- a/src/operator/mkldnn/mkldnn_memory-inl.h
+++ b/src/operator/mkldnn/mkldnn_memory-inl.h
@@ -42,10 +42,12 @@ struct MKLMemoryDescriptorBase {
       status = dnnDelete<DType>(this->convert_from_int);
       CHECK_EQ(status, E_SUCCESS);
     }
+    this->convert_from_int = NULL;
     if (this->convert_to_int) {
       status = dnnDelete<DType>(this->convert_to_int);
       CHECK_EQ(status, E_SUCCESS);
     }
+    this->convert_to_int = NULL;
     if (this->layout_int && !dnnLayoutCompare<DType>(layout_usr, layout_int)) {
       CHECK(layout_usr);
       status =

--- a/src/operator/mkldnn/mkldnn_memory-inl.h
+++ b/src/operator/mkldnn/mkldnn_memory-inl.h
@@ -1,0 +1,164 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_memory-inl.h
+ * \brief
+ * \author Chen, Xiaoming
+*/
+
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_MEMORY_INL_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_MEMORY_INL_H_
+
+#include <dmlc/logging.h>
+#include "./mkldnn_cppwrapper.h"
+namespace mxnet {
+#if MXNET_USE_MKLDNN == 1
+template <typename DType>
+struct MKLMemoryDescriptorBase {
+  MKLMemoryDescriptorBase()
+      : layout_usr(NULL),
+        layout_int(NULL),
+        convert_to_int(NULL),
+        convert_from_int(NULL),
+        internal_ptr(NULL) {}
+  ~MKLMemoryDescriptorBase() {
+    dnnLayoutDelete<DType>(layout_usr);
+    dnnLayoutDelete<DType>(layout_int);
+    dnnReleaseBuffer<DType>(internal_ptr);
+    dnnDelete<DType>(convert_to_int);
+    dnnDelete<DType>(convert_from_int);
+  }
+
+  void allocate() {
+    if (internal_ptr == NULL) {
+      CHECK_EQ(dnnAllocateBuffer<DType>(reinterpret_cast<void**>(&internal_ptr),
+                                        layout_int),
+               E_SUCCESS);
+    }
+  }
+
+  void create_conversions() {
+    dnnError_t status;
+    if (this->convert_from_int) {
+      status = dnnDelete<DType>(this->convert_from_int);
+      CHECK_EQ(status, E_SUCCESS);
+    }
+    if (this->convert_to_int) {
+      status = dnnDelete<DType>(this->convert_to_int);
+      CHECK_EQ(status, E_SUCCESS);
+    }
+    if (this->layout_int && !dnnLayoutCompare<DType>(layout_usr, layout_int)) {
+      CHECK(layout_usr);
+      status =
+          dnnConversionCreate<DType>(&convert_to_int, layout_usr, layout_int);
+      CHECK_EQ(status, E_SUCCESS);
+      status =
+          dnnConversionCreate<DType>(&convert_from_int, layout_int, layout_usr);
+      CHECK_EQ(status, E_SUCCESS);
+    }
+  }
+
+  void create_internal_layout(const dnnPrimitive_t primitive,
+                              dnnResourceType_t type) {
+    dnnError_t status;
+    if (this->layout_int) {
+      status = dnnLayoutDelete<DType>(this->layout_int);
+      CHECK_EQ(status, E_SUCCESS);
+    }
+    status =
+        dnnLayoutCreateFromPrimitive<DType>(&this->layout_int, primitive, type);
+    CHECK_EQ(status, E_SUCCESS) << "internal layout create fail with status "
+                                << status;
+
+    if (this->layout_usr) this->create_conversions();
+  }
+
+  void create_user_layout(size_t dimension, const size_t size[],
+                          const size_t strides[]) {
+    dnnError_t status;
+    if (this->layout_usr) {
+      status = dnnLayoutDelete<DType>(this->layout_usr);
+      CHECK_EQ(status, E_SUCCESS);
+    }
+
+    status =
+        dnnLayoutCreate<DType>(&this->layout_usr, dimension, size, strides);
+    CHECK_EQ(status, E_SUCCESS) << "user layout create fail";
+
+    if (this->layout_int) this->create_conversions();
+  }
+
+  void create_layouts(const dnnPrimitive_t primitive, dnnResourceType_t type,
+                      size_t dimension, const size_t size[],
+                      const size_t strides[]) {
+    this->create_internal_layout(primitive, type);
+    this->create_user_layout(dimension, size, strides);
+  }
+
+  dnnLayout_t layout_usr;
+  dnnLayout_t layout_int;
+  dnnPrimitive_t convert_to_int;
+  dnnPrimitive_t convert_from_int;
+  DType* internal_ptr;
+};
+
+template <typename DType>
+struct MKLMemoryDescriptor : MKLMemoryDescriptorBase<DType> {
+  DType* get_converted_prv(DType* data, bool second_use) {
+    if (second_use) {
+      if (this->convert_to_int) {
+        return this->internal_ptr;
+      }
+      return data;
+    }
+
+    if (this->convert_to_int) {
+      dnnError_t status;
+      void* convert_resources[dnnResourceNumber];
+
+      this->allocate();
+      convert_resources[dnnResourceFrom] = reinterpret_cast<void*>(data);
+      convert_resources[dnnResourceTo] =
+          reinterpret_cast<void*>(this->internal_ptr);
+
+      status = dnnExecute<DType>(this->convert_to_int, convert_resources);
+      CHECK_EQ(status, E_SUCCESS) << "status " << status;
+
+      return this->internal_ptr;
+    }
+
+    return data;
+  }
+
+  DType* set_output_ptr(DType* data) {
+    if (this->convert_to_int) {
+      this->allocate();
+      return this->internal_ptr;
+    }
+    return data;
+  }
+
+  DType* get_output_ptr(DType* data) {
+    if (this->convert_from_int) {
+      dnnError_t status;
+      void* convert_resources[dnnResourceNumber];
+
+      convert_resources[dnnResourceFrom] =
+          reinterpret_cast<void*>(this->internal_ptr);
+      convert_resources[dnnResourceTo] = reinterpret_cast<void*>(data);
+
+      status = dnnExecute<DType>(this->convert_from_int, convert_resources);
+      CHECK_EQ(status, E_SUCCESS) << "status " << status;
+    }
+
+    return data;
+  }
+};
+
+template <typename DType> struct MKLData : MKLMemoryDescriptor<DType> {
+};
+
+template struct MKLData<float>;
+template struct MKLData<double>;
+#endif
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_MEMORY_INL_H_

--- a/src/operator/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/mkldnn/mkldnn_pooling-inl.h
@@ -37,7 +37,7 @@ bool UseMKLDNNPooling(PoolingParam param, std::vector<TShape> *in_shape,
         1 + static_cast<int>(ceil(static_cast<float>(
                 input_width + 2 * param.pad[1] -
                 param.kernel[1]) / param.stride[1]));
-    if ((full_model_output_height == output_height) || (full_model_output_width == output_width)) {
+    if ((full_model_output_height == output_height) && (full_model_output_width == output_width)) {
       return true;
     } else {
       return false;

--- a/src/operator/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/mkldnn/mkldnn_pooling-inl.h
@@ -126,6 +126,7 @@ class MKLDNNPoolingOp : public Operator {
           reinterpret_cast<void *>(bwd_out_diff_->get_converted_prv(outgrad.dptr_, false));
       pooling_res_[dnnResourceDiffSrc] =
           reinterpret_cast<void *>(bwd_in_diff_->get_converted_prv(ingrad.dptr_, false));
+      // sngle-threaded memset will hurt performance
       memset(pooling_res_[dnnResourceDiffSrc], 0,
              sizeof(DType) * ingrad.shape_.Size());
       CHECK_EQ(dnnExecute<DType>(poolingBwd_, pooling_res_), E_SUCCESS);
@@ -180,12 +181,12 @@ class MKLDNNPoolingOp : public Operator {
         dst_strides[1] = dst_sizes[0];
         dst_strides[2] = dst_sizes[0] * dst_sizes[1];
         dst_strides[3] = dst_sizes[0] * dst_sizes[1] * dst_sizes[2];
-        kernel_size[0] = this->param_.kernel[0];
-        kernel_size[1] = this->param_.kernel[1];
-        kernel_stride[0] = this->param_.stride[0];
-        kernel_stride[1] = this->param_.stride[1];
-        src_offset[0] = -this->param_.pad[0];
-        src_offset[1] = -this->param_.pad[1];
+        kernel_size[0] = this->param_.kernel[1];
+        kernel_size[1] = this->param_.kernel[0];
+        kernel_stride[0] = this->param_.stride[1];
+        kernel_stride[1] = this->param_.stride[0];
+        src_offset[0] = -this->param_.pad[1];
+        src_offset[1] = -this->param_.pad[0];
 
         fwd_in_data_->create_user_layout(dim, src_sizes, src_strides);
         fwd_out_data_->create_user_layout(dim, dst_sizes, dst_strides);

--- a/src/operator/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/mkldnn/mkldnn_pooling-inl.h
@@ -1,0 +1,229 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file mkldnn_pooling-inl.h
+ * \brief
+ * \author yandai
+*/
+
+#ifndef MXNET_OPERATOR_MKLDNN_MKLDNN_POOLING_INL_H_
+#define MXNET_OPERATOR_MKLDNN_MKLDNN_POOLING_INL_H_
+#include <vector>
+#include <algorithm>
+#include "../pooling-inl.h"
+#include "mkldnn_memory-inl.h"
+
+namespace mxnet {
+namespace op {
+
+bool UseMKLDNNPooling(PoolingParam param, std::vector<TShape> *in_shape,
+                      std::vector<TShape> *out_shape) {
+  if (param.kernel.ndim() != 2) {
+    return false;
+  }
+  if (param.pooling_convention == pool_enum::kFull) {
+    return true;
+  } else {
+    TShape input_shape = (*in_shape)[pool_enum::kData];
+    TShape output_shape = (*out_shape)[pool_enum::kOut];
+    const size_t input_height = input_shape[2];
+    const size_t input_width = input_shape[3];
+    const size_t output_height = output_shape[2];
+    const size_t output_width = output_shape[3];
+    size_t full_model_output_height =
+        1 + static_cast<int>(ceil(static_cast<float>(
+                input_height + 2 * param.pad[0] -
+                param.kernel[0]) / param.stride[0]));
+    size_t full_model_output_width =
+        1 + static_cast<int>(ceil(static_cast<float>(
+                input_width + 2 * param.pad[1] -
+                param.kernel[1]) / param.stride[1]));
+    if ((full_model_output_height == output_height) || (full_model_output_width == output_width)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+template <typename DType>
+class MKLDNNPoolingOp : public Operator {
+ public:
+  explicit MKLDNNPoolingOp(PoolingParam p)
+      : param_(p),
+        init_mkldnn_(false),
+        poolingFwd_(NULL),
+        poolingBwd_(NULL),
+        fwd_out_data_(new MKLData<DType>()),
+        fwd_in_data_(new MKLData<DType>()),
+        bwd_in_diff_(new MKLData<DType>()),
+        bwd_out_diff_(new MKLData<DType>()) {
+    switch (this->param_.pool_type) {
+      case pool_enum::kMaxPooling:
+        mode_ = dnnAlgorithmPoolingMax;
+        break;
+      case pool_enum::kAvgPooling:
+        mode_ = dnnAlgorithmPoolingAvg;
+        break;
+      default:
+        LOG(FATAL) << "Not implmented";
+    }
+  }
+
+  ~MKLDNNPoolingOp() {
+    dnnDelete<DType>(poolingFwd_);
+    dnnDelete<DType>(poolingBwd_);
+    dnnReleaseBuffer<DType>(pooling_res_[dnnResourceWorkspace]);
+  }
+
+  virtual void Forward(const OpContext &ctx, const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 1);
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+    if (this->param_.kernel.ndim() == 2) {
+      // 2d pool
+      if (!init_mkldnn_) {
+        this->Init(s, in_data, out_data);
+      }
+      Tensor<cpu, 4, DType> data =
+          in_data[pool_enum::kData].get<cpu, 4, DType>(s);
+      Tensor<cpu, 4, DType> out =
+          out_data[pool_enum::kOut].get<cpu, 4, DType>(s);
+      pooling_res_[dnnResourceSrc] =
+          reinterpret_cast<void *>(fwd_in_data_->get_converted_prv(data.dptr_, false));
+      pooling_res_[dnnResourceDst] =
+          reinterpret_cast<void *>(fwd_out_data_->get_converted_prv(out.dptr_, false));
+      CHECK_EQ(dnnExecute<DType>(poolingFwd_, pooling_res_), E_SUCCESS);
+      fwd_out_data_->get_output_ptr(data.dptr_);
+    } else {
+      LOG(FATAL) << "Only support 2D pooling";
+    }
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+    if (this->param_.kernel.ndim() == 2) {
+      if (!init_mkldnn_) {
+        this->Init(s, in_data, out_data);
+      }
+      Tensor<cpu, 4, DType> ingrad =
+          in_grad[pool_enum::kData].get<cpu, 4, DType>(s);
+      Tensor<cpu, 4, DType> outgrad =
+          out_grad[pool_enum::kOut].get<cpu, 4, DType>(s);
+      pooling_res_[dnnResourceDiffDst] =
+          reinterpret_cast<void *>(bwd_out_diff_->get_converted_prv(outgrad.dptr_, false));
+      pooling_res_[dnnResourceDiffSrc] =
+          reinterpret_cast<void *>(bwd_in_diff_->get_converted_prv(ingrad.dptr_, false));
+      memset(pooling_res_[dnnResourceDiffSrc], 0,
+             sizeof(DType) * ingrad.shape_.Size());
+      CHECK_EQ(dnnExecute<DType>(poolingBwd_, pooling_res_), E_SUCCESS);
+      bwd_in_diff_->get_output_ptr(ingrad.dptr_);
+    } else {
+      LOG(FATAL) << "Only support 2D pooling";
+    }
+  }
+
+ private:
+  inline void Init(mshadow::Stream<cpu> *s, const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 1);
+    if (!init_mkldnn_) {
+      init_mkldnn_ = true;
+      if (this->param_.kernel.ndim() == 2) {
+        Tensor<cpu, 4, DType> data =
+            in_data[pool_enum::kData].get<cpu, 4, DType>(s);
+        Tensor<cpu, 4, DType> out =
+            out_data[pool_enum::kOut].get<cpu, 4, DType>(s);
+
+        size_t src_sizes[4], src_strides[4];
+        size_t dst_sizes[4], dst_strides[4];
+        size_t kernel_size[2];
+        size_t kernel_stride[4];
+        int src_offset[2];
+        size_t dim = 4;
+
+        const size_t batch_size = data.size(0);
+        const size_t input_channels = data.size(1);
+        const size_t input_height = data.size(2);
+        const size_t input_width = data.size(3);
+        const size_t output_channels = input_channels;
+        const size_t output_height = out.size(2);
+        const size_t output_width = out.size(3);
+
+        src_sizes[0] = input_width;
+        src_sizes[1] = input_height;
+        src_sizes[2] = input_channels;
+        src_sizes[3] = batch_size;
+        src_strides[0] = 1;
+        src_strides[1] = src_sizes[0];
+        src_strides[2] = src_sizes[0] * src_sizes[1];
+        src_strides[3] = src_sizes[0] * src_sizes[1] * src_sizes[2];
+        dst_sizes[0] = output_width;
+        dst_sizes[1] = output_height;
+        dst_sizes[2] = output_channels;
+        dst_sizes[3] = batch_size;
+        dst_strides[0] = 1;
+        dst_strides[1] = dst_sizes[0];
+        dst_strides[2] = dst_sizes[0] * dst_sizes[1];
+        dst_strides[3] = dst_sizes[0] * dst_sizes[1] * dst_sizes[2];
+        kernel_size[0] = this->param_.kernel[0];
+        kernel_size[1] = this->param_.kernel[1];
+        kernel_stride[0] = this->param_.stride[0];
+        kernel_stride[1] = this->param_.stride[1];
+        src_offset[0] = -this->param_.pad[0];
+        src_offset[1] = -this->param_.pad[1];
+
+        fwd_in_data_->create_user_layout(dim, src_sizes, src_strides);
+        fwd_out_data_->create_user_layout(dim, dst_sizes, dst_strides);
+        bwd_in_diff_->create_user_layout(dim, src_sizes, src_strides);
+        bwd_out_diff_->create_user_layout(dim, dst_sizes, dst_strides);
+
+        CHECK_EQ(dnnPoolingCreateForward<DType>(
+                     &poolingFwd_, NULL, mode_, fwd_in_data_->layout_usr,
+                     kernel_size, kernel_stride, src_offset, dnnBorderZeros),
+                 E_SUCCESS);
+        CHECK_EQ(dnnPoolingCreateBackward<DType>(
+                     &poolingBwd_, NULL, mode_, fwd_in_data_->layout_usr,
+                     kernel_size, kernel_stride, src_offset, dnnBorderZeros),
+                 E_SUCCESS);
+        CHECK_EQ(dnnLayoutCreateFromPrimitive<DType>(&workspace_, poolingFwd_,
+                                                     dnnResourceWorkspace),
+                 E_SUCCESS);
+        CHECK_EQ(dnnAllocateBuffer<DType>(
+                     reinterpret_cast<void **>(&pooling_res_[dnnResourceWorkspace]), workspace_),
+                 E_SUCCESS);
+        fwd_in_data_->create_internal_layout(poolingFwd_, dnnResourceSrc);
+        fwd_out_data_->create_internal_layout(poolingFwd_, dnnResourceDst);
+        bwd_out_diff_->create_internal_layout(poolingBwd_, dnnResourceDiffDst);
+        bwd_in_diff_->create_internal_layout(poolingBwd_, dnnResourceDiffSrc);
+      }
+    }
+  }
+
+  PoolingParam param_;
+  dnnLayout_t workspace_;
+  bool init_mkldnn_;
+  dnnPrimitive_t poolingFwd_, poolingBwd_;
+  std::shared_ptr<MKLData<DType>> fwd_out_data_, fwd_in_data_;
+  std::shared_ptr<MKLData<DType>> bwd_in_diff_, bwd_out_diff_;
+  dnnAlgorithm_t mode_;
+  void *pooling_res_[dnnResourceNumber];
+};  // class MKLDNNPoolingOp
+}   // namespace op
+}   // namespace mxnet
+
+#endif  // MXNET_OPERATOR_MKLDNN_MKLDNN_POOLING_INL_H_

--- a/src/operator/mkldnn/mkldnn_pooling-inl.h
+++ b/src/operator/mkldnn/mkldnn_pooling-inl.h
@@ -126,7 +126,7 @@ class MKLDNNPoolingOp : public Operator {
           reinterpret_cast<void *>(bwd_out_diff_->get_converted_prv(outgrad.dptr_, false));
       pooling_res_[dnnResourceDiffSrc] =
           reinterpret_cast<void *>(bwd_in_diff_->get_converted_prv(ingrad.dptr_, false));
-      // sngle-threaded memset will hurt performance
+      // single-threaded memset will hurt performance
       memset(pooling_res_[dnnResourceDiffSrc], 0,
              sizeof(DType) * ingrad.shape_.Size());
       CHECK_EQ(dnnExecute<DType>(poolingBwd_, pooling_res_), E_SUCCESS);

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -15,6 +15,7 @@
 #include <istream>
 #include <ostream>
 #include <string>
+// #define PRINT_LAYER_TIME
 
 namespace mxnet {
 namespace op {

--- a/src/operator/pooling-inl.h
+++ b/src/operator/pooling-inl.h
@@ -25,6 +25,7 @@ namespace pool_enum {
 enum PoolingOpInputs {kData};
 enum PoolingOpOutputs {kOut};
 enum PoolingOpType {kMaxPooling, kAvgPooling, kSumPooling};
+enum PoolingOpPadConventionType {kValid, kFull};
 }  // namespace pool_enum
 
 struct PoolingParam : public dmlc::Parameter<PoolingParam> {
@@ -32,6 +33,7 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
   TShape stride;
   TShape pad;
   int pool_type;
+  int pooling_convention;
   bool global_pool;
   DMLC_DECLARE_PARAMETER(PoolingParam) {
     DMLC_DECLARE_FIELD(global_pool).set_default(false)
@@ -47,6 +49,13 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
     .add_enum("avg", pool_enum::kAvgPooling)
     .add_enum("sum", pool_enum::kSumPooling)
     .describe("Pooling type to be applied.");
+
+    DMLC_DECLARE_FIELD(pooling_convention).set_default(pool_enum::kValid)
+    .add_enum("full", pool_enum::kFull)
+    .add_enum("valid", pool_enum::kValid)
+    .describe("Pooling convention to be applied."
+              "kValid is default setting of Mxnet and rounds down the output pooling size."
+              "kFull is compatible with Caffe and rounds up the output pooling size.");
 
     int stride_shape[] = {1, 1};
     DMLC_DECLARE_FIELD(stride).set_default(TShape(stride_shape, stride_shape + 2))
@@ -162,13 +171,14 @@ class PoolingOp : public Operator {
     }
   }
 
- private:
+ protected:
   PoolingParam param_;
 };  // class PoolingOp
 
 template<typename xpu>
-Operator* CreateOp(PoolingParam param, int dtype);
-
+Operator* CreateOp(PoolingParam param, int dtype,
+                   std::vector<TShape> *in_shape,
+                   std::vector<TShape> *out_shape);
 
 #if DMLC_USE_CXX11
 class PoolingProp : public OperatorProperty {
@@ -199,8 +209,19 @@ class PoolingProp : public OperatorProperty {
         CHECK(param_.kernel[0] <= dshape[2] + 2 * param_.pad[0]
               && param_.kernel[1] <= dshape[3] + 2 * param_.pad[1])
             << "kernel size exceed input";
-        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
-        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
+        if (param_.pooling_convention == pool_enum::kValid) {
+          oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) /
+                              param_.stride[0];
+          oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) /
+                              param_.stride[1];
+        } else {
+          oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(
+                              dshape[2] + 2 * param_.pad[0] -
+                              param_.kernel[0]) / param_.stride[0]));
+          oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(
+                              dshape[3] + 2 * param_.pad[1] -
+                              param_.kernel[1]) / param_.stride[1]));
+        }
       }
       out_shape->clear();
       out_shape->push_back(oshape);
@@ -215,9 +236,24 @@ class PoolingProp : public OperatorProperty {
         oshape[3] = 1;
         oshape[4] = 1;
       } else {
-        oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) / param_.stride[0];
-        oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) / param_.stride[1];
-        oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) / param_.stride[2];
+        if (param_.pool_type == pool_enum::kValid) {
+          oshape[2] = 1 + (dshape[2] + 2 * param_.pad[0] - param_.kernel[0]) /
+                              param_.stride[0];
+          oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) /
+                              param_.stride[1];
+          oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) /
+                              param_.stride[2];
+        } else {
+          oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(
+                              dshape[2] + 2 * param_.pad[0] -
+                              param_.kernel[0]) / param_.stride[0]));
+          oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(
+                              dshape[3] + 2 * param_.pad[1] -
+                              param_.kernel[1]) / param_.stride[1]));
+          oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(
+                              dshape[4] + 2 * param_.pad[2] -
+                              param_.kernel[2]) / param_.stride[2]));
+        }
       }
 
       out_shape->clear();

--- a/src/operator/pooling-inl.h
+++ b/src/operator/pooling-inl.h
@@ -171,7 +171,7 @@ class PoolingOp : public Operator {
     }
   }
 
- protected:
+ private:
   PoolingParam param_;
 };  // class PoolingOp
 

--- a/src/operator/pooling.cu
+++ b/src/operator/pooling.cu
@@ -13,7 +13,9 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator *CreateOp<gpu>(PoolingParam param, int dtype) {
+Operator *CreateOp<gpu>(PoolingParam param, int dtype,
+                        std::vector<TShape> *in_shape,
+                        std::vector<TShape> *out_shape) {
   Operator *op = NULL;
 #if MXNET_USE_CUDNN == 1
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -98,6 +98,7 @@ def proto2script(proto_file):
             type_string = 'mx.symbol.Pooling'
             param = layer[i].pooling_param
             param_string = ''
+            param_string += "pooling_convention='full', "
             if param.global_pooling == True:
                 # there must be a param `kernel` in a pooling layer
                 param_string += "global_pool=True, kernel=(1,1)"


### PR DESCRIPTION
Hi, @piiswrong 

Mxnet's CPU performance is not as good as GPU's. 
please see #2986. @xmchen1987

This PR integrates MKLDNN into mxnet including all the major operations(conv, pool, lrn, bn and fc).
It turns out we can achieve 750+ fps for alexnet scoring and 280+ fps for Googlenet-v1 scoring with this patch in two-socket broadwell server and the backward also can benefit greatly from this patch. 

Please review the patches then give us feedbacks.
Thanks.
