### PR TITLE
Updates setup instructions for mac to include pkg-config installation

### DIFF
--- a/docs/get_started/setup.md
+++ b/docs/get_started/setup.md
@@ -167,6 +167,7 @@ Followed by installation of dependencies:
 ```bash
 brew update
 brew install git
+brew install pkg-config
 brew tap homebrew/science
 brew info opencv
 brew install opencv


### PR DESCRIPTION
This PR updates setup instructions for mac. Current instructions did not work for me out of box. I had to install missing pkg-config.