### PR TITLE
fixing links

### DIFF
--- a/docs/api/python/kvstore.md
+++ b/docs/api/python/kvstore.md
@@ -3,7 +3,6 @@ KVStore API
 
 * [Basic Push and Pull](#basic-push-and-pull)
 * [Interface for list key-value pairs](#interface-for-list-key-value-pairs)
-* [Multiple machines]() TODO
 
 ## Basic Push and Pull
 

--- a/docs/get_started/setup.md
+++ b/docs/get_started/setup.md
@@ -68,10 +68,6 @@ For users of Python on Amazon Linux and Ubuntu operating systems, MXNet provides
 
 To contribute easy installation scripts for other operating systems and programming languages, see [community page](http://mxnet.io/how_to/contribute.html).
 
-### Quick Installation on Amazon Linux
-
-```<Coming Soon>```
-
 ### Quick Installation on Ubuntu
 
 The simple installation scripts set up MXNet for Python on computers running Ubuntu 12 or later. The scripts install MXNet in your home folder ```~/MXNet```.

--- a/docs/tutorials/computer_vision/segmentation.md
+++ b/docs/tutorials/computer_vision/segmentation.md
@@ -7,7 +7,7 @@ You can get the source code for this example from [GitHub](https://github.com/dm
 
 ## Sample Results
 
-![fcn-xs pasval_voc result](https://github.com/dmlc/web-data/blob/master/mxnet/image/fcnxs-example-result.jpg)
+![fcn-xs pasval_voc result](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/fcnxs-example-result.jpg)
 
 We trained a simple fcn-xs model, using the following parameters:
 

--- a/docs/zh/api/python/io.md
+++ b/docs/zh/api/python/io.md
@@ -168,7 +168,7 @@ dataiter = mx.io.ImageRecordIter(
 ```eval_rst
 .. raw:: html
 
-    <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+    <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 ```
 
 

--- a/docs/zh/api/python/kvstore.md
+++ b/docs/zh/api/python/kvstore.md
@@ -3,7 +3,6 @@ KVStore API
 
 * [基本的 Push 和 Pull 操作](#basic-push-and-pull)
 * [key-value pairs 列表的接口](#interface-for-list-key-value-pairs)
-* [多机]() TODO
 
 ## Basic Push and Pull
 
@@ -117,7 +116,7 @@ update on key: 9
 ```eval_rst
 .. raw:: html
 
-    <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+    <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 ```
 
 

--- a/docs/zh/api/python/ndarray.md
+++ b/docs/zh/api/python/ndarray.md
@@ -120,7 +120,7 @@ mxnet.base.MXNetError: [13:29:12] src/ndarray/ndarray.cc:33: Check failed: lhs.c
 ```eval_rst
 .. raw:: html
 
-    <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+    <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 ```
 
 NDArray API Reference


### PR DESCRIPTION
Fixing various links. Also removing one TODO from kvstore.md (the link just links back to the same page) and another TODO for installation on Amazon Linux from setup.md -- better to include it when it's done, or otherwise it makes the docs seem unfinished.