### PR TITLE
Adding link to R reference manual

### DIFF
--- a/docs/api/r/index.md
+++ b/docs/api/r/index.md
@@ -11,4 +11,6 @@ We are working on MXNet for R API interface documentation. In the mean time you 
 
 Resources
 =========
-* [MXNet for R Tutorials](http://mxnet.io/tutorials/index.html#R-Tutorials)
+* [MXNet for R Tutorials](http://mxnet.io/tutorials/index.html#r-tutorials)
+* [MXNet R Reference Manual](http://mxnet.io/api/r/mxnet-r-reference-manual.pdf)
+

--- a/docs/sphinx_util.py
+++ b/docs/sphinx_util.py
@@ -16,6 +16,14 @@ def run_build_mxnet(folder):
     except OSError as e:
         sys.stderr.write("build execution failed: %s" % e)
 
+def build_r_docs(root_path):
+    r_root = os.path.join(root_path, 'R-package')
+    pdf_path = os.path.join(root_path, 'docs', 'api', 'r', 'mxnet-r-reference-manual.pdf')
+    subprocess.call('cd ' + r_root +'; R CMD Rd2pdf . -o ' + pdf_path, shell = True)
+    dest_path = os.path.join(root_path, 'docs', '_build', 'html', 'api', 'r')
+    subprocess.call('mkdir -p ' + dest_path, shell = True)
+    subprocess.call('mv ' + pdf_path + ' ' + dest_path, shell = True)
+
 if not os.path.exists('../recommonmark'):
     subprocess.call('cd ..; rm -rf recommonmark;' +
                     'git clone https://github.com/tqchen/recommonmark', shell = True)
@@ -27,6 +35,8 @@ subprocess.call('./build-notebooks.sh')
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 root_path = os.path.join(curr_path, '..')
 run_build_mxnet(root_path)
+
+build_r_docs(root_path)
 
 sys.path.insert(0, os.path.abspath('../recommonmark/'))
 

--- a/docs/sphinx_util.py
+++ b/docs/sphinx_util.py
@@ -19,7 +19,7 @@ def run_build_mxnet(folder):
 def build_r_docs(root_path):
     r_root = os.path.join(root_path, 'R-package')
     pdf_path = os.path.join(root_path, 'docs', 'api', 'r', 'mxnet-r-reference-manual.pdf')
-    subprocess.call('cd ' + r_root +'; R CMD Rd2pdf . -o ' + pdf_path, shell = True)
+    subprocess.call('cd ' + r_root +'; R CMD Rd2pdf . --no-preview -o ' + pdf_path, shell = True)
     dest_path = os.path.join(root_path, 'docs', '_build', 'html', 'api', 'r')
     subprocess.call('mkdir -p ' + dest_path, shell = True)
     subprocess.call('mv ' + pdf_path + ' ' + dest_path, shell = True)


### PR DESCRIPTION
Builds the PDF from mxnet/R-package, puts it in api/r, links to it from api/r/index. I checked that I can get to the pdf from http://localhost:8008/api/r/mxnet-r-...pdf

Dependencies needed on build server are R and LaTeX. If you're using apt you can apt-get install r-base, no other R packages are required. And also a LaTeX distribution is required.

I didn't change the Dockerfile in mxnet/docs since that would require installing LaTeX which would greatly increase the image size (~3 GB for basically no benefit). 

(Also, fixed the r tutorials link to http://mxnet.io/tutorials/index.html#r-tutorials)