### PR TITLE
Improve Python API reference

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -79,6 +79,7 @@ def check_call(ret):
 if sys.version_info[0] < 3:
     def c_str(string):
         """Create ctypes char * from a python string
+
         Parameters
         ----------
         string : string type
@@ -93,6 +94,7 @@ if sys.version_info[0] < 3:
 else:
     def c_str(string):
         """Create ctypes char * from a python string
+
         Parameters
         ----------
         string : string type

--- a/python/mxnet/executor_manager.py
+++ b/python/mxnet/executor_manager.py
@@ -14,6 +14,7 @@ from .io import DataDesc
 
 def _split_input_slice(batch_size, work_load_list):
     """Get input slice from the input shape.
+
     Parameters
     ----------
     batch_size : int
@@ -21,10 +22,12 @@ def _split_input_slice(batch_size, work_load_list):
     work_load_list : list of float or int, optional
         The list of work load for different devices,
         in the same order as ctx
+
     Returns
     -------
     slices : list of slice
         The split slices to get a specific slice.
+
     Raises
     ------
     ValueError
@@ -50,6 +53,7 @@ def _check_arguments(symbol):
     """Check the argument names of symbol.
     This function checks the duplication of arguments in Symbol.
     The check is done for feedforward net for now.
+
     Parameters
     ----------
     symbol : Symbol
@@ -271,6 +275,7 @@ class DataParallelExecutorGroup(object):
 
 class DataParallelExecutorManager(object):
     """ Helper class to manage multiple executors for data parallelism.
+
     Parameters
     ----------
     symbol : Symbol
@@ -335,6 +340,7 @@ class DataParallelExecutorManager(object):
 
     def set_params(self, arg_params, aux_params):
         """ set parameter and aux values
+
         Parameters
         ----------
         arg_params : list of NDArray
@@ -348,12 +354,14 @@ class DataParallelExecutorManager(object):
 
     def copy_to(self, arg_params, aux_params):
         """ Copy data from each executor to `arg_params` and `aux_params`
+
         Parameters
         ----------
         arg_params : list of NDArray
             target parameter arrays
         aux_params : list of NDArray
             target aux arrays
+
         Notes
         -----
         - This function will inplace update the NDArrays in arg_params and aux_params.

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -401,6 +401,7 @@ def _init_data(data, allow_empty, default_name):
 
 class NDArrayIter(DataIter):
     """NDArrayIter object in mxnet. Taking NDArray or numpy array to get dataiter.
+
     Parameters
     ----------
     data: NDArray or numpy.ndarray, a list of them, or a dict of string to them.
@@ -413,6 +414,7 @@ class NDArrayIter(DataIter):
         Whether to shuffle the data
     last_batch_handle: 'pad', 'discard' or 'roll_over'
         How to handle the last batch
+
     Note
     ----
     This iterator will pad, discard or roll over the last batch if
@@ -517,6 +519,7 @@ class NDArrayIter(DataIter):
 
 class MXDataIter(DataIter):
     """DataIter built in MXNet. List all the needed functions here.
+
     Parameters
     ----------
     handle : DataIterHandle
@@ -668,10 +671,12 @@ def _make_io_iterator(handle):
     def creator(*args, **kwargs):
         """Create an iterator.
         The parameters listed below can be passed in as keyword arguments.
+
         Parameters
         ----------
         name : string, required.
             Name of the resulting data iterator.
+
         Returns
         -------
         dataiter: Dataiter

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -124,6 +124,7 @@ def _train_multi_device(symbol, ctx, arg_names, param_names, aux_names,
                         eval_batch_end_callback=None, sym_gen=None):
     """Internal training function on multiple devices.
     This function will also work for single device as well.
+
     Parameters
     ----------
     symbol : Symbol
@@ -582,6 +583,7 @@ class FeedForward(BASE_ESTIMATOR):
 
     def predict(self, X, num_batch=None, return_data=False, reset=True):
         """Run the prediction, always only use one device.
+
         Parameters
         ----------
         X : mxnet.DataIter
@@ -650,6 +652,7 @@ class FeedForward(BASE_ESTIMATOR):
 
     def score(self, X, eval_metric='acc', num_batch=None, batch_end_callback=None, reset=True):
         """Run the model on X and calculate the score with eval_metric
+
         Parameters
         ----------
         X : mxnet.DataIter

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -682,6 +682,7 @@ class RMSProp(Optimizer):
 
     def create_state(self, index, weight):
         """Create additional optimizer state: mean, variance
+
         Parameters
         ----------
         weight : NDArray
@@ -694,6 +695,7 @@ class RMSProp(Optimizer):
 
     def update(self, index, weight, grad, state):
         """Update the parameters.
+
         Parameters
         ----------
         index : int


### PR DESCRIPTION
WHatever system renders the python class docstrings into HTML is failing in some cases because there isn't a blank line between the class description and the line that says "Parameters\n----------".  The result is e.g. http://mxnet.io/api/python/io.html#mxnet.io.NDArrayIter where the description writes out the list of parameters in paragraph form like "Taking NDArray or numpy array to get dataiter. :param data: NDArrayIter supports single or".  

This change just adds blank lines to a bunch of docstrings, and should fix all these issues.