### PR TITLE
cuDNN RNN Cell parameter initialization

### DIFF
--- a/example/rnn-time-major/rnn_cell_demo.py
+++ b/example/rnn-time-major/rnn_cell_demo.py
@@ -83,28 +83,10 @@ if __name__ == '__main__':
         embed = mx.sym.Embedding(data=data, input_dim=len(vocab),
                                  output_dim=num_embed, name='embed')
 
-        # TODO(tofix)
-        # currently all the LSTM parameters are concatenated as
-        # a huge vector, and named '<name>_parameters'. By default
-        # mxnet initializer does not know how to initilize this
-        # guy because its name does not ends with _weight or _bias
-        # or anything familiar. Here we just use a temp workaround
-        # to create a variable and name it as LSTM_bias to get
-        # this demo running. Note by default bias is initialized
-        # as zeros, so this is not a good scheme. But calling it
-        # LSTM_weight is not good, as this is 1D vector, while
-        # the initialization scheme of a weight parameter needs
-        # at least two dimensions.
-        rnn_params = mx.sym.Variable('LSTM_bias')
-
         # RNN cell takes input of shape (time, batch, feature)
         rnn = mx.sym.RNN(data=embed, state_size=num_hidden,
                          num_layers=num_lstm_layer, mode='lstm',
-                         name='LSTM', 
-                         # The following params can be omitted
-                         # provided we do not need to apply the
-                         # workarounds mentioned above
-                         parameters=rnn_params)
+                         name='LSTM')
 
         # the RNN cell output is of shape (time, batch, dim)
         # if we need the states and cell states in the last time
@@ -134,7 +116,7 @@ if __name__ == '__main__':
     if len(buckets) == 1:
         mod = mx.mod.Module(*sym_gen(buckets[0]), context=contexts)
     else:
-        mod = mx.mod.BucketingModule(sym_gen, 
+        mod = mx.mod.BucketingModule(sym_gen,
                                      default_bucket_key=data_train.default_bucket_key,
                                      context=contexts)
 

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -90,9 +90,11 @@ class Initializer(object):
     def _init_beta(self, _, arr):
         arr[:] = 0.0
 
+    # pylint: disable=unused-argument
     def _init_cudnn_rnn_params(self, name, arr, state_size):
         scale = 1.0 / np.sqrt(state_size)
         random.uniform(-scale, scale, out=arr)
+    # pylint: enable=unused-argument
 
     def _init_weight(self, name, arr):
         """Abstruct method to Initialize weight"""

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -90,7 +90,7 @@ class Initializer(object):
     def _init_beta(self, _, arr):
         arr[:] = 0.0
 
-    def _init_cudnn_rnn_params(name, arr, state_size):
+    def _init_cudnn_rnn_params(self, name, arr, state_size):
         scale = 1.0 / np.sqrt(state_size)
         random.uniform(-scale, scale, out=arr)
 

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -51,7 +51,13 @@ class Initializer(object):
         elif name.endswith("moving_avg"):
             self._init_zero(name, arr)
         else:
-            self._init_default(name, arr)
+            ret = re.search(r'_RNN_params_H(\d+)', name)
+            if ret:
+                self._init_cudnn_rnn_params(name, arr,
+                                            state_size=int(ret.group(1)))
+            else:
+                self._init_default(name, arr)
+
     # pylint: disable=no-self-use, missing-docstring, invalid-name
     def _init_bilinear(self, _, arr):
         weight = np.zeros(np.prod(arr.shape), dtype='float32')
@@ -83,6 +89,10 @@ class Initializer(object):
 
     def _init_beta(self, _, arr):
         arr[:] = 0.0
+
+    def _init_cudnn_rnn_params(name, arr, state_size):
+        scale = 1.0 / np.sqrt(state_size)
+        random.uniform(-scale, scale, out=arr)
 
     def _init_weight(self, name, arr):
         """Abstruct method to Initialize weight"""

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -29,8 +29,8 @@ namespace rnn_enum {
 
 // A utility function to calculate input size
 inline int rnn_single_param_size(int inputSize,
-                                int hiddenSize,
-                                int mode) {
+                                 int hiddenSize,
+                                 int mode) {
   int size = hiddenSize * (hiddenSize + inputSize + 2);
   // Different RNN's have different num weights
   switch (mode) {
@@ -141,10 +141,13 @@ Operator* CreateOp(RNNParam param, int dtype);
 class RNNProp : public OperatorProperty {
  public:
   std::vector<std::string> ListArguments() const override {
+    // we encode state size in the RNN param name so that
+    // the initializer could know the correct scale
+    auto param_name = "RNN_params_H" + std::to_string(param_.state_size);
     if (param_.mode == rnn_enum::kLstm) {
-      return {"data", "parameters", "state", "state_cell"};
+      return {"data", param_name, "state", "state_cell"};
     } else {
-      return {"data", "parameters", "state"};
+      return {"data", param_name, "state"};
     }
   }
 


### PR DESCRIPTION
This is a workaround, as our initializer interface only have access to the parameter name. We currently encode the hidden state size in the name for cuDNN RNN cells in order to get a suitable init scale.
