### PR TITLE
doc changes: MKL readme edits, fixing 404s

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -112,3 +112,4 @@ List of Contributors
 * [Yan Li](https://github.com/Godricly)
 * [Yuance Li](https://github.com/liyuance)
 * [Sandeep Krishnamurthy] (https://github.com/sandeep-krishnamurthy)
+* [Andre Moeller] (https://github.com/andremoeller)

--- a/MKL_README.md
+++ b/MKL_README.md
@@ -1,29 +1,32 @@
 # MKL2017 PLUGIN
 
-MKL2017 is one INTEL released library to accelerate Deep Neural Network (DNN) applications on Intel architecture.
-This README shows user how to setup and install MKL2017 library with mxnet.
+MKL2017 is an INTEL released library to accelerate Deep Neural Network (DNN) applications on Intel architecture.
+This README shows the user how to setup and install MKL2017 library with mxnet.
 
+## Build/Install MXNet with MKL:
 
-## Build/Install Instructions:
-```
-Download MKL:
-
-```
-
-## Build/Install MxNet
   1. Enable USE_MKL2017=1 in make/config.mk
+
     1.1 USE_BLAS should be atlas by default
-    1.2 if need USE_BLAS to be mkl, please  Navigate here - https://registrationcenter.intel.com/en/forms/?productid=2558&licensetype=2 to do a full MKL installation
-    1.3 By default, MKL_2017_EXPRIEMENTAL=0. If setting MKL_2017_EXPRIEMENTAL=1, MKL buffer will be created and transferred between layers to achiever much higher performance. 
+
+    1.2 if you need USE_BLAS to be mkl, please navigate here to do a full MKL installation: https://registrationcenter.intel.com/en/forms/?productid=2558&licensetype=2
+
+    1.3 By default, MKL_2017_EXPRIEMENTAL=0. If setting MKL_2017_EXPRIEMENTAL=1, MKL buffer will be created and transferred between layers to achiever much higher performance.
+
   2. Run 'make -jX'
+
     2.1 Makefile will execute "prepare_mkl.sh" to download the mkl under root folder.e.g. <MXNET ROOTDIR> /mklml_lnx_<MKL VRSION>
-    2.2 if download failed because of proxy setting, please do it manually before make
+
+    2.2 if the download failed because of proxy setting, please download it manually before make
+
     2.2.1 wget https://github.com/dmlc/web-data/raw/master/mxnet/mklml-release/mklml_lnx_<MKL VERSION>.tgz
+
     2.2.2 tar zxvf mklml_lnx_<MKL VERSION>.tgz
 
   3. Navigate into the python directory
-  4. Run 'sudo python setup.py install'
-  5. Before excute python scipt, need to set LD_LIBRARY_PATH
-  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<MXNET ROOTDIR>/mklml_lnx_<MKL VERSION>/lib
-```
+  
+  4. Set LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<MXNET ROOTDIR>/mklml_lnx_<MKL_VERSION>/lib
+
+  5. Run 'sudo python setup.py install'
+
 

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -1,7 +1,7 @@
 <img src=https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo-m/mxnetR.png width=155/> Deep Learning for R
 ==========================
 [![Build Status](https://travis-ci.org/dmlc/mxnet.svg?branch=master)](https://travis-ci.org/dmlc/mxnet)
-[![Documentation Status](https://readthedocs.org/projects/mxnet/badge/?version=latest)](http://mxnet.readthedocs.org/en/latest/packages/r/index.html)
+[![Documentation Status](https://readthedocs.org/projects/mxnet/badge/?version=latest)](http://mxnet.readthedocs.io/en/latest/api/r/index.html)
 
 You have found MXNet R Package! The MXNet R packages brings flexible and efficient GPU
 computing and state-of-art deep learning to R.

--- a/docs/architecture/note_memory.md
+++ b/docs/architecture/note_memory.md
@@ -188,7 +188,7 @@ As we can see that if we want to parallelizing the computation, more care need t
 Stay correct, this is the very first principle we need to know. This means execute in a way to take the implicit dependency
 memory sharing into consideration. This can done by adding the implicit dependency edge to execution graph.
 Or even simpler, if the execution engine is mutate aware as described in the
-[dependency engine note](http://mxnet.readthedocs.org/en/latest/developer-guide/note_engine.html), push the operation
+[dependency engine note](http://mxnet.io/architecture/note_engine.html), push the operation
 in sequence and write to the same variable tag that represents the same memory region.
 
 Another way is always produce memory allocation plan that is safe, which means never allocate same memory to nodes that can

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -777,6 +777,5 @@ situation. But they are different on both semantic and performance.
 
 # Recommended Next Steps
 
-* [Analogy to other DL systems](http://mxnet.io/architecture/analogy.html)
 * [How to read MXNet code](http://mxnet.io/architecture/read_code.html)
 * [Develop and hack MXNet](http://mxnet.io/how_to/develop_and_hack.html)

--- a/docs/tutorials/r/charRnnModel.md
+++ b/docs/tutorials/r/charRnnModel.md
@@ -8,7 +8,7 @@ Data can be found at [here](https://github.com/dmlc/web-data/tree/master/mxnet/t
 Preface
 -------
 This tutorial is written in Rmarkdown.
-- You can directly view the hosted version of the tutorial from [MXNet R Document](http://mxnet.io/api/tutorials/charRnnModel.html)
+- You can directly view the hosted version of the tutorial from [MXNet R Document](http://mxnet.io/tutorials/r/charRnnModel.html)
 - You can find the download the Rmarkdown source from [here](https://github.com/dmlc/mxnet/blob/master/R-package/vignettes/CharRnnModel.Rmd)
 
 Load Data 

--- a/docs/zh/api/r/CharRnnModel.Rmd
+++ b/docs/zh/api/r/CharRnnModel.Rmd
@@ -8,7 +8,7 @@
 
 本教程由Rmd编辑完成。
 
-- 你可以直接访问主站版本的教程：[MXNet R Document](http://mxnet.io/api/r/CharRnnModel.html)
+- 你可以直接访问主站版本的教程：[MXNet R Document](http://mxnet.io/tutorials/r/charRnnModel.html)
 - 你也可以从[这里](https://github.com/dmlc/mxnet/blob/master/R-package/vignettes/CharRnnModel.Rmd) 下载到Rmarkdown源文件
 
 ## 加载数据

--- a/example/memcost/README.md
+++ b/example/memcost/README.md
@@ -1,7 +1,7 @@
 Memory Cost of Deep Nets under Different Allocations
 ====================================================
 This folder contains a script to show the memory cost of different allocation strategies,
-discussed in [Note on Memory Optimization](http://mxnet.readthedocs.org/en/latest/developer-guide/note_memory.html).
+discussed in [Note on Memory Optimization](http://mxnet.io/architecture/note_memory.html).
 
 We use inception-bn as an example, with batch size of 32.
 

--- a/python/README.md
+++ b/python/README.md
@@ -6,4 +6,4 @@ It allows you to mix the flavours of deep learning programs together to maximize
 
 Installation
 ------------
-To install, check [Build Instruction](http://mxnet.readthedocs.org/en/latest/build.html)
+To install, check [Build Instruction](http://mxnet.io/get_started/setup.html)

--- a/scala-package/README.md
+++ b/scala-package/README.md
@@ -45,7 +45,7 @@ Refer to the next section for how to build it from the very source.
 Build
 ------------
 
-Checkout the [Installation Guide](http://mxnet.readthedocs.org/en/latest/how_to/build.html) contains instructions to install mxnet.
+Checkout the [Installation Guide](http://mxnet.io/get_started/setup.html) contains instructions to install mxnet.
 Then you can compile the Scala Package by
 
 ```bash
@@ -74,7 +74,7 @@ java -Xmx4m -cp \
 ```
 
 If you've compiled with `USE_DIST_KVSTORE` enabled, the python tools in `mxnet/tracker` can be used to launch distributed training.
-The following command runs the above example using 2 worker nodes (and 2 server nodes) in local. Refer to [Distributed Training](http://mxnet.readthedocs.org/en/latest/distributed_training.html) for more details.
+The following command runs the above example using 2 worker nodes (and 2 server nodes) in local. Refer to [Distributed Training](http://mxnet.io/how_to/multi_devices.html) for more details.
 
 ```bash
 tracker/dmlc_local.py -n 2 -s 2 \

--- a/scala-package/spark/README.md
+++ b/scala-package/spark/README.md
@@ -11,7 +11,7 @@ The MXNet on Spark is still in *experimental stage*. Any suggestion or contribut
 Build
 ------------
 
-Checkout the [Installation Guide](http://mxnet.readthedocs.org/en/latest/how_to/build.html) contains instructions to install mxnet. Remember to enable the distributed training, i.e., set `USE_DIST_KVSTORE = 1`.
+Checkout the [Installation Guide](http://mxnet.io/get_started/setup.html) contains instructions to install mxnet. Remember to enable the distributed training, i.e., set `USE_DIST_KVSTORE = 1`.
 
 Compile the Scala Package by
 


### PR DESCRIPTION
Fixed some formatting issues with MKL_README.md and reordered two steps that were out of order.

Fixed some URLs that were redirecting to 404s. Caveat: I couldn't find the correct documentation page that corresponds to http://mxnet.io/architecture/analogy.html, so I just removed it completely.