### PR TITLE
fix char-lstm dataset URL

### DIFF
--- a/example/rnn/char-rnn.ipynb
+++ b/example/rnn/char-rnn.ipynb
@@ -145,9 +145,9 @@
    ],
    "source": [
     "import os\n",
-    "data_url = \"http://data.dmlc.ml/mxnet/data/lab_data.zip\"\n",
+    "data_url = \"http://data.dmlc.ml/mxnet/data/char_lstm.zip\"\n",
     "os.system(\"wget %s\" % data_url)\n",
-    "os.system(\"unzip -o lab_data.zip\")"
+    "os.system(\"unzip -o char_lstm.zip\")"
    ]
   },
   {


### PR DESCRIPTION
I found out that data_url for char-rnn demo was changed to "http://data.dmlc.ml/mxnet/data/char_lstm.zip". I updated the ipynb to the correct URL.