### PR TITLE
[EXEC] Enable inplace sum optimization

### DIFF
--- a/src/executor/exec_pass.h
+++ b/src/executor/exec_pass.h
@@ -83,6 +83,24 @@ Graph AttachOpExecs(Graph g);
  */
 Graph AttachOpResources(Graph g);
 
+/*!
+ * \brief Discover chance of inplace addto operators.
+ *  i.e. z = plus(z, source_op), and encourage it to become z += source_op.
+ *
+ * This optimization is coupled with executor. This is helpful to reduce memory
+ * and computation for gradient aggregation of RNN.
+ *
+ * Require storage placement to be already finished.
+ *
+ * \param g input graph need to contain op_exec attribute.
+ *
+ * \return graph two new attributes, changes attribute "storage_id".
+ *  - "addto_entry", std::vector<bool> size=g.num_node_entries()
+ *    - addto_entry[eid] == 1, the corresponding op need to be performed using req=kAddTo
+ *  - "skip_plus_node", std::vector<int> if set to 1, current op's execution is skiped.
+ */
+Graph DetectInplaceAddTo(Graph g);
+
 }  // namespace exec
 }  // namespace mxnet
 

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -52,6 +52,8 @@ class GraphExecutor : public Executor {
     Context ctx;
     // The executor
     std::shared_ptr<OpExecutor> exec;
+    // skip the execution of this node
+    bool skip_exec_node{false};
     // cached operator handle
     Engine::OprHandle cached_opr{nullptr};
   };

--- a/src/executor/inplace_addto_detect_pass.cc
+++ b/src/executor/inplace_addto_detect_pass.cc
@@ -1,0 +1,63 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file inplace_addto_detect_pass.cc
+ * \brief Detect whether inplace addto operation is possible for certain op.
+ */
+#include <mxnet/base.h>
+#include <mxnet/operator.h>
+#include <mxnet/op_attr_types.h>
+#include <nnvm/graph_attr_types.h>
+
+#include "./exec_pass.h"
+
+namespace mxnet {
+namespace exec {
+
+Graph DetectInplaceAddTo(Graph g) {
+  nnvm::StorageVector storage_id =
+      g.MoveCopyAttr<nnvm::StorageVector>("storage_id");
+  std::vector<int> storage_inplace_index =
+      g.MoveCopyAttr<std::vector<int> >("storage_inplace_index");
+  static const Op* ewise_plus_op = Op::Get("_ewise_plus");
+  auto& idx = g.indexed_graph();
+  // reference cont.
+  std::vector<int> ref_count(idx.num_node_entries(), 0);
+  std::vector<int> addto_entry(idx.num_node_entries(), 0);
+  std::vector<int> skip_plus_node(idx.num_nodes(), 0);
+
+  for (auto& e : idx.outputs()) {
+    ++ref_count[idx.entry_id(e)];
+  }
+  for (uint32_t nid = 0; nid < idx.num_nodes(); ++nid) {
+    for (auto &e : idx[nid].inputs) {
+      ++ref_count[idx.entry_id(e)];
+    }
+  }
+
+  for (uint32_t nid = 0; nid < idx.num_nodes(); ++nid) {
+    const auto& inode = idx[nid];
+    if (inode.source->op() != ewise_plus_op) continue;
+    int sid = storage_id[idx.entry_id(inode.inputs[0])];
+    if (sid != storage_id[idx.entry_id(nid, 0)]) continue;
+    if (idx[inode.inputs[0].node_id].source->is_variable()) continue;
+    if (idx[inode.inputs[1].node_id].source->is_variable()) continue;
+    uint32_t eid_rhs  = idx.entry_id(inode.inputs[1]);
+    if (ref_count[eid_rhs] != 1) continue;
+    if (inode.inputs[0].node_id >= inode.inputs[1].node_id) continue;
+    CHECK_NE(storage_id[eid_rhs], sid);
+    storage_id[eid_rhs] = sid;
+    addto_entry[eid_rhs] = 1;
+    storage_inplace_index[eid_rhs] = -1;
+    skip_plus_node[nid] = 1;
+  }
+
+  g.attrs["storage_id"] = std::make_shared<nnvm::any>(std::move(storage_id));
+  g.attrs["storage_inplace_index"] = std::make_shared<nnvm::any>(
+      std::move(storage_inplace_index));
+  g.attrs["addto_entry"] = std::make_shared<nnvm::any>(std::move(addto_entry));
+  g.attrs["skip_plus_node"] = std::make_shared<nnvm::any>(std::move(skip_plus_node));
+  return g;
+}
+
+}  // namespace exec
+}  // namespace mxnet

