### PR TITLE
Docs: tutorials page reformatting TOC

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -4,56 +4,54 @@
 
 ### Computer Vision
 
-#### [Image Classification](http://mxnet.io/tutorials/computer_vision/image_classification.html) 
+- [Image Classification](http://mxnet.io/tutorials/computer_vision/image_classification.html) 
 *A simple example of classifying images using a convolutional neural network.*
-
-#### [Image Segmentation](http://mxnet.io/tutorials/computer_vision/segmentation.html)
+- [Image Segmentation](http://mxnet.io/tutorials/computer_vision/segmentation.html)
 *An example of segmenting various object out of an image using a convolutional neural network.*
-
-#### [Object Detection using Faster R-CNN](http://mxnet.io/tutorials/computer_vision/detection.html)
+- [Object Detection using Faster R-CNN](http://mxnet.io/tutorials/computer_vision/detection.html)
 *An example of detecting object bounding boxes in an image using a region proposal network.*
-
-#### [Neural Art: Adding Artistic Style to Images](http://mxnet.io/tutorials/computer_vision/neural_art.html)
+- [Neural Art: Adding Artistic Style to Images](http://mxnet.io/tutorials/computer_vision/neural_art.html)
 *An example of transferring styles of famous artists onto an image using a convolutional neural network.*
-
-#### [Large Scale Image Classification: Training With 14 Million Images on a Single Machine](http://mxnet.io/tutorials/computer_vision/imagenet_full.html)
+- [Large Scale Image Classification: Training With 14 Million Images on a Single Machine](http://mxnet.io/tutorials/computer_vision/imagenet_full.html)
 *An advanced example of training a deep convolutional network on the large ImageNet dataset efficiently.*
 
 ### Natural Language Processing
 
-#### [Recurrent Neural Networks](http://mxnet.io/tutorials/nlp/rnn.html)
-#### [Text Classification using Convolutional Neural Network](http://mxnet.io/tutorials/nlp/cnn.html)
-#### [NCE Loss](http://mxnet.io/tutorials/nlp/nce_loss.html)
+- [Recurrent Neural Networks](http://mxnet.io/tutorials/nlp/rnn.html)
+- [Text Classification using Convolutional Neural Network](http://mxnet.io/tutorials/nlp/cnn.html)
+- [NCE Loss](http://mxnet.io/tutorials/nlp/nce_loss.html) 
+*Using Noise Contrastive Estimation (NCE) \[[Mnih 2013](http://papers.nips.cc/paper/5165-learning-word-embeddings-efficiently-with-noise-contrastive-estimation.pdf)\] loss to scale efficiently when predicting against large vocabularies.*
 
 ### Speech Recognition
 
-#### [Speech LSTM](http://mxnet.io/tutorials/speech_recognition/speech_lstm.html)
-#### [Baidu Warp CTC](http://mxnet.io/tutorials/speech_recognition/baidu_warp_ctc.html)
+- [Speech LSTM](http://mxnet.io/tutorials/speech_recognition/speech_lstm.html)
+- [Baidu Warp CTC](http://mxnet.io/tutorials/speech_recognition/baidu_warp_ctc.html)
+*Connectionist Temporal Classification (CTC) \[[Graves, 2006](http://www.cs.toronto.edu/~graves/icml_2006.pdf)\] allows prediction against a sequence when the alignment to the input is not known beforehand.  Warp CTC provides an efficient GPU implementation of this technique.*
 
 ### Unsupervised Learning
 
-#### [Generative Adversarial Network](http://mxnet.io/tutorials/unsupervised_learning/gan.html)
-#### [Auto Encoders](http://mxnet.io/tutorials/unsupervised_learning/auto_encoders.html)
+- [Generative Adversarial Network](http://mxnet.io/tutorials/unsupervised_learning/gan.html)
+- [Auto Encoders](http://mxnet.io/tutorials/unsupervised_learning/auto_encoders.html)
 
 ### General Machine Learning
 
-#### [Recommendation Systems](http://mxnet.io/tutorials/general_ml/recommendation_systems.html)
+- [Recommendation Systems](http://mxnet.io/tutorials/general_ml/recommendation_systems.html)
 
 ## Language Tutorials 
 
 ### Python Tutorials
-* [NDArray](http://mxnet.io/tutorials/python/ndarray.html)
-* [Symbol](http://mxnet.io/tutorials/python/symbol.html)
-* [KVStore](http://mxnet.io/tutorials/python/kvstore.html)
+- [NDArray](http://mxnet.io/tutorials/python/ndarray.html)
+- [Symbol](http://mxnet.io/tutorials/python/symbol.html)
+- [KVStore](http://mxnet.io/tutorials/python/kvstore.html)
 
 ### R Tutorials
-* [NDArray](http://mxnet.io/tutorials/r/ndarray.html)
-* [Symbol](http://mxnet.io/tutorials/r/symbol.html)
-* [Write and use callback functions](http://mxnet.io/tutorials/r/CallbackFunctionTutorial.html)
-* [Neural Networks with MXNet in Five Minutes](http://mxnet.io/tutorials/r/fiveMinutesNeuralNetwork.html)
-* [Classify Real-World Images with Pre-trained Model](http://mxnet.io/tutorials/r/classifyRealImageWithPretrainedModel.html)
-* [Handwritten Digits Classification Competition](http://mxnet.io/tutorials/r/mnistCompetition.html)
-* [Character Language Model using RNN](http://mxnet.io/tutorials/r/charRnnModel.html)
+- [NDArray](http://mxnet.io/tutorials/r/ndarray.html)
+- [Symbol](http://mxnet.io/tutorials/r/symbol.html)
+- [Write and use callback functions](http://mxnet.io/tutorials/r/CallbackFunctionTutorial.html)
+- [Neural Networks with MXNet in Five Minutes](http://mxnet.io/tutorials/r/fiveMinutesNeuralNetwork.html)
+- [Classify Real-World Images with Pre-trained Model](http://mxnet.io/tutorials/r/classifyRealImageWithPretrainedModel.html)
+- [Handwritten Digits Classification Competition](http://mxnet.io/tutorials/r/mnistCompetition.html)
+- [Character Language Model using RNN](http://mxnet.io/tutorials/r/charRnnModel.html)
 
 ## Other Resources
 - Collection of MXNet Tutorials for NVidia GTC 2016. [MXNet GTC 15 Tutorials](https://github.com/dmlc/mxnet-gtc-tutorial)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -20,7 +20,7 @@
 - [Recurrent Neural Networks](http://mxnet.io/tutorials/nlp/rnn.html)
 - [Text Classification using Convolutional Neural Network](http://mxnet.io/tutorials/nlp/cnn.html)
 - [NCE Loss](http://mxnet.io/tutorials/nlp/nce_loss.html) 
-*Using Noise Contrastive Estimation (NCE) \[[Mnih 2013](http://papers.nips.cc/paper/5165-learning-word-embeddings-efficiently-with-noise-contrastive-estimation.pdf)\] loss to scale efficiently when predicting against large vocabularies.*
+*Using Noise Contrastive Estimation (NCE) loss \[[Mnih 2013](http://papers.nips.cc/paper/5165-learning-word-embeddings-efficiently-with-noise-contrastive-estimation.pdf)\] to scale efficiently when predicting against large vocabularies.*
 
 ### Speech Recognition
 


### PR DESCRIPTION
Changing the CV examples to not be headers so they don't pollute the table of contents.

Also adding a couple explanations and academic citations.