### PR TITLE
Fix heading in intro page. Fix broken link. Bring Python main API refrence headings to top header under API

### DIFF
--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -58,11 +58,17 @@ src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/github_f
         <span id="dropdown-menu-position-anchor">
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">{{name}} <span class="caret"></span></a>
           <ul id="package-dropdown-menu" class="dropdown-menu">
-            {% for lang in ['Python', 'R', 'Julia', 'C++', 'Scala'] %}
-            <li><a href="{{url_root}}{{name.lower()|replace(" ", "_")}}/{{lang.lower()}}/index.html">
-                {{lang}}
-            </a></li>
-            {% endfor %}
+            <li><a class="main-nav-link" href="{{url_root}}api/python/index.html">Python</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/module.html">- Module</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/model.html">- Model</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/symbol.html">- Symbol</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/io.html">- I/O</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/ndarray.html">- NDArray</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/kvstore.html">- KVStore</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/r/index.html">R</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/julia/index.html">Julia</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/c++/index.html">C++</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/scala/index.html">Scala</a></li>
           </ul>
           {% endfor %}
         </span>

--- a/docs/get_started/index.md
+++ b/docs/get_started/index.md
@@ -37,7 +37,7 @@ Parallelizes both I/O and computation with an optimized C++ backend engine, and 
 
 &nbsp;
 
-#MXNet Open Source Community 
+# MXNet Open Source Community 
 
 **Broad Model Support** – Train and deploy the latest deep convolutional neural networks (CNNs) and long short-term memory (LSTMs) models 
 

--- a/docs/how_to/new_op.md
+++ b/docs/how_to/new_op.md
@@ -89,4 +89,4 @@ mlp = mx.symbol.Custom(data=fc3, name='softmax', op_type='softmax')
 The complete code for this example can be found at `examples/numpy-ops/custom_softmax.py`
 
 ## C++/MShadow(CUDA)
-Please refer to [Developer Guide - SimpleOp](../system/operator_util.md) and [Developer Guide - Operators](http://mxnet.io/architecture/overview.html#operators-in-mxnet) for detail.
+Please refer to [Developer Guide - SimpleOp](http://mxnet.io/architecture/overview.html#simpleop-the-unified-operator-api) and [Developer Guide - Operators](http://mxnet.io/architecture/overview.html#operators-in-mxnet) for detail.


### PR DESCRIPTION
* Fix corrupted heading in intro page
* Fix broken link in http://mxnet.io/how_to/new_op.html
* Brought all high level Python API options (Module, Model, Symbol ...) to high level heading under python. This helps users to easily access commonly used API references in one click. Without this changes, users first click on API/Python then choose topic of interest.