--- a/src/operator/tensor/elemwise_binary_broadcast_op.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.cc
@@ -14,6 +14,10 @@ MXNET_OPERATOR_REGISTER_BINARY_BROADCAST(_plus)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, mshadow::op::plus>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_plus"});
 
+// specialized to elementwise plus, currently only used for gradient aggregation
+MXNET_OPERATOR_REGISTER_BINARY(_ewise_plus)
+.set_attr<FCompute>("FCompute<cpu>", BinaryCompute<cpu, mshadow::op::plus>);
+
 NNVM_REGISTER_OP(_backward_plus)
 .set_num_inputs(1)
 .set_num_outputs(2)

--- a/src/operator/tensor/elemwise_binary_broadcast_op.cu
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.cu
@@ -13,8 +13,12 @@ NNVM_REGISTER_OP(_plus)
 .set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, mshadow::op::plus>);
 
 NNVM_REGISTER_OP(_backward_plus)
-.set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastBackwardUseNone<gpu, mshadow_op::identity,
-                                                                mshadow_op::identity>);
+.set_attr<FCompute>("FCompute<gpu>",
+                    BinaryBroadcastBackwardUseNone<gpu,
+                    mshadow_op::identity, mshadow_op::identity>);
+
+NNVM_REGISTER_OP(_ewise_plus)
+.set_attr<FCompute>("FCompute<gpu>", BinaryCompute<gpu, mshadow::op::plus>);
 
 NNVM_REGISTER_OP(_minus)
 .set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, mshadow::op::minus>);

--- a/src/operator/tensor/elemwise_unary_op.cc
+++ b/src/operator/tensor/elemwise_unary_op.cc
@@ -8,10 +8,12 @@
 
 namespace mxnet {
 namespace op {
+
 // copy
 MXNET_OPERATOR_REGISTER_UNARY(_copy)
-.MXNET_DESCRIBE("Copy src to output")
-.set_attr<FCompute>("FCompute<cpu>", UnaryCompute<cpu, mshadow_op::identity>)
+.MXNET_DESCRIBE("Identity mapping, copy src to output")
+.add_alias("identity")
+.set_attr<FCompute>("FCompute<cpu>", IdentityCompute<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_copy"});
 
 // negative

--- a/src/operator/tensor/elemwise_unary_op.cu
+++ b/src/operator/tensor/elemwise_unary_op.cu
@@ -10,7 +10,7 @@ namespace mxnet {
 namespace op {
 // copy
 NNVM_REGISTER_OP(_copy)
-.set_attr<FCompute>("FCompute<gpu>", UnaryCompute<gpu, mshadow_op::identity>);
+.set_attr<FCompute>("FCompute<gpu>", IdentityCompute<gpu>);
 
 // negative
 NNVM_REGISTER_OP(negative)


### PR DESCRIPTION
@antinucleon @piiswrong

Also other fixes in this PR, the optimization will trigger when sum of gradients takes inputs larger than MXNET_EXEC_INPLACE_GRAD_SUM_CAP
-  identity function now do not compute during WriteInplace
- CUDNN convolution can take kAddTo correctly for both forward and backward.

This optimization requires ops involved to implement kAddTo requirement correctly. I find some ops are sloppy at this case. Currently it is an opt out strategy and assumes every op support kAddTo by default. I am wondering if it is safer to choose an opt in strategy. 

i.e. add an attribute to ask each operator declare if they support kAddTo correctly and the optimization only triggers for those ops that does