### PR TITLE
Fixing bug in NDArrayIter.provide_data

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -462,7 +462,7 @@ class NDArrayIter(DataIter):
         """The name and shape of data provided by this iterator"""
         return [
             DataDesc(k, tuple([self.batch_size] + list(v.shape[1:])), v.dtype)
-            for k, v in self.label
+            for k, v in self.data
         ]
 
     @property


### PR DESCRIPTION
One-word bug fix. The NDArrayIter class which iterates over data loaded in memory was returning a descriptor of the "label" set when asked for a description of the "data" set. 
