### PR TITLE
Grammar and language correction to pages under architecture. Broken link fix. Avoid 404s for old packages and system sections.

### DIFF
--- a/docs/api/c++/index.md
+++ b/docs/api/c++/index.md
@@ -1,6 +1,6 @@
 # MXNet - C++ API
 
-Please refer below for Namespaces, Classes and code files of MXNet C++ package.
+For namespaces, classes, and code files for the MXNet C++ package, see the  following:
 
 * [Namespaces](http://mxnet.io/doxygen/namespaces.html)
 * [Classes](http://mxnet.io/doxygen/annotated.html)

--- a/docs/api/julia/index.md
+++ b/docs/api/julia/index.md
@@ -3,8 +3,8 @@ MXNet - Julia API
 MXNet supports Julia programming language. The MXNet Julia package brings flexible and efficient GPU
 computing and state-of-art deep learning to Julia.
 
-- It enables you to write seamless tensor/matrix computation with multiple GPUs in R.
-- It also enables you construct and customize the state-of-art deep learning models in R,
+- It enables you to write seamless tensor/matrix computation with multiple GPUs in Julia.
+- It also enables you construct and customize the state-of-art deep learning models in Julia,
   and apply them to tasks such as image classification and data science challenges.
 
 

--- a/docs/api/python/model.md
+++ b/docs/api/python/model.md
@@ -8,7 +8,7 @@ modules to make neural network training easy.
 * [Save the Model](#save-the-model)
 * [Periodically Checkpoint](#periodically-checkpoint)
 * [Initializer API Reference](#initializer-api-reference)
-* [Evaluation Metric API Reference](#initializer-api-reference)
+* [Evaluation Metric API Reference](#evaluation-metric-api-reference)
 * [Optimizer API Reference](#optimizer-api-reference)
 
 ## Train a Model

--- a/docs/architecture/note_engine.md
+++ b/docs/architecture/note_engine.md
@@ -1,223 +1,216 @@
-Dependency Engine for Deep Learning
-===================================
-One always important theme of deep learning libraries is to run faster and scale to larger
-datasets. In order to do so, one natural direction is to always go beyond using one device (GPU),
-and make use of more computation resources.
+# Dependency Engine for Deep Learning
 
-When library designer started to think about this problem, one natural theme will occur.
-How can we ***parallelize*** the computation across devices? More importantly,
-how do we ***synchronize*** the computation when we introduce multi-threading?
+We always want deep learning libraries to run faster and scale to larger
+datasets. One solution is to apply more computation resources by using more than one device (GPU).
 
-Runtime dependency engine is a generic solution to such problems. This article discusses
-the runtime dependency scheduling problem in deep learning. We will introduce the dependency
-scheduling problem, how it can help make multi-device deep learning easier and faster, and
-discuss possible designs of a generic dependency engine that is library and operation independent.
+Library designers then ask:
+How can we *parallelize* computation across devices? And, more important,
+how do we *synchronize* computation when we introduce multi-threading?
 
-Most design details of this article inspires the dependency engine of MXNet, with the dependency tracking algorithm majorly contributed by [Yutian Li](https://github.com/hotpxl) and [Mingjie Wang](https://github.com/jermainewang).
+A runtime dependency engine is a generic solution to these problems. 
 
-Dependency Scheduling Problem
------------------------------
-While most of the users want to take advantage of parallel computation,
-most of us are more used to serial programs. So it is interesting to ask
-if we can write serial programs, and build a library to automatically parallelize
-operations for you asynchronously.
+This topic examines how to use runtime dependency scheduling in deep learning, and how runtime dependency scheduling speeds and simplified multi-device deep learning. It also
+explores potential designs for a generic dependency engine that is library- and operation-independent.
 
-For example, in the following code snippet. We can actually run ```B = A + 1```
-and ```C = A + 2``` in any order, or in parallel.
+Most of the design concepts in this topic inspired the MXNet dependency engine. The dependency tracking algorithm was primarily developed by [Yutian Li](https://github.com/hotpxl) and [Mingjie Wang](https://github.com/jermainewang).
+
+## Dependency Scheduling 
+
+Although most users want to take advantage of parallel computation,
+most of us are more familiar with serial programs. So, how do we write serial programs and build a library to automatically parallelize
+operations in an asynchronized way?
+
+For example, in the following code, we can run ```B = A + 1```
+and ```C = A + 2``` in any order, or in parallel:
+
 ```python
-A = 2
-B = A + 1
-C = A + 2
-D = B * C
+    A = 2
+    B = A + 1
+    C = A + 2
+    D = B * C
 ```
 
-However, it is quite hard to code the sequence manually, as the last operation,
-```D = B * C```, needs to wait for both the above operations to complete before it starts running.
-We can represent the computation as the following dependency graph.
+However, it's quite hard to code the sequence manually because the last operation,
+```D = B * C```, needs to wait for both of the preceding operations to complete before it starts.
+The following dependency graph/data flow graph illustrates this.
 
 ![Dep Simple](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/dep_simple.png)
 
-In this specific case, the graph is also called data-flow graph, as it represents the dependency
-in terms of data and computation.
 
-A dependency engine is a library that takes some sequence of operations, and schedules them
-correctly according to the dependency pattern, and potentially in parallel. So in the toy example,
+A dependency engine is a library that takes a sequence of operations and schedules them according to the dependency pattern, and potentially in parallel. So in this example,
 a dependency library could run ```B = A + 1``` and ```C = A + 2``` in parallel, and run ```D = B * C```
 after both operations complete.
 
-Problems in Dependency Scheduling
----------------------------------
-In last section we introduced what is dependency engine mean in this article. It seems a quite interesting
-thing to use as it relieves our burden from writing concurrent programs. However, as things go parallel,
-there are new (dependency tracking)problems that arises which need to be solved in order to make the running
-program correct and efficient. In this section, let us discuss the problems we will encounter in deep
-learning libraries when things go parallel.
+## Problems in Dependency Scheduling
+
+A dependency engine relieves the burden of writing concurrent programs. However, as operations become parallelized,
+new dependency tracking problems arise. In this section, we discuss those problems.
 
 ### Data Flow Dependency
-The central thing that almost every dependency engine will have to solve, is the dataflow dependency problem.
+Data flow dependency describes how the outcome of one computation can be used in other computations. Every dependency engine has to solve the data flow dependency problem.
 
 ![Dep Simple](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/dep_simple.png)
 
-Data Flow dependency describes how the outcome of one computation can be used in other computations.
-As we have elaborated this in last section, we will only put the same figure here. Libraries that have
+
+Because we discussed this issue in the preceding section, we include the same figure here. Libraries that have
 data flow tracking engines include Minerva and Purine2.
 
-### Correct Memory Recycle
-One problem that we will encounter is when to recycle memory we allocated to the arrays.
-This is simple in the serial case. Because we can simply recycle the memory after the variable
-go out of scope. However, things becomes a bit harder in parallel case. Consider the following
-example
+### Memory Recycling
+When should we recycle memory we allocated to the arrays?
+In serial processing, this is simple because we can recycle the memory after the variable
+goes out of scope. However, as the following figure shows, this is a bit harder in parallel processing. 
 
 ![Dep Del](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/dep_del.png)
 
-In the above example, because both computation needs to use values from A. We cannot perform
-the memory recycling before these computation completes. So a correct engine
-need to schedule the memory recycle operations according to the dependency, and make sure it
-is executed after both ```B = A + 1``` and ```C = A + 2``` completes.
+In this example, because both computations needs to use values from A, we can't recycle
+the memory until both complete. The engine
+needs to schedule the memory recycling operations according to the dependencies, and ensure that they
+are executed after both ```B = A + 1``` and ```C = A + 2``` complete.
 
 
 ### Random Number Generation
-Random number generators are commonly used in machine learning. However, they also bring
-interesting challenges for dependency engine. Consider the following example
+Random number generators, which are commonly used in machine learning, pose
+interesting challenges for a dependency engine. Consider the following example:
 
 ![Dep Rand](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/dep_rand.png)
 
-Here we are generating random numbers in a sequence. While it seems that the two random number
-generations can be parallelized. This is usually not the case. Because usually a pseudo random
-number generator (PRNG) is not thread-safe because it might contain some internal state to mutate
-when generating a new number. Even if the PRNG is thread-safe, it is still desirable to
-run the generation in the a serialized way, so we can get reproducible random numbers.
+In this example, we are generating random numbers in a sequence. Although it seems that the two random number
+generations can be parallelized, this is usually not the case. A pseudo random
+number generator (PRNG) is not thread-safe because it might cause some internal state to mutate
+when generating a new number. Even if the PRNG is thread-safe, it is preferable to
+serialize number generation, so we can get reproducible random numbers.
 
-So in this case, actually what we might want to do is to serialize the operations that uses the same PRNG.
+In this case, we might want to serialize the operations that use the same PRNG.
 
-Case Study on Multi-GPU Neural Net
-----------------------------------
-In the last section, we have discussed the problem we may facing in dependency engine.
-But before thinking about how we can design a generic engine to solve this problems.
-Let us first talk about how can dependency engine help in multi GPU training of neural net.
-The following is a pseudo python program that describes one batch training of two layer
-neural net.
+## Case Study: A Dependency Engine for a Multi-GPU Neural Network
+
+In the last section, we discussed the problems we might face in designing a dependency engine.
+Before thinking about how to design a generic engine to solve those problems,
+let's consider how a dependency engine can help in multi-GPU training of a neural network.
+The following pseudo Python program illustrates training one batch on a  two-layer
+neural network.
 
 ```python
-# Example of one iteration Two GPU neural Net
-data = next_batch()
-data[gpu0].copyfrom(data[0:50])
-data[gpu1].copyfrom(data[50:100])
-# forward, backprop on GPU 0
-fc1[gpu0] = FullcForward(data[gpu0], fc1_weight[gpu0])
-fc2[gpu0] = FullcForward(fc1[gpu0], fc2_weight[gpu0])
-fc2_ograd[gpu0] = LossGrad(fc2[gpu0], label[0:50])
-fc1_ograd[gpu0], fc2_wgrad[gpu0] =
-     FullcBackward(fc2_ograd[gpu0] , fc2_weight[gpu0])
-_, fc1_wgrad[gpu0] = FullcBackward(fc1_ograd[gpu0] , fc1_weight[gpu0])
-# forward, backprop on GPU 1
-fc1[gpu1] = FullcForward(data[gpu1], fc1_weight[gpu1])
-fc2[gpu1] = FullcForward(fc1[gpu1], fc2_weight[gpu1])
-fc2_ograd[gpu1] = LossGrad(fc2[gpu1], label[50:100])
-fc1_ograd[gpu1], fc2_wgrad[gpu1] =
-     FullcBackward(fc2_ograd[gpu1] , fc2_weight[gpu1])
-_, fc1_wgrad[gpu1] = FullcBackward(fc1_ograd[gpu1] , fc1_weight[gpu1])
-# aggregate gradient and update
-fc1_wgrad[cpu]  = fc1_wgrad[gpu0] + fc1_wgrad[gpu1]
-fc2_wgrad[cpu]  = fc2_wgrad[gpu0] + fc2_wgrad[gpu1]
-fc1_weight[cpu] -= lr *  fc1_wgrad[gpu0]
-fc2_weight[cpu] -= lr *  fc2_wgrad[gpu0]
-fc1_weight[cpu].copyto(fc1_weight[gpu0] , fc1_weight[gpu1])
-fc2_weight[cpu].copyto(fc2_weight[gpu0] , fc2_weight[gpu1])
+    # Example of one iteration Two GPU neural Net
+    data = next_batch()
+    data[gpu0].copyfrom(data[0:50])
+    data[gpu1].copyfrom(data[50:100])
+    # forward, backprop on GPU 0
+    fc1[gpu0] = FullcForward(data[gpu0], fc1_weight[gpu0])
+    fc2[gpu0] = FullcForward(fc1[gpu0], fc2_weight[gpu0])
+    fc2_ograd[gpu0] = LossGrad(fc2[gpu0], label[0:50])
+    fc1_ograd[gpu0], fc2_wgrad[gpu0] =
+      FullcBackward(fc2_ograd[gpu0] , fc2_weight[gpu0])
+      _, fc1_wgrad[gpu0] = FullcBackward(fc1_ograd[gpu0] , fc1_weight[gpu0])
+    # forward, backprop on GPU 1
+    fc1[gpu1] = FullcForward(data[gpu1], fc1_weight[gpu1])
+    fc2[gpu1] = FullcForward(fc1[gpu1], fc2_weight[gpu1])
+    fc2_ograd[gpu1] = LossGrad(fc2[gpu1], label[50:100])
+    fc1_ograd[gpu1], fc2_wgrad[gpu1] =
+         FullcBackward(fc2_ograd[gpu1] , fc2_weight[gpu1])
+         _, fc1_wgrad[gpu1] = FullcBackward(fc1_ograd[gpu1] , fc1_weight[gpu1])
+    # aggregate gradient and update
+    fc1_wgrad[cpu]  = fc1_wgrad[gpu0] + fc1_wgrad[gpu1]
+    fc2_wgrad[cpu]  = fc2_wgrad[gpu0] + fc2_wgrad[gpu1]
+    fc1_weight[cpu] -= lr *  fc1_wgrad[gpu0]
+    fc2_weight[cpu] -= lr *  fc2_wgrad[gpu0]
+    fc1_weight[cpu].copyto(fc1_weight[gpu0] , fc1_weight[gpu1])
+    fc2_weight[cpu].copyto(fc2_weight[gpu0] , fc2_weight[gpu1])
 ```
-In this program, the example 0 to 50  are copied to GPU0 and example 50 to 100
-are copied to GPU1. The calculated gradient are aggregated in CPU, which then performs
+In this program, the data 0 to 50  is copied to GPU 0, and the data 50 to 100
+is copied to GPU 1. The calculated gradients are aggregated in the CPU, which then performs
 a simple SGD update, and copies the updated weight back to each GPU.
-This is a common data parallel program written in a serial manner.
+This is a common way to write a parallel program in a serial manner.
 The following dependency graph shows how it can be parallelized:
 
 ![Dep Net](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/dep_net.png)
 
-Few important notes:
-- The copy of gradient to CPU, can happen as soon as we get gradient of that layer.
-- The copy back of weight, can also be done as soon as the weight get updated.
-- In the forward pass, actually we have a dependency to ```fc1_weight[cpu].copyto(fc1_weight[gpu0] , fc1_weight[gpu1])```
-  from previous iteration.
-- There is a lag of computation between last backward to layer k to next forward call to layer k.
-	- We can do the weight synchronization of layer k ***in parallel*** with other computation in this lag.
+***Notes:***
 
-The points mentioned in above list is the exact optimization used by multi GPU deep learning libraries such as CXXNet.
-The idea is to overlap the weight synchronization(communication) with the computation.
-However, as you may find out it is really not easy to do that, as the copy need to be triggered as soon as backward of
-that layer completes, which then triggers the reduction, updates etc.
+- The gradient can be copied  to the CPU as soon as we get the gradient of a layer.
+- The weight can be copied back soon as the weight is updated.
+- In the forward pass, we have a dependency on ```fc1_weight[cpu].copyto(fc1_weight[gpu0] , fc1_weight[gpu1])```
+  from the previous iteration.
+- There is a delay in computation between the last backward pass to layer k and the next forward call to layer k. We can synchronize the weight of layer k *in parallel* with other computation during this delay.
 
-Having a dependency engine to schedule these operations makes our life much easier, by pushing the task of multi-threading
-and dependency tracking to the engine.
+This approach to optimization is used by multi-GPU deep learning libraries, such as CXXNet.
+The point is to overlap weight synchronization(communication) with computation.
+However, it's not easy to do that, because the copy operation needs to be triggered as soon as the backward pass of
+the layer completes, which then triggers the reduction, updates, etc.
 
-Design a Generic Dependency Engine
-----------------------------------
-Now hopefully you are convinced that a dependency engine is useful for scaling deep learning programs to multiple devices.
-Let us now discuss how we can actually design a generic interface for dependency engine, and how we can implement one.
-We need to emphasize that solution discussed in this section is not the only possible design for dependency engine,
-but rather an example that we think is useful to most cases.
+A dependency engine can schedule these operations and perform multi-threading
+and dependency tracking.
 
-One of the most goal thing we like to focus on is ***generic*** and ***lightweight***. Ideally, we would like the engine
-to be easily pluggable to existing deep learning codes, to scale them up to multiple machines with minor modifications.
-In order to do so, we need to make less assumption of what user can or cannot do, and focus only on the dependency tracking part.
+## Designing a Generic Dependency Engine
 
-Here are some summarized goals of engine:
-- It should not be aware of operation being performed, so user can do any operations they defined.
-- It should not be specific to certain types of object it schedules.
-	- We may want to schedule dependency on GPU/CPU memory
-	- We may also want to track dependency on random number generator etc.
-- It should not allocate resources, but only tracks the dependency
-	- The user can allocate their own memory, PRNG etc.
+We hope that you're convinced that a dependency engine is useful for scaling deep learning programs to multiple devices.
+Now let's discuss how we can design and implement a generic interface for a dependency engine.
+This solution isn't the only possible design for a dependency engine.
+It's an example that we think is useful in most cases.
 
-The following python snippet provides a possible engine interface to reach our goal. Note that usually
-the real implementation is in C++.
+Our goal is to create a dependency engine that is *generic* and *lightweight*. Ideally, we'd like the engine
+to easily plug in to existing deep learning code, and to scale up to multiple machines with minor modifications.
+To do that, we need to focus only on dependency tracking, not on assumptions about what users can or can't do.
+
+Here's a summary of goals for the engine:
+
+- It should be unaware of operations that are being performed, so that users can perform any operations they define.
+- It shouldn't schedule only certain types of objects.
+	- We should be able to schedule dependency on GPU andCPU memory.
+	- We should be able to track dependency on the random number generator, etc.
+- It shouldn't allocate resources. It should only track  dependencies. Users can allocate their own memory, PRNG, etc.
+
+The following Python snippet provides an engine interface that might help us reach our goal. Note that
+the real implementation is usually in C++.
+
 ```python
-class DepEngine(object):
-	def new_variable():
-		"""Return a new variable tag
-		Returns
-		-------
-		vtag : Variable Tag
-		    The token of engine to represent dependencies.
-		"""
-		pass
+    class DepEngine(object):
+	    def new_variable():
+		    """Return a new variable tag
+		    Returns
+		    -------
+		    vtag : Variable Tag
+		        The token of engine to represent dependencies.
+		    """
+		    pass
 
-	def push(exec_func, read_vars, mutate_vars):
-		"""Push the operation to the engine.
+	    def push(exec_func, read_vars, mutate_vars):
+		    """Push the operation to the engine.
 
-		Parameters
-		----------
-		exec_func : callable
-			The real operation to be performed.
+		    Parameters
+		    ----------
+		    exec_func : callable
+			    The real operation to be performed.
 
-		read_vars : list of Variable Tags
-			The list of variables this operation will read from.
+		    read_vars : list of Variable Tags
+			    The list of variables this operation will read from.
 
-		mutate_vars : list of Variable Tags
-			The list of variables this operation will mutate.
-		"""
-		pass
+		    mutate_vars : list of Variable Tags
+			    The list of variables this operation will mutate.
+		    """
+		    pass
 ```
 
-Because we cannot assume the object we are scheduling on. What we can do instead is to ask user to allocate a
+Because we can't assume the object we are scheduling, we ask the user to allocate a
 ```virtual tag``` that is associated with each object to represent what we need to schedule.
-So at the beginning, user can allocate the variable tag, and attach it to each of object that we want to schedule.
+So, at the beginning, the user can allocate the variable tag, and attach it to each of the objects that we want to schedule.
 
 ![Dep Net](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/tag_var.png)
 
-After having the variable tags, user call ```push``` to tell the engine about the function we want to execute.
-In addition, user need to specify the dependencies of the operation by ```read_vars``` and ```write_vars```.
-- ```read_vars``` are variable tags of objects which the operation will "read from", without changing its internal state.
-- ```mutate_vars``` are variable tags of objects which the operation will mutate their internal states.
+The user then calls ```push``` to tell the engine about the function to execute.
+In addition, the user needs to specify the dependencies of the operation with ```read_vars``` and ```write_vars```:
+
+- ```read_vars``` are variable tags for objects that the operation will "read from," without changing their internal state.
+- ```mutate_vars``` are variable tags for objects whose internal states the operation will mutate.
 
 ![Push Op](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/push_var.png)
 
-The above figure shows how we can push operation ```B = A + 1``` to dependency engine. Here ```B.data```,
-```A.data``` are the real allocated space. We should note that engine is ***only aware of variable tags***.
-Any the execution function can be any function closures user like to execute. So this interface is generic
-to what operation and resources we want to schedule.
+The preceding figure shows how to push operation ```B = A + 1``` to the dependency engine. ```B.data```and
+```A.data``` are the allocated space. Note that the engine is *only aware of variable tags*.
+Any execution function can be processed. This interface is generic
+for the operations and resources we want to schedule.
 
-As a light touch on how the engine internals works with the tags, we could consider the following code snippet.
-
+For fun, let's look at how the engine internals work with the tags by considering the following code snippet:
     B = A + 1
     C = A + 2
     A = C * 2
@@ -225,100 +218,98 @@ As a light touch on how the engine internals works with the tags, we could consi
 
 The first line reads variable `A` and mutates variable `B`. The second line reads variable `A` and mutates variable `C`. And so on.
 
-The engine is going to maintain a queue for each variable, as the following animation shows for each of the four lines. Green blocks represents a read action, while a red one represents a mutation.
+The engine maintains a queue for each variable, as the following animation shows for each of the four lines. Green blocks represents a read action, while a red block represents a mutation.
 
 ![Dependency Queue](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/dep_queue.gif)
 
-Upon building this queue, the engine sees that the first two green blocks at the front of A's queue, could actually be run in parallel, because they are both read actions and won't conflict with each other. The following graph illustrates this point.
+Upon building this queue, the engine sees that the first two green blocks at the beginning of A's queue could actually be run in parallel, because they are both read actions and won't conflict with each other. The following graph illustrates this point.
 
 ![Dependency Parallelism](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/dep_parallel.png)
 
-The cool thing about all this scheduling is, it is not confined to numerical calculations. Since everything scheduled is only a tag, the engine could schedule everything!
+The cool thing about all this scheduling is that it's not confined to numerical calculations. Because everything that is scheduled is only a tag, the engine could schedule everything!
 
 The following figure gives a complete push sequence of the programs we mentioned in previous sections.
+
 ![Push Seq](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/push_seq.png)
 
-### Port Existing Codes to the Dependency Engine
-Because the generic interface do not take control of things like memory allocation and what operation to execute.
-Most existing code can be scheduled by dependency engine in two steps:
-- Allocate the variable tags associates them resources like memory blob, PRNGS.
-- Call ```push``` with the execution function to be original code to execute, and put the variable tags of
+### Porting Existing Code to the Dependency Engine
+Because the generic interface doesn't control things like memory allocation and which operation to execute, most existing code can be scheduled by the dependency engine in two steps:
+
+
+1. Allocate the variable tags associated with resources like memory blob, PRNGS.
+	- Call ```push``` with the execution function as the original code to execute, and put the variable tags of
   corresponding resources correctly in ```read_vars``` and ```mutate_vars```.
 
-Implement the Generic Engine
-----------------------------
+## Implementing the Generic Dependency Engine
+
 We have described the generic engine interface and how it can be used to schedule various operations.
-How can we implement such an engine. In this section, we provide high level discussion on how such engine
-can be implemented.
+In this section, we provide a high-level discussion of how to implement  such an engine.
 
-The general idea is as follows
-- Use a queue to track all the pending dependencies on each variable tag.
-- Use counter on each operation to track how many dependencies are yet to be full-filled.
-- When operations are completed, we update the state of the queue and dependency counters to schedule new operations.
+The general idea is as follows:
 
-The following figure gives a visual example of the scheduling algorithm, which might give you a better sense
+- Use a queue to track all of the pending dependencies on each variable tag.
+- Use a counter on each operation to track how many dependencies are yet to be fulfilled.
+- When operations are completed, update the state of the queue and dependency counters to schedule new operations.
+
+The following figure is a visual example of the scheduling algorithm, which might give you a better sense
 of what is going on in the engine.
 
 ![Dep Tracking](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/engine_queue_step.png)
 
-The following figure gives another example that involves random number generations.
+The following figure shows another example that involves random number generations.
 
 ![Dep Rand](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/engine/engine_queue_rand.png)
 
-As we can see, the algorithm is mainly about update pending queues of operations and doing the right
-state transition when operation completed. More care should be taken to make sure the state transition
-are done in a thread safe way.
+As you can see, the algorithm is mainly about updating pending queues of operations and doing the right
+state transition when an operation has completed. More care should be taken to make sure the state transitions
+are done in a way that's safe for threads.
 
 ### Separate Dependency Tracking with Running Policy
-If you read carefully, you can find that previous section only shows the algorithm to decide when an operation
-can be executed. We did not show how an operation can be run. In practice, there can be many different policies.
-For example, we can either use a global thread-pool to run all operations, or use specific thread to run operations
+If you read carefully, you noticed that the preceding section shows only the algorithm for deciding when an operation
+can be executed. We didn't show how an operation can be run. In practice, there can be many different policies.
+For example, we can either use a global thread-pool to run all operations, or use a specific thread to run operations
 on each device.
 
-This running policy is usually independent of dependency tracking, and can be separated out either as an independent module
-or virtual interface of base dependency tracking modules. Having a runtime policy that is fare to all operations and schedule
+This running policy is usually independent of dependency tracking, and can be separated out as either an independent module
+or a virtual interface of base-dependency tracking modules. Developing a runtime policy that is fair to all operations and schedules
 smoothly is an interesting systems problem itself.
 
-Discussions
------------
-We should emphasize that the designs mentioned in this article is not the only solution to the dependency tracking problem,
-but is an example on how things can be done. There are several design choices that are debatable.
-We will discuss some of of them here.
+## Discussion
 
-### Dynamic vs Static
-The dependency engine interface discussed in this article is somewhat dynamic.
-In a sense that user can push operations one by one, instead of declaring the entire dependency graph (static).
-The dynamic scheduling may mean more overhead than static declarations, in terms of data structure.
-However, it also enables more flexible patterns such as supporting auto parallelism for imperative programs
-or mixture of imperative and symbolic programs. Some level of pre-declared operations can also be added
-to the interface to enable data structure re-use.
+The design discussed in this article isn't the only solution to the dependency tracking problem,
+it's an example. There are several design choices that are debatable.
+We'll discuss some of of them in this section.
 
-### Mutation vs Immutable
-The generic engine interface in this article support explicit scheduling for mutation.
-In normal dataflow engine, the data are usually immutable. Immutable data have a lot of good properties,
-for example, they are usually good for better parallelization, and easier fault tolerance in distributed setting via re-computation.
+### Dynamic vs. Static
+The dependency engine interface discussed in this topic is somewhat dynamic
+in the sense that the user can push operations one by one, instead of declaring the entire dependency graph (static).
+Dynamic scheduling can require more overhead than static declarations, in terms of data structure.
+However, it also enables more flexibility, such as supporting auto parallelism for imperative programs
+or a mixture of imperative and symbolic programs. You can also add some level of predeclared operations 
+to the interface to enable data structure reuse.
 
-However, making things purely immutable makes several things hard:
-- It is harder to schedule the resource contention problems such as random number and deletion.
-- The engine usually need to manage resources (memory, random number) to avoid conflicts.
-	- It is harder to plug in user allocated space etc.
-- No pre-allocated static memory, again because the usual pattern is write to a pre-allocated layer space,
-  which is not supported is data is immutable.
+### Mutation vs. Immutable
+The generic engine interface in this topic supports explicit scheduling for mutation.
+In a typical data flow engine, the data are usually immutable. Immutable data have a lot of benefits.
+For example, they are usually suitable for better parallelization, and allow easier fault tolerance in a distributed setting by way of recomputation.
 
-The mutation semantics makes these issues easier. It is in lower level than a data flow engine, in a sense that if we
-allocate a new variable and memory for each operations, it can be used to schedule immutable operations.
-But it also makes things like random number generation easier as the operation is indeed mutation of state.
+However, immutability presents several challenges:
 
-Contribution to this Note
--------------------------
-This note is part of our effort to [open-source system design notes](index.md)
- for deep learning libraries. You are more welcomed to contribute to this Note, by submitting a pull request.
+- It's harder to schedule resource contention problems, such as random number and deletion.
+- The engine usually needs to manage resources (memory, random number) to avoid conflicts. It's harder to plug in user-allocated space, etc.
+- Preallocated static memory isn't available, again because the usual pattern is to write to a preallocated layer space,
+  which is not supported if data is immutable.
 
-### Source Code of the Generic Dependency Engine
-[MXNet](https://github.com/dmlc/mxnet) provides an implementation of generic dependency engine described in this article.
-You can find more descriptions in the [here](engine.md). You are also welcome to contribute to the code.
+The mutation semantics makes these issues easier. It is in a lower level than a data flow engine, in the sense that if we
+allocate a new variable and memory for each operation, it can be used to schedule immutable operations.
+It also makes things like random number generation easier because the operation is indeed a mutation of state.
 
-# Recommended next steps
+
+## Source Code of the Generic Dependency Engine
+[MXNet](https://github.com/dmlc/mxnet) provides an implementation of the generic dependency engine described in this topic.
+You can find more details in [this topic](engine.md). We welcome your contributions. 
+
+## Next Steps
 
 * [Squeeze the Memory Consumption of Deep Learning](http://mxnet.io/architecture/note_memory.html)
 * [Efficient Data Loading Module for Deep Learning](http://mxnet.io/architecture/note_data_loading.html)

--- a/docs/architecture/note_memory.md
+++ b/docs/architecture/note_memory.md
@@ -1,239 +1,228 @@
-Optimizing the Memory Consumption in Deep Learning
-===============================================
-One important theme about deep learning is to train deeper and larger nets.
-While the hardware has been upgraded rapidly in recent years, the huge deepnet monsters are
-always hungry about the GPU RAMS. Being able to use less memory for the same net also means we can
-use larger batch size, and usually higher GPU utilization rate.
+# Optimizing Memory Consumption in Deep Learning
 
-This article discusses how memory allocation optimization can be done for deep neural nets, and provide
-some of candidate solutions to the problems. The solutions discussed in this article is by no means complete,
-but rather as example that we think is useful to most cases.
+In deep learning, we strive to train deeper and larger networks. Although hardware has improved rapidly in recent years, the huge deep network monsters are
+always hungry for more GPU RAM. Using less memory for the same network also means we can
+use a larger batch size and, usually, a higher GPU utilization rate.
 
-Computation Graph
------------------
-We will start the discussion by introducing computation graph, since this is the tool that will help us in the later
-part of the section. Computation graph describes the (data-flow) dependencies between the operations in the deep nets.
-The operation performed in the graph can either be fine-grained or coarse grained.
-The following figure gives two examples of computation graph.
+This topic discusses how to optimize memory allocation for deep neural networks, and provides
+ candidate solutions for some of the problems. The solutions are by no means complete;
+they are examples that we think can be useful in most cases.
+
+## Computation Graph
+
+We'll start the discussion by introducing the computation graph because it's a tool that we will rely on later. A computation graph describes the (data flow) dependencies between the operations in the deep network.
+The operations performed in the graph can be either fine-grained or coarse-grained.
+The following figure shows two examples of computation graphs.
 
 ![Comp Graph Example](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/comp_graph_example.png)
 
-The idea of computation graph is deeply rooted in the packages such as Theano, CGT. Actually they also exists implicitly
-in most libraries as the network configuration. The major difference in these library comes to how do they calculate gradient.
-There are mainly two ways, doing back-propagation on the same graph, or have an explicit backward path that calculates
+The concept of a computation graph is deeply rooted in packages such as Theano and CGT. Actually, they also exist implicitly
+in most libraries as the network configuration. The major difference in these library comes down to how they calculate gradient.
+There are mainly two ways: doing back-propagation on the same graph, or having an explicit backward path that calculates
 the gradient needed.
 
 ![Backward Graph](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/back_graph.png)
 
-Libraries like Caffe, CXXNet, torch uses the backprop on same graph. While libraries like Theano, CGT takes the explicit
-backward path approach. We will adopt the ***explicit backward path*** way in the article, because it brings several advantages
-in turns of optimization.
+Libraries like Caffe, CXXNet, and Torch use the backprop on the same graph. Libraries like Theano and CGT takes the explicit
+backward path approach. In this topic, we adopt the *explicit backward path* approach because it has several advantages
+for optimization.
 
-However, we should emphasize that choosing the explicit backward path way for execution will not restrict us
-to scope of symbolic libraries such as Theano, CGT. We can also use the explicit backward path for gradient calculation of
-layer-based(which ties forward, backward together) libraries. The following graph shows how this can be done.
-Basically, we can introduce a backward node that links to the forward node of the graph, and calls the ```layer.backward```
+However, we should emphasize that choosing the explicit backward path approach doesn't restrict us
+to symbolic libraries, such as Theano and CGT. We can also use the explicit backward path for gradient calculation of
+layer-based (which ties forward and backward together) libraries. The following graph shows how to do this.
+Basically, we introduce a backward node that links to the forward node of the graph and calls the ```layer.backward```
 in the backward operations.
 
 ![Backward Layer](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/explicit_back_layer.png)
 
-So this discussion applies to almost all deep learning libraries that exists
-(There are differences between these libraries,  e.g. high order differentiation. which are beyond the scope of in this article).
+This discussion applies to almost all existing deep learning libraries. 
+(There are differences between libraries,  e.g., high-order differentiation, which are beyond the scope of this topic.)
 
-Why explicit backward path is better? Let us explain it with two examples. The first reason is that the explicit backward path
-clearly describes the dependency between the computation. Consider the following case, where we want to get
-the gradient of A and B. As we can see clearly from the graph, that computation of ```d(C)``` gradient do not depend on F.
-This means we can free the memory of ```F``` right after the the forward computation is done, similarly the memory
+Why is the explicit backward path better? Let's explain it with two examples. The first reason is that the explicit backward path
+clearly describes the dependency between computations. Consider the following case, where we want to get
+the gradient of A and B. As we can see clearly from the graph, the computation of the ```d(C)``` gradient doesn't depend on F.
+This means that we can free the memory of ```F``` right after the forward computation is done. Similarly the memory
 of ```C``` can be recycled.
 
 ![Backward Prune](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/back_dep_prune.png)
 
-Another advantage of explicit backward path is to be able to have a different backward path rather than an mirror of forward one.
-One common example is the split connection case, as shown in the following figure.
+Another advantage of the explicit backward path is the ability to have a different backward path, instead of a mirror of forward one.
+A common example is the split connection case, as shown in the following figure.
 
 ![Backward Agg](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/back_agg_grad.png)
 
 In this example, the output of B is referenced by two operations. If we want to do the gradient calculation in the same
-network, an explicit split layer need to be introduced. This means we need to do the split for the forward pass as well.
-In this figure, the forward pass do not contain a split layer, but the graph will automatically insert a gradient
-aggregation node before passing gradient back to B. This helps us to save the memory cost of allocating output of
-split layer, as well as operation cost of replicate the data in forward pass.
+network, we need to introduce an explicit split layer. This means we need to do the split for the forward pass, too.
+In this figure, the forward pass doesn't contain a split layer, but the graph will automatically insert a gradient
+aggregation node before passing the gradient back to B. This helps us to save the memory cost of allocating the output of the
+split layer, and the operation cost of replicating the data in the forward pass.
 
-If we adopt the explicit backward view of computation graph, there is no difference between the forward pass
-and backward pass. We will simply go forward in topological order of the computation graph, and carry out computations.
-This also simplifies our discussions. The problem now becomes:
+If we adopt the explicit backward approach, there's no difference between the forward pass
+and the backward pass. We simply proceed in the chronological order of the computation graph, and carry out computations.
+This also simplifies our discussions. The problem now is: How do we allocate the memory of each output node of a computation graph?
 
-- How to allocate the memory of each output node of a computation graph?
+This seems to have nothing to do with deep learning, but is more about the context of compiling, data flow optimization, etc.
+It's really the hungry monster of deep learning that motivates us to attack this problem, and benefit from it.
 
-Hmm, seems it has nothing to do with deep learning, but more of context of compiling, data flow optimization etc.
-But it is really the hungry monster of deep learning that motivates us attack this problem, and benefit from it.
+## What Can Be Optimized?
 
-What can be Optimized
----------------------
-Hopefully you are convinced that the computation graph is a good way to discuss memory allocation optimization techniques.
-As you can see some memory saving can already been bought by using explicit backward graph. Let us discuss more about
-what optimization we can do, and what is the baseline.
+We hope you're convinced that the computation graph is a good way to discuss memory allocation optimization techniques.
+As you can see, we've already saved some memory by using the explicit backward graph. Let's explore
+what we can optimize, and determine the baseline.
 
-Assume we want to build a neural net with ```n``` layers. A typical implementation of neural net will
-need to allocate node space for output of each layer, as well as gradient values for back-propagation.
-This means we need roughly ```2 n``` memory cells. This is the same in the explicit backward graph case, as
-the number of nodes in backward pass in roughly the same as forward pass.
+Assume that we want to build a neural network with ```n``` layers. A typical implementation of a neural network will
+need to allocate node space for output of each layer and gradient values for back-propagation.
+This means we need roughly ```2 n``` memory cells. This is the same in the explicit backward graph approach because
+the number of nodes in a backward pass is roughly the same as in a forward pass.
 
-### Inplace Operations
-One of the very first thing that we can do is in-place memory sharing of operations. This is usually done for
+### In-place Operations
+One of the very first things that we can do is in-place memory sharing of operations. This is usually done for
 simple operations such as activation functions. Consider the following case, where we want to
-compute the value of three chained sigmoid function.
+compute the value of three chained sigmoid functions.
 
 ![Inplace op](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/alloc_inline.png)
 
-Because we can compute sigmoid in the ```in-place``` manner, that is, use the same memory for input and output.
-We can simply allocate one copy of memory, and use it compute arbitrary length of sigmoid chain.
+Because we can compute sigmoid ```in-place```, that is, use the same memory for input and output, we can simply allocate one copy of memory, and use it to compute an arbitrary length of sigmoid chain.
 
-However, the in-place optimization sometimes can be done in the wrong way, especially when the package tries
-to be a bit general. Consider the following case, where the value of B is not only used by C, but also F.
+However, in-place optimization sometimes can be done incorrectly, especially when the package tries
+to be a bit general. Consider the following case, where the value of B is not only used by C, but also by F.
 
 ![In-place trap](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/alloc_inline_trap.png)
 
-We cannot perform in-place optimization because the value of B is still needed after ```C=sigmoid(B)``` is computed.
-So an algorithm that simply do in-place optimization for every sigmoid operation might fall into such trap,
-and we need to be careful on when we can do it.
+We can't perform in-place optimization because the value of B is still needed after ```C=sigmoid(B)``` is computed.
+An algorithm that simply does in-place optimization for every sigmoid operation might fall into such trap,
+so we need to be careful about when we can use it.
 
-### Normal Memory Sharing
-Memories can also be shared besides the in-place operation. Consider the following case, because the
+### Standard Memory Sharing
+Memory can be shared in other ways than in in-place operations. In the following case, because the
 value of B is no longer needed when we compute E, we can reuse the memory to hold the result of E.
 
 ![Normal Sharing](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/alloc_normal.png)
 
-We would like to point out that is ***memory sharing does not necessarily require same data shape****.
-In the above example, the shape of ```B``` and ```E``` can be different, and we can simply allocate a
-memory region that is the maximum of the two sizes and share it between the two.
+*Memory sharing doesn't necessarily require the same data shape*.
+In the preceding example, the shape of ```B``` and ```E``` can differ. We can simply allocate a
+memory region that is the maximum of the two sizes and share it between them.
 
-### Real Neural Net Allocation Example
-The above examples are all make up cases, that only contains the computation of the forward pass.
-Actually the idea holds the same for the real neural net cases. The following figure shows an allocation
-plan we can do for a two layer perception.
+### Example of Real Neural Network Allocation 
+The preceding examples, which contain only the computation of the forward pass, are made up.
+But, the same idea holds for real neural networks. The following figure shows an allocation
+plan for a two-layer perceptron.
 
 ![Net Alloc](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/alloc_mlp.png)
 
-In the above example:
-- Inplace optimization is applied on computing ```act1```, ```d(fc1)```, ```out``` and ```d(fc2)```.
-- The memory sharing is used between ```d(act1)``` and ```d(A)```.
+In this example:
 
-Memory Allocation Algorithm
----------------------------
-We have discussed how the general techniques to optimize memory allocations in previous section.
-However, we also see that there are traps which we want to avoid like the in-place case.
-How can we allocate the memory correctly? This is not a new problem. For example, it is very similar
-to register allocation in compilers. So there could be a lot we can borrow. We do not attempt to give
-a comprehensive review of techniques here, but rather introduce some simple but useful trick to attack
+- In-place optimization is applied on computing ```act1```, ```d(fc1)```, ```out``` and ```d(fc2)```.
+- Memory is shared between ```d(act1)``` and ```d(A)```.
+
+## Memory Allocation Algorithm
+
+We've discussed general techniques for optimizing memory allocation.
+We've also seen that there are traps to avoid, like the one we saw for in-place memory optimization.
+So, how can we allocate memory correctly? This is not a new problem. For example, it is very similar
+to the problem with register allocation in compilers. There might be techniques that we can borrow. We're not attempting to give
+a comprehensive review of techniques here, but rather to introduce some simple, but useful tricks to attack
 the problem.
 
-The key problem is we want to place resources, such that they do not conflict each other.
-More specifically, each variable have a ```life time``` between the time it get computed till the last time it get used.
-In the multilayer perception case, the ```life time``` of ```fc1``` ends after ```act1``` get computed.
+The key problem is that we need to place resources so that they don't conflict with each other.
+More specifically, each variable has a ```life time``` between the time it get computed until the last time it is used.
+In the case of the multi-layer perceptron, the ```life time``` of ```fc1``` ends after ```act1``` get computed.
 
 ![Net Alloc](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/alloc_mlp.png)
 
-The principle is ***to only allow memory sharing between the variables whose lifetime do not overlap***. There are multiple
-ways to solve this problem. One possible way is to construct the conflicting graph of with each variable as node and link edge
-between variables with overlapping lifespan, and run a graph-coloring algorithm. This will likely require ```$O(n^2)$```
-complexity where ```n``` is number of nodes in the graph, which could be an reasonable price to pay.
+The principle is *to allow memory sharing only between variables whose lifetimes don't overlap*. There are multiple
+ways to do this. You can construct the conflicting graph with each variable as a node and link the edge
+between variables with overlapping lifespans, and then run a graph-coloring algorithm. This likely has ```$O(n^2)$```
+complexity, where ```n``` is the number of nodes in the graph. This might be too costly.
 
-We will introduce another simple heuristic here. The idea is to simulate the procedure of traversing the graph,
+Let's consider another simple heuristic. The idea is to simulate the procedure of traversing the graph,
 and keep a counter of future operations that depends on the node.
 
 ![Alloc](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/alloc_step.png)
 
-- An in-place optimization can be performed when only current operation depend on the source(i.e. counter=1)
-- A memory can be recycled into the box on the upper right corner when counter goes to 0
-- Every time, when we need new memory, we can either get it from the box, or allocate a new one.
+- An in-place optimization can be performed when only the current operation depends on the source (i.e., counter=1).
+- Memory can be recycled into the box on the upper right corner when the counter goes to 0.
+- When we need new memory, we can either get it from the box or allocate a new one.
 
-One note is that during the simulation, no memory is allocated, but we rather keep record of how much memory each node need,
+***Note:*** During the simulation, no memory is allocated. Instead, we keep a record of how much memory each node needs,
 and allocate the maximum of the shared parts in the final memory plan.
 
-### Static vs Dynamic Allocation
+## Static vs. Dynamic Allocation
 
-If you think carefully, you will find the above strategy exactly simulates the dynamic memory allocation procedure in imperative
-languages such as python. The counter is the reference counter of each memory object, and the object get garbage collected when
-the reference counter goes to zero. In that sense, we are simulating the dynamic memory allocation once to create a static allocation plan.
-Now the question is, can we simply use an imperative language that dynamically allocates and de-allocates memories?
+The preceding strategy exactly simulates the dynamic memory allocation procedure in imperative
+languages, such as Python. The counter is the reference counter of each memory object, and the object gets garbage collected when
+the reference counter goes to 0. In that sense, we are simulating dynamic memory allocation once to create a static allocation plan.
+Can we simply use an imperative language that dynamically allocates and deallocates memory?
 
-The major difference is that the static allocation is only done once, so we can afford to use more complicated algorithms
-- For example, do searching over memories sizes that are similar to the require memory block.
-- The allocation can also be made graph aware, see more discussion in next section.
-- The dynamic way will push more pressure on fast memory allocator and garbage collector.
+The major difference is that static allocation is only done once, so we can afford to use more complicated algorithms. For example, we can search over memory sizes that are similar to the required memory block. The Allocation can also be made graph aware. We'll talk about that in the next section. Dynamic allocation puts more pressure on fast memory allocation and garbage collection.
 
-There is also one takeaway for users who want to reply on dynamic memory allocations:
-***do not take unnecessary reference of object***. For example, if we organize all the nodes in
-a list and store then in a Net object, these nodes will never get de-referenced, getting us no gain of the space.
-Unfortunately, this is one common way to organize the code.
+There is also one takeaway for users who want to rely on dynamic memory allocations: *do not unnecessarily reference objects*. For example, if we organize all of the nodes in
+a list and store then in a Net object, these nodes will never get dereferenced, and we gain no space.
+Unfortunately, this is a common way to organize code.
 
 
-Allocation for on Parallel Operations
--------------------------------------
-In the previous section, we discussed how we can ```simulate``` the running procedure of computation graph,
-and get a static allocation plan. However, there are more problems when we want to optimize for parallel computation
-as resource sharing and parallelization are on the two ends of a balance.
-Let us look at the following two allocation plan for the same graph:
+## Memory Allocation for Parallel Operations
+
+In the previous section, we discussed how we can *simulate* running the procedure for a computation graph to get a static allocation plan. However, optimizing for parallel computation presents other challenges 
+because resource sharing and parallelization are on the two ends of a balance.
+Let's look at the following two allocation plans for the same graph:
 
 ![Parallel Alloc](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/parallel_alloc.png)
 
-Both allocation plans are valid, if we run the computation in a serial manner from ```A[1]``` to ```A[8]```.
-However, the allocation plan on the left side introduces extra dependencies, which means we cannot
-run computation of ```A[2]``` and ```A[5]``` in parallel, while the right one can.
+Both allocation plans are valid if we run the computation in serially, from ```A[1]``` to ```A[8]```.
+However, the allocation plan on the left introduces additional dependencies, which means we can't
+run computation of ```A[2]``` and ```A[5]``` in parallel. The plan on the right can.
 
-As we can see that if we want to parallelizing the computation, more care need to be done in terms of computation.
+To parallelize computation, we need to take greater care.
 
-### Stay Safe and Correct First
-Stay correct, this is the very first principle we need to know. This means execute in a way to take the implicit dependency
-memory sharing into consideration. This can done by adding the implicit dependency edge to execution graph.
-Or even simpler, if the execution engine is mutate aware as described in the
-[dependency engine note](http://mxnet.io/architecture/note_engine.html), push the operation
+### Be Correct and Safe First
+Being correct is our first principle. This means execute in a way that takes  implicit dependency
+memory sharing into consideration. You can do this by adding the implicit dependency edge to the execution graph.
+Or, even simpler, if the execution engine is mutate aware, as described in the
+[dependency engine topic](http://mxnet.readthedocs.org/en/latest/developer-guide/note_engine.html), push the operation
 in sequence and write to the same variable tag that represents the same memory region.
 
-Another way is always produce memory allocation plan that is safe, which means never allocate same memory to nodes that can
-be parallelized. This may not be the ideal case, because sometimes memory reduction is more desirable, and there is not too
-much gain we can get by multiple computing stream execution on the same GPU.
+Always produce a safe memory allocation plan. This means never allocate the same memory to nodes that can
+be parallelized. This might not be ideal because sometimes memory reduction is more desirable, and we don't gain too
+much when we can get multiple computing stream execution on the same GPU.
 
 ### Try to Allow More Parallelization
-Given that we can always be correct, we are now safe to do some optimizations. The general idea is to try to
-encourage memory sharing between nodes that cannot be parallelized. This again can be done by creating a ancestor relation
-graph and query this during allocation, which cost around ```$O(n^2)$``` time to construct. We can also use heuristic here,
-for example, one way is to color the path in the graph.
-The idea is shown in the figure below, every time we tries to find a longest path in the graph, color them to same color,
+Now we can safely perform some optimizations. The general idea is to try to
+encourage memory sharing between nodes that can't be parallelized. You can do this by creating an ancestor relationship
+graph and querying it during allocation, which costs approximately ```$O(n^2)$``` in time to construct. We can also use a heuristic here,
+for example, color the path in the graph.
+As shown in the following figure, when you try to find the longest paths in the graph, color them the same color,
 and continue.
 
 ![Path Color](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/memory/graph_color.png)
 
-After we get the color of the node, we can only allow sharing (or encourage such sharing ) between nodes in the same color.
-This is a more strict version than the ancestor relation, but only cost ```$O(n)$``` time if we only search for first ```k``` path.
+After you get the color of the node, you allow sharing (or encourage sharing) only between nodes of the same color.
+This is a stricter version of the ancestor relationship, but it costs only ```$O(n)$``` of time if you search for only the first ```k``` path.
 
-The strategy discussed here is by no means the only solution, we can expect more sophisticated approaches along this line.
+This is by no means the only solution. More sophisticated approaches might exist
 
-How much can We Save
---------------------
-Thanks for reading till this part! We have discussed the techniques and algorithms we can use to squeeze the memory usage of deep learning.
-Now comes the question on how much we can really save by using these techniques.
+## How Much Can you Save?
 
-The answer is we can roughly reduce the memory consumption ***by half*** using these techniques. This is on the coarse grained operation graphs that are already optimized with big operations. More memory reduction could be seen if we are optimizing a fine-grained computation network used by symbolic libraries such as Theano.
+We've discussed the techniques and algorithms you can use to squeeze  memory usage for deep learning.
+How much you can really save by using these techniques?
 
-Most of the ideas in this article inspires the design of MXNet.
-We provide an [Memory Cost Estimation Script](https://github.com/dmlc/mxnet/tree/master/example/memcost),
-which you can play with to see how much memory we need under different strategies.
+On coarse-grained operation graphs that are already optimized with big operations, you can reduce memory consumption roughly *by half*. You can reduce memory usage even more if you are optimizing a fine-grained computation network used by symbolic libraries, such as Theano.
 
-If you play with the script, there is one option called ```forward_only```, which shows the cost only running the forward pass.
-You will find that the cost is extremely low compared to others.  You won't be surprised if you read previous part of
-the article, this is simply because more memory re-use if we only run the forward pass. So here are the two takeaways:
+Most of the ideas in this article inspired the design of MXNet.
+We've also provided an [Memory Cost Estimation Script](https://github.com/dmlc/mxnet/tree/master/example/memcost),
+which you can use to see how much memory you need under different scenarios.
 
-- Use computation graph to allocate the memory smartly and correctly.
-- Running deep learning prediction cost much less memory than deep learning training.
+The script has an option called ```forward_only```, which shows the cost of  running only the forward pass.
+You will find that cost when using this option is extremely low compared to others. This is simply because there's  more memory reuse if you run only the forward pass. So here are two takeaways:
 
-Contribution to this Note
--------------------------
-This note is part of our effort to [open-source system design notes](index.md)
- for deep learning libraries. You are more welcomed to contribute to this Note, by submitting a pull request.
+- Use a computation graph to allocate memory.
+- Deep learning prediction consumes much less memory than deep learning training.
 
-# Recommended next steps
+## Contributing to This Topic
+
+This topic is part of our effort to provide [open-source system design notes](index.md)
+ for deep learning libraries. We welcome your contributions.
+## Next Steps
 
 * [Efficient Data Loading Module for Deep Learning](http://mxnet.io/architecture/note_data_loading.html)
 * [Survey of RNN Interface](http://mxnet.io/architecture/rnn_interface.html)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,780 +2,814 @@
 
 ![System Overview](https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/mxnet/system/overview.png)
 
-Above image shows major modules/components of the MXNet system and their interaction. The modules are:
+This figure shows the major modules and components of the MXNet system and their interaction. The modules are:
+
 - Runtime Dependency Engine: Schedules and executes the
   operations according to their read/write dependency.
-- Storage Allocator: Efficiently allocate and recycles memory blocks for GPU and
-  CPU.
-- Resource Manager: Manage global resources such as random number generator, temporal space.
-- NDArray: Dynamic asynchronous n-dimensional arrays, provide flexible
+- Storage Allocator: Efficiently allocates and recycles memory blocks for GPU and
+  CPU processors.
+- Resource Manager: Manages global resources, such as the random number generator and temporal space.
+- NDArray: Dynamic asynchronous n-dimensional arrays, which provide flexible
   imperative programs for MXNet.
-- Symbolic Execution: Static symbolic graph executor, provide efficient symbolic
+- Symbolic Execution: Static symbolic graph executor, which provides efficient symbolic
   graph execution and optimization.
-- Operator: Operators that defines static forward and gradient
-  calculation(backprop).
+- Operator: Operators that define static forward and gradient
+  calculation (backprop).
 - SimpleOp: Operators that extend to NDArray operators and symbolic operators
   in a unified fashion.
-- Symbol Construction: Symbolic construction, provide a way to construct
-  computation graph(net configuration)
-- KVStore: Key-value store interface for easy parameter synchronizations.
+- Symbol Construction: Symbolic construction, which provides a way to construct
+  a computation graph (net configuration).
+- KVStore: Key-value store interface for easy parameter synchronization.
 - Data Loading(IO): Efficient distributed data loading and augmentation.
 
 # MXNet System Components
 
 ## Execution Engine
 
-MXNet's engine is not only for deep learning or any domain-specific problem. Rather, it is designed to face a general problem: execute a bunch of functions following their dependencies. Execution of any two functions with dependencies should be serialized.
-Functions with no dependencies *may* be executed in parallel to boost performance.
-See also [Note on Dependency Engine](note_engine.md) for general discussions on the topic.
+You can use MXNet's engine not only for deep learning, but for any domain-specific problem. It's designed to solve a general problem: execute a bunch of functions following their dependencies. Execution of any two functions with dependencies should be serialized.
+To boost performance, functions with no dependencies *can* be executed in parallel.
+For a general discussion of this topic, see the [Note on Dependency Engine](note_engine.md).
 
 ### Interface
 
-The core interface of execution engine is:
-```c++
-virtual void PushSync(Fn exec_fun, Context exec_ctx,
-                      std::vector<VarHandle> const& const_vars,
-                      std::vector<VarHandle> const& mutate_vars) = 0;
-```
-This API allows users to push a function (`exec_fun`), along with its context information and dependencies to the engine. The `exec_ctx` is the context information in which the `exec_fun` should be executed. `const_vars` denotes the variables that the function would read from while `mutate_vars` are the variables that to be modified. Regardless of the details that would be explained later, the engine guarantees following order:
+The following API is the core interface for the execution engine:
 
->*The execution of any two functions that any one of them modifies at least one common variable would be serialized in their push order.*
+```c++
+    virtual void PushSync(Fn exec_fun, Context exec_ctx,
+                          std::vector<VarHandle> const& const_vars,
+                          std::vector<VarHandle> const& mutate_vars) = 0;
+```
+This API allows you to push a function (`exec_fun`), along with its context information and dependencies, to the engine. `exec_ctx` is the context information in which the `exec_fun` should be executed. `const_vars` denotes the variables that the function reads from,  and `mutate_vars` are the variables to be modified. Regardless of the details that we'll explain later, the engine guarantees following order:
+
+>*The execution of any two functions when one of them modifies at least one common variable is serialized in their push order.*
 
 ### Function
 
 The function type of the engine is:
-```c++
-using Fn = std::function<void(RunContext)>;
-```
-The `RunContext` contains runtime information which is determined by the engine:
-```c++
-struct RunContext {
-    // stream pointer which could be safely cast to
-    // cudaStream_t* type
-	void *stream;
-};
-```
-Alternatively, one could use `mxnet::engine::DAGEngine::Fn` which is the same type definition.
 
-All the functions will be executed by the internal threads of the engine. In such model, it is usually not suggested to push *blocking* functions to the engine (usually for dealing with I/O tasks like disk, web service, UI, etc.) since it will occupy the execution thread and reduce the total throughput. In such case, we provide another *asynchronous* function type:
 ```c++
-using Callback = std::function<void()>;
-using AsyncFn = std::function<void(RunContext, Callback)>;
+    using Fn = std::function<void(RunContext)>;
 ```
-In the `AsyncFn` function, user could pass the heavy part to their own threads and safely exit the function body. The engine will not consider the function to be finished until the `Callback` function is called.
+`RunContext` contains runtime information, which is determined by the engine:
+
+```c++
+    struct RunContext {
+        // stream pointer which could be safely cast to
+        // cudaStream_t* type
+	    void *stream;
+    };
+```
+Alternatively, you could use `mxnet::engine::DAGEngine::Fn`, which is the same type definition.
+
+All of the functions are executed by the engine's internal threads. In such a model, it's usually not a good idea to push *blocking* functions to the engine (usually for dealing with I/O tasks like disk, web service, UI, etc.) because it will occupy the execution thread and reduce total throughput. In that case, we provide another *asynchronous* function type:
+
+```c++
+    using Callback = std::function<void()>;
+    using AsyncFn = std::function<void(RunContext, Callback)>;
+```
+In the `AsyncFn` function, you can pass the heavy part to your own threads and safely exit the body of the function. The engine doesn't consider the function finished until the `Callback` function is called.
 
 ### Context
 
-User could specify the `Context` of the function to be executed within. This usually includes whether the function should be run on CPU or GPU, and if GPU, which GPU to use. `Context` is different from `RunContext`. `Context` contains device type (gpu/cpu) and device id while `RunContext` contains information that could only be decided during runtime like on which stream the function should be executed.
+You can specify the `Context` of the function to be executed within. This usually includes whether the function should be run on a CPU or a GPU, and if you specify a GPU, which GPU to use. `Context` is different from `RunContext`. `Context` contains device type (gpu/cpu) and device id, while `RunContext` contains information that can be decided only during runtime, for example, on which stream the function should be executed.
 
 ### VarHandle
 
-`VarHandle` is used to specify the dependencies of functions. The design of MXNet engine is to decouple it with other modules in MXNet. So `VarHandle` is like an engine-given token for user to represent the external resources the functions may use or modified. It is designed to be light, so create, delete or copy a variable will incur little overhead. Upon pushing functions, users need to specify the variables that will be used (immutable) in `const_vars` vector and the variables to be modified (mutable) in `mutate_vars` vector. The only rule for the engine to resolve the dependencies among functions pushed is:
+`VarHandle` is used to specify the dependencies of functions. The MXNet engine is designed to be decoupled from other MXNet modules. So `VarHandle` is like an engine-provided token you use to represent the external resources the functions can use or modify. It's designed to be lightweight, so creating, deleting, or copying a variable incurs little overhead. Upon pushing the functions, you need to specify the variables that will be used (immutable) in the `const_vars` vector, and the variables that will be modified (mutable) in the `mutate_vars` vector. The engine uses one rule for resolving the dependencies among functions:
 
->*The execution of any two functions that any one of them modifies at least one common variable would be serialized in their push order.*
+>*The execution of any two functions when one of them modifies at least one common variable is serialized in their push order.*
 
-For example, if `Fn1`, `Fn2` both mutate `V2`, `Fn2` is guaranteed to be executed after `Fn1` if `Fn2` is pushed after `Fn1`. On the other hand, if `Fn1` and `Fn2` both use `V2`, their actual execution order could be any kind.
+For example, if `Fn1` and `Fn2` both mutate, `V2`, `Fn2` is guaranteed to be executed after `Fn1` if `Fn2` is pushed after `Fn1`. On the other hand, if `Fn1` and `Fn2` both use `V2`, their actual execution order could be random.
 
-This design allows the engine to schedule *state-mutating* operations. For example, the weight update function in DNN can now use `+=` operator to update the weights in place, rather than generating a new weight array each time.
+This design allows the engine to schedule *state-mutating* operations. For example, the weight update function in DNN can now use the `+=` operator to update the weights in place, rather than generating a new weight array each time.
 
-To create a variable, use `NewVar()` API. To delete a variable, use `PushDelete` API.
+To create a variable, use the `NewVar()` API. To delete a variable, use the `PushDelete` API.
 
-### Push & Wait
+### Push and Wait
 
-**All `Push` APIs are asynchronous.** The API call will return immediately no matter the pushed `Fn` is finished or not. This allows engine to start computing at the same time user thread is pushing functions. All `Push` APIs are not thread-safe. To be specific, only one thread should make engine API calls at one time.
+*All `Push` APIs are asynchronous.* The API call returns immediately regardless of whether the pushed `Fn` is finished. This allows the engine to start computing at the same time the user thread is pushing functions. All `Push` APIs are not thread-safe. To be specific, only one thread should make engine API calls at a time.
 
-If you want to wait for a specific `Fn` to be finished, include a callback function in the closure and call the function at the end of your `Fn`.
+If you want to wait for a specific `Fn` to be finished, include a callback function in the closure, and call the function at the end of your `Fn`.
 
-If you want to wait for all `Fn` that involves (use/mutate) a certain variable to be finished, use `WaitForVar(var)` API.
+If you want to wait for all `Fn`s that involve (use or mutate) a certain variable to finish, use the `WaitForVar(var)` API.
 
-If you want to wait for all pushed `Fn` to be finished, use `WaitForAll()` API.
+If you want to wait for all pushed `Fn`s to finish, use the `WaitForAll()` API.
 
 ### Save Object Creation Cost
 
-In some cases, you need to push several functions to the engine but for tons of times. If the computation of these functions are light, the overhead of copying lambdas and creating use/mutate variable lists would become relatively high. We provide an API to create an `OprHandle` beforehand:
+In some cases, you need to push several functions to the engine for a long period of time. If the computation of these functions is light, the overhead of copying lambdas and creating use/mutate variable lists becomes relatively high. We provide an API to create an `OprHandle` beforehand:
+
 ```c++
-virtual OprHandle NewOperator(AsyncFn fn,
-                              std::vector<VarHandle> const& const_vars,
-                              std::vector<VarHandle> const& mutate_vars) = 0;
+    virtual OprHandle NewOperator(AsyncFn fn,
+                                  std::vector<VarHandle> const& const_vars,
+                                  std::vector<VarHandle> const& mutate_vars) = 0;
 ```
-So you could keep pushing the `OprHandle` without repeatedly creating them:
+You can keep pushing the `OprHandle` without repeatedly creating them:
+
 ```c++
-virtual void Push(OprHandle op, Context exec_ctx) = 0;
+    virtual void Push(OprHandle op, Context exec_ctx) = 0;
 ```
-To delete it, simply call `DeleteOperator(OprHandle op)`. But please make sure the operator has finished computing.
+To delete it, call the `DeleteOperator(OprHandle op)` API. Ensure that the operator has finished computing before calling this API.
 
 
 ### API Reference
 
 ```eval_rst
-.. doxygenclass:: mxnet::Engine
-   :members:
+    .. doxygenclass:: mxnet::Engine
+       :members:
 ```
 
 ## Operators in MXNet
 
-An operator in MXNet is a class that contains both actual computation logic and auxiliary informations that could aid our system to perform optimizations like in-place updates and auto-derivative. Before continue on this document, it is strongly recommended for you to first understand `mshadow` library, since all operators compute on tensor-like structure `mshadow::TBlob` provided by the system during runtime. MXNet's operator interface tries its best to offer users flexibility including:
+In MXNet, an operator is a class that contains both actual computation logic and auxiliary information that can aid the system in performing optimizations, like in-place updates and auto-derivatives. Before you continue with this document, we strongly recommend that you understand the `mshadow` library, because all operators compute on the tensor-like structure `mshadow::TBlob` provided by the system during runtime. 
+
+MXNet's operator interface allows you to:
+
 * Save memory allocation cost by specifying in-place updates.
-* Hide some internal arguments from python side to make it cleaner.
-* Define the relationships among input tensors and output tensors which allows system to perform shape check for you.
-* Acquire additional temporary spaces from system to perform computation (e.g. calling `cudnn` routines).
+* Hide some internal arguments from Python to make it cleaner.
+* Define the relationships among input tensors and output tensors, which allows the system to perform shape checking for you.
+* Acquire additional temporary spaces from the system to perform computation (e.g., calling `cudnn` routines).
 
 ### Operator Interface
 
-The core interface of operator is `Forward`:
-```c++
-virtual void Forward(const OpContext &ctx,
-                     const std::vector<TBlob> &in_data,
-                     const std::vector<OpReqType> &req,
-                     const std::vector<TBlob> &out_data,
-                     const std::vector<TBlob> &aux_states) = 0;
-```
-* The `OpContext` structure is like follows:
-  ```c++
-  struct OpContext {
-    int is_train;
-    RunContext run_ctx;
-    std::vector<Resource> requested;
-  }
-  ```
-  
-  , where you could get whether the operator is in train/test phase; which device the operator should be run on (in `run_ctx`) and requested resources (covered in the following sections).
-* `in_data` and `out_data` represent the input and output tensors respectively. All the tensor spaces have been allocated by the system.
-* `req` denotes how the computation results are written into the `out_data`. In other word, `req.size() == out_data.size()` and `req[i]` corresponds to the write type of `out_data[i]`. The `OpReqType` is defined as:
+`Forward` is the core operator interface:
 
-  ```c++
-  enum OpReqType {
-    kNullOp,
-    kWriteTo,
-    kWriteInplace,
-    kAddTo
-  };
-  ```
-  Normally, the types of all `out_data` should be `kWriteTo`, meaning the provided `out_data` tensor is a *raw* memory block so the operator should directly write results into it. In some cases, for example when calculating the `gradient` tensor, it would be great if we could accumulate the result rather than directly overwrite the tensor contents so no extra space need to be created each time. In such case, the corresponding `req` type will be set as `kAddTo`, indicating a `+=` should be called.
-* `aux_states` is intentionally designed for auxiliary tensors used to help computation. It is currently useless.
-
-Apart from `Forward` operator, user could also optionally implement `Backward` interface defined as follows:
 ```c++
-virtual void Backward(const OpContext &ctx,
-                      const std::vector<TBlob> &out_grad,
-                      const std::vector<TBlob> &in_data,
-                      const std::vector<TBlob> &out_data,
-                      const std::vector<OpReqType> &req,
-                      const std::vector<TBlob> &in_grad,
-                      const std::vector<TBlob> &aux_states);
+    virtual void Forward(const OpContext &ctx,
+                         const std::vector<TBlob> &in_data,
+                         const std::vector<OpReqType> &req,
+                         const std::vector<TBlob> &out_data,
+                         const std::vector<TBlob> &aux_states) = 0;
 ```
-The interface follows the design principle as `Forward` interface, except that `out_grad`, `in_data` and `out_data` are given and the operator should computes `in_grad` as results. The name strategy is similar to torch's convention and could be summarized in following figure:
+The `OpContext` structure is:
+
+```c++
+           struct OpContext {
+             int is_train;
+             RunContext run_ctx;
+             std::vector<Resource> requested;
+           }
+``` 
+It describes whether the operator is in the train or test phase, which device the operator should be run on (in `run_ctx`), and requested resources (covered in the following sections). 
+
+
+- `in_data` and `out_data` represent the input and output tensors, respectively. All of the tensor spaces have been allocated by the system.
+- `req` denotes how the computation results are written into the `out_data`. In other words, `req.size() == out_data.size()` and `req[i]` correspond to the write type of `out_data[i]`. 
+
+
+- The `OpReqType` is defined as:
+
+```c++
+           enum OpReqType {
+             kNullOp,
+             kWriteTo,
+             kWriteInplace,
+             kAddTo
+           };
+```
+  Normally, the types of all `out_data` should be `kWriteTo`, meaning that the provided `out_data` tensor is a *raw* memory block, so the operator should write results directly into it. In some cases, for example when calculating the `gradient` tensor, it would be great if we could accumulate the result, rather than directly overwrite the tensor contents so that  no extra space needs to be created each time. In such a case, the corresponding `req` type is set as `kAddTo`, indicating that a `+=` should be called.
+
+
+- `aux_states` is intentionally designed for auxiliary tensors used to help computation. Currently, it is useless.
+
+Aside from the `Forward` operator, you could optionally implement the `Backward` interface:
+
+```c++
+    virtual void Backward(const OpContext &ctx,
+                          const std::vector<TBlob> &out_grad,
+                          const std::vector<TBlob> &in_data,
+                          const std::vector<TBlob> &out_data,
+                          const std::vector<OpReqType> &req,
+                          const std::vector<TBlob> &in_grad,
+                          const std::vector<TBlob> &aux_states);
+```
+This interface follows the same design principle as the `Forward` interface, except that `out_grad`, `in_data`, and `out_data` are given, and the operator computes `in_grad` as the results. The naming strategy is similar to Torch's convention, and can be summarized in following figure:
 
 [input/output semantics figure]
 
-Some operator may not need all the `out_grad`, `in_data` and `out_data`. This could be specified by the `DeclareBackwardDependency` interface in `OperatorProperty`.
+Some operators might not need all of the following: `out_grad`, `in_data` and `out_data`. Specified this with the `DeclareBackwardDependency` interface in `OperatorProperty`.
 
 ### Operator Property
 
-It is possible that one convolution has several implementations and users want to switch among them to achieve best performance. Therefore, we separate the operator *semantic* interfaces from the implementation interface (`Operator` class) into `OperatorProperty` class. The `OperatorProperty` interface consists of:
+One convolution might have several implementations, and you might want to switch among them to achieve the best performance. Therefore, we separate the operator *semantic* interfaces from the implementation interface (`Operator` class) into the `OperatorProperty` class. The `OperatorProperty` interface consists of:
 
 * **InferShape:**
-  ```c++
-  virtual bool InferShape(std::vector<TShape> *in_shape,
-                          std::vector<TShape> *out_shape,
-                          std::vector<TShape> *aux_shape) const = 0;
-  ```
-  There are two purposes of this interface: (1) tell system the size of each input and output tensor, so it could allocate them before the `Forward` and `Backward` call; (2) do size check to make sure there is no obvious error before running. The shape in `in_shape` would be set by the system (from the `out_shape` of the previous operators). Return `false` when there is not enough information to interence shapes or throw error when the shape is inconsistent.
 
-* **Request Resources:** Operation like `cudnnConvolutionForward` need a workspace to help computation. It is would be nice if the system could manage that since the system then could do optimizations like reuse the space and so on. MXNet defines two interfaces to achieve this:
-  ```c++
-  virtual std::vector<ResourceRequest> ForwardResource(
-      const std::vector<TShape> &in_shape) const;
-  virtual std::vector<ResourceRequest> BackwardResource(
-      const std::vector<TShape> &in_shape) const;
-  ```
-  The `ResourceRequest` structure (in `resource.h`) currently contains only a type flag:
-  ```c++
-  struct ResourceRequest {
-    enum Type {
-      kRandom,  // get an mshadow::Random<xpu> object
-      kTempSpace,  // request temporary space
-    };
-    Type type;
-  };
-  ```
-  If the `ForwardResource` and `BackwardResource` return non-empty arrays, system will offer the corresponding resources through the `ctx` parameter in the `Forward` and `Backward` interface of `Operator`. Basically, to access those resources, simply write:
-  ```c++
-  auto tmp_space_res = ctx.requested[kTempSpace].get_space(some_shape, some_stream);
-  auto rand_res = ctx.requested[kRandom].get_random(some_stream);
-  ``` 
-  Please refer to `src/operator/cudnn_convolution-inl.h` for a concrete example.
+```c++
+           virtual bool InferShape(std::vector<TShape> *in_shape,
+                                   std::vector<TShape> *out_shape,
+                                   std::vector<TShape> *aux_shape) const = 0;
+```
+  This interface has two purposes: 1. Tell the system the size of each input and output tensor, so it can allocate space for them before the `Forward` and `Backward` call; 2. Perform a size check to make sure that there isn't an obvious error before running. The shape in `in_shape` is set by the system (from the `out_shape` of the previous operators). It returns `false` when there is not enough information to infer shapes or throws an error when the shape is inconsistent.
 
-* **Backward dependency:** Let us first see two different operator signatures (we name all the arguments for demonstration purpose):
-  ```c++
-  void FullyConnectedForward(TBlob weight, TBlob in_data, TBlob out_data);
-  void FullyConnectedBackward(TBlob weight, TBlob in_data, TBlob out_grad, TBlob in_grad);
-
-  void PoolingForward(TBlob in_data, TBlob out_data);
-  void PoolingBackward(TBlob in_data, TBlob out_data, TBlob out_grad, TBlob in_grad);
-  ```
-  Note that the `out_data` in `FullyConnectedForward` is not used by `FullyConnectedBackward` while `PoolingBackward` requires all the arguments of `PoolingForward`. Therefore, for `FullyConnectedForward`, the `out_data` tensor once consumed by its consumers could be safely freed since backward function will not need it. This provides a chance for system to garbage collect some tensors as soon as possible. To specify this situation, we provide an interface:
-  ```c++
-  virtual std::vector<int> DeclareBackwardDependency(
-      const std::vector<int> &out_grad,
-      const std::vector<int> &in_data,
-      const std::vector<int> &out_data) const;
-  ```
-  The `int` element of the argument vector is an id to distinguish different arrays. Let us see how this interface specifies different dependencies for `FullyConnected` and `Pooling`:
-  ```c++
-  std::vector<int> FullyConnectedProperty::DeclareBackwardDependency(
-      const std::vector<int> &out_grad,
-      const std::vector<int> &in_data,
-      const std::vector<int> &out_data) const {
-    return {out_grad[0], in_data[0]};  // NOTE: out_data[0] is NOT included
-  }
-  std::vector<int> PoolingProperty::DeclareBackwardDependency(
-      const std::vector<int> &out_grad,
-      const std::vector<int> &in_data,
-      const std::vector<int> &out_data) const {
-    return {out_grad[0], in_data[0], out_data[0]};
-  }
-  ```
-
-* **Inplace Option:** To further save memory allocation cost, in-place update are welcomed. This usually happens for element-wise operations when input tensor and output tensor are of the same shape. This could be specified by the following interface:
-  ```c++
-  virtual std::vector<std::pair<int, void*>> ElewiseOpProperty::ForwardInplaceOption(
-      const std::vector<int> &in_data,
-      const std::vector<void*> &out_data) const {
-    return { {in_data[0], out_data[0]} };
-  }
-  virtual std::vector<std::pair<int, void*>> ElewiseOpProperty::BackwardInplaceOption(
-      const std::vector<int> &out_grad,
-      const std::vector<int> &in_data,
-      const std::vector<int> &out_data,
-      const std::vector<void*> &in_grad) const {
-    return { {out_grad[0], in_grad[0]} }
-  }
-  ```
-  The above tells the system the `in_data[0]` and `out_data[0]` tensors could share the same memory spaces during `Forward`, and so do `out_grad[0]` and `in_grad[0]` during `Backward`.
+* **Request Resources:** Operations like `cudnnConvolutionForward` need a work space for computation. If the system can manage that, it could then perform optimizations, like reuse the space, and so on. MXNet defines two interfaces to achieve this:
   
-  >**ATTENTION:** Even with the above specification, it is *not* guaranteed that input and output tensors will share the same space. In fact, this is only a hint for the system for the final decision. However, in either case, such decision is completely transparent to user, so the actual `Forward` and `Backward` implementation does not need to consider that.
+```c++
+           virtual std::vector<ResourceRequest> ForwardResource(
+               const std::vector<TShape> &in_shape) const;
+           virtual std::vector<ResourceRequest> BackwardResource(
+               const std::vector<TShape> &in_shape) const;
+```
+  The `ResourceRequest` structure (in `resource.h`) currently contains only a type flag:
 
-* **Expose Operator to Python:** Due to the restriction of c++ language, we need user to implement following interfaces:
-  ```c++
-  // initial the property class from a list of key-value string pairs
-  virtual void Init(const vector<pair<string, string>> &kwargs) = 0;
-  // return the parameters in a key-value string map
-  virtual map<string, string> GetParams() const = 0;
-  // return the name of arguments (for generating signature in python)
-  virtual vector<string> ListArguments() const;
-  // return the name of output values
-  virtual vector<string> ListOutputs() const;
-  // return the name of auxiliary states
-  virtual vector<string> ListAuxiliaryStates() const;
-  // return the number of output values
-  virtual int NumOutputs() const;
-  // return the number of visible outputs
-  virtual int NumVisibleOutputs() const;
-  ```
+```c++
+           struct ResourceRequest {
+             enum Type {
+               kRandom,  // get an mshadow::Random<xpu> object
+               kTempSpace,  // request temporay space
+             };
+             Type type;
+           };
+```
+  If `ForwardResource` and `BackwardResource` return non-empty arrays, the system offers the corresponding resources through the `ctx` parameter in the `Forward` and `Backward` interface of `Operator`. Basically, to access those resources, simply write:
 
-### Create Operator from Operator Property
+```c++
+           auto tmp_space_res = ctx.requested[kTempSpace].get_space(some_shape, some_stream);
+           auto rand_res = ctx.requested[kRandom].get_random(some_stream);
+``` 
+  For an example, see `src/operator/cudnn_convolution-inl.h`.
 
-As mentioned above, `OperatorProperty` includes all *semantic* attributes of an operation. It is also in charge of creating `Operator` pointer for actual computation.
+* **Backward dependency:** Let's look at two different operator signatures (we name all of the arguments for demonstration purposes):
+
+```c++
+           void FullyConnectedForward(TBlob weight, TBlob in_data, TBlob out_data);
+           void FullyConnectedBackward(TBlob weight, TBlob in_data, TBlob out_grad, TBlob in_grad);
+
+           void PoolingForward(TBlob in_data, TBlob out_data);
+           void PoolingBackward(TBlob in_data, TBlob out_data, TBlob out_grad, TBlob in_grad);
+```
+  Note that `out_data` in `FullyConnectedForward` is not used by `FullyConnectedBackward`, while `PoolingBackward` requires all of the arguments of `PoolingForward`. Therefore, for `FullyConnectedForward`, the `out_data` tensor once consumed could be safely freed because the backward function will not need it. This provides a chance for the system to collect some tensors as garbage as soon as possible. To specify this situation, we provide an interface:
+  
+```c++
+          virtual std::vector<int> DeclareBackwardDependency(
+               const std::vector<int> &out_grad,
+               const std::vector<int> &in_data,
+               const std::vector<int> &out_data) const;
+```
+  The `int` element of the argument vector is an ID to distinguish different arrays. Let's see how this interface specifies different dependencies for `FullyConnected` and `Pooling`:
+  
+ ```c++
+           std::vector<int> FullyConnectedProperty::DeclareBackwardDependency(
+               const std::vector<int> &out_grad,
+               const std::vector<int> &in_data,
+               const std::vector<int> &out_data) const {
+             return {out_grad[0], in_data[0]};  // NOTE: out_data[0] is NOT included
+           }
+           std::vector<int> PoolingProperty::DeclareBackwardDependency(
+               const std::vector<int> &out_grad,
+               const std::vector<int> &in_data,
+               const std::vector<int> &out_data) const {
+             return {out_grad[0], in_data[0], out_data[0]};
+           }
+```
+
+* **Inplace Option:** To further save the cost of memory allocation, you can use in-place updates. They are appropriate for element-wise operations when the input tensor and output tensor have the same shape. You specify and in-place update with the following interface:
+  
+```c++
+           virtual std::vector<std::pair<int, void*>>    ElewiseOpProperty::ForwardInplaceOption(
+               const std::vector<int> &in_data,
+               const std::vector<void*> &out_data) const {
+             return { {in_data[0], out_data[0]} };
+           }
+           virtual std::vector<std::pair<int, void*>> ElewiseOpProperty::BackwardInplaceOption(
+               const std::vector<int> &out_grad,
+               const std::vector<int> &in_data,
+               const std::vector<int> &out_data,
+               const std::vector<void*> &in_grad) const {
+             return { {out_grad[0], in_grad[0]} }
+           }
+```
+  This tells the system that the `in_data[0]` and `out_data[0]` tensors could share the same memory spaces during `Forward`, and so do `out_grad[0]` and `in_grad[0]` during `Backward`.
+  
+  >**Important:** Even if you use the preceding specification, it's *not* guaranteed that the input and output tensors will share the same space. In fact, this is only a suggestion for the system, which makes the final decision. However, in either case, the decision is completely transparent to you, so the actual `Forward` and `Backward` implementation does not need to consider that.
+
+* **Expose Operator to Python:** Because of the restrictions of C++, you need user to implement following interfaces:
+
+```c++
+           // initial the property class from a list of key-value string pairs
+           virtual void Init(const vector<pair<string, string>> &kwargs) = 0;
+           // return the parameters in a key-value string map
+           virtual map<string, string> GetParams() const = 0;
+           // return the name of arguments (for generating signature in python)
+           virtual vector<string> ListArguments() const;
+           // return the name of output values
+           virtual vector<string> ListOutputs() const;
+           // return the name of auxiliary states
+           virtual vector<string> ListAuxiliaryStates() const;
+           // return the number of output values
+           virtual int NumOutputs() const;
+           // return the number of visible outputs
+           virtual int NumVisibleOutputs() const;
+```
+
+### Create an Operator from the Operator Property
+
+ `OperatorProperty` includes all *semantical* attributes of an operation. It's also responsible for creating the `Operator` pointer for actual computation.
 
 #### Create Operator
-Implement following interface in `OperatorProperty`:
+Implement the following interface in `OperatorProperty`:
+
 ```c++
-virtual Operator* CreateOperator(Context ctx) const = 0;
+    virtual Operator* CreateOperator(Context ctx) const = 0;
 ```
 For example:
+
 ```c++
-class ConvolutionOp {
- public:
-  void Forward( ... ) { ... }
-  void Backward( ... ) { ... }
-};
-class ConvolutionOpProperty : public OperatorProperty {
- public:
-  Operator* CreateOperator(Context ctx) const {
-    return new ConvolutionOp;
-  }
-};
+    class ConvolutionOp {
+     public:
+      void Forward( ... ) { ... }
+      void Backward( ... ) { ... }
+    };
+    class ConvolutionOpProperty : public OperatorProperty {
+     public:
+      Operator* CreateOperator(Context ctx) const {
+        return new ConvolutionOp;
+      }
+    };
 ```
 
 #### Parametrize Operator
-When implementing convolution operator, we need to know the kernal size, the stride size, padding size and so on. These parameters should be passed to the operator before any `Forward` or `Backward` interface is called. To do so, user could define a `ConvolutionParam` structure:
+When implementing a convolution operator, you need to know the kernel size, the stride size, padding size, and so on. These parameters should be passed to the operator before any `Forward` or `Backward` interface is called. To do so, you could define a `ConvolutionParam` structure, as follows:
+
 ```c++
-#include <dmlc/parameter.h>
-struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
-  TShape kernel, stride, pad;
-  uint32_t num_filter, num_group, workspace;
-  bool no_bias;
-};
+    #include <dmlc/parameter.h>
+    struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
+      TShape kernel, stride, pad;
+      uint32_t num_filter, num_group, workspace;
+      bool no_bias;
+    };
 ```
-Put it in `ConvolutionOpProperty` and pass it to the operator class during construction:
+Put it in `ConvolutionOpProperty`, and pass it to the operator class during construction:
+
 ```c++
-class ConvolutionOp {
- public:
-  ConvolutionOp(ConvolutionParam p): param_(p) {}
-  void Forward( ... ) { ... }
-  void Backward( ... ) { ... }
- private:
-  ConvolutionParam param_;
-};
-class ConvolutionOpProperty : public OperatorProperty {
- public:
-  void Init(const vector<pair<string, string>& kwargs) {
-    // initialize param_ using kwargs
-  }
-  Operator* CreateOperator(Context ctx) const {
-    return new ConvolutionOp(param_);
-  }
- private:
-  ConvolutionParam param_;
-};
+    class ConvolutionOp {
+     public:
+      ConvolutionOp(ConvolutionParam p): param_(p) {}
+      void Forward( ... ) { ... }
+      void Backward( ... ) { ... }
+     private:
+      ConvolutionParam param_;
+    };
+    class ConvolutionOpProperty : public OperatorProperty {
+     public:
+      void Init(const vector<pair<string, string>& kwargs) {
+        // initialize param_ using kwargs
+      }
+      Operator* CreateOperator(Context ctx) const {
+        return new ConvolutionOp(param_);
+      }
+     private:
+      ConvolutionParam param_;
+    };
 ```
 
-#### Register Operator to MXNet
-Use following macros to register the parameter structure and the operator property class to MXNet system:
+#### Register the Operator Property Class and the Parameter Class to MXNet
+Use following macros to register the parameter structure and the operator property class to MXNet:
+
 ```c++
-DMLC_REGISTER_PARAMETER(ConvolutionParam);
-MXNET_REGISTER_OP_PROPERTY(Convolution, ConvolutionOpProperty);
+    DMLC_REGISTER_PARAMETER(ConvolutionParam);
+    MXNET_REGISTER_OP_PROPERTY(Convolution, ConvolutionOpProperty);
 ```
-The first argument to the macro is the name string, the second is the property class name.
+The first argument is the name string, the second is the property class name.
 
-### All in a list
+### Interface Summary
 
-Finally! We almost covered the interface we needed to define a new operator. Let's do a recap in a list:
-* Use `Operator` interface to write your actual computation logic (`Forward` and `Backward`).
-* Use `OperatorProperty` interface to:
-  - Pass parameter to operator class (may use `Init` interface).
-  - Create operator using `CreateOperator` interface.
-  - Correctly implement the operator description interface such as the names of arguments, etc.
+We've almost covered the entire interface required to define a new operator. Let's do a recap:
+
+* Use the `Operator` interface to write your computation logic (`Forward` and `Backward`).
+* Use the `OperatorProperty` interface to:
+  - Pass the parameter to the operator class (you can use the `Init` interface).
+  - Create an operator using the `CreateOperator` interface.
+  - Correctly implement the operator description interface, such as the names of arguments, etc.
   - Correctly implement the `InferShape` interface to set the output tensor shape.
   - [Optional] If additional resources are needed, check `ForwardResource` and `BackwardResource`.
-  - [Optional] If `Backward` does not need all the input and output of `Forward`, check `DeclareBackwardDependency`.
-  - [Optional] If inplace update is supported, check `ForwardInplaceOption` and `BackwardInplaceOption`.
+  - [Optional] If `Backward` doesn't need all of the input and output of `Forward`, check `DeclareBackwardDependency`.
+  - [Optional] If in-place update is supported, check `ForwardInplaceOption` and `BackwardInplaceOption`.
 * Register the `OperatorProperty` class and the parameter class.
 
-## Unifying NDArray Operator and Symbolic Operator : How does it work
-NDArray operations are similar to symbolic operations except the fact that sometimes we 
-cannot write in place to the operands without a complete dependency graph. However, the 
-logics underlying NDArray and Symbolic operation are almost the same. Unifying different 
-invoking process and returning to the fundamental elements of operators are the purpose of 
-**SimpleOp**, a new unified operator API. Because most mathematical operators attend to one or two 
-operands and more operands make dependency-related optimization useful, the unified operator 
-are specially designed for unary and binary operations.
+## Unifying the NDArray Operator and Symbolic Operator 
+NDArray operations are similar to symbolic operations, except that sometimes you 
+can't write in place to the operands without a complete dependency graph. However, the 
+logic underlying NDArray and symbolic operations is almost identical. *SimpleOp*, a new unified operator API, unifies different 
+invoking processes and returns to the fundamental elements of operators. Because most mathematical operators attend to one or two 
+operands, and more operands make dependency-related optimization useful, the unified operator 
+is specifically designed for unary and binary operations.
 
-Consider elements of an operation. Ideally, functions and derivatives are all we need to 
-describe an operation. Let us restrict that to the space of unary and binary operations. How 
-do we classify all operations to maximize the possibility of inplace write optimization? Note 
-that functions can be separate out by the number of operands. Derivatives are a bit more 
-complex. Whether output value, input data or neither are needed alongside head gradient is 
-crucial to construct a dependency graph. Gradient functions in the unified API is thus 
-differentiated through the types of operands it takes for calculation.
+Consider the elements of an operation. Ideally, you need only functions and derivatives to  
+describe an operation. Let's restrict that to the space of unary and binary operations. How 
+do we classify all operations to maximize the possibility of in-place write optimization? Note 
+that you can separate functions by the number of operands. Derivatives are a bit more 
+complex. To construct a dependency graph, you need to know whether output value, input data, or neither are needed alongside head gradient. Gradient functions in the unified API are  
+differentiated by the types of operands it takes for calculation.
 
-Before we continue on the SimpleOp interface, it is recommend to take a look at the [mshadow
-library guide](https://github.com/dmlc/mshadow/tree/master/guide) since actual calculations 
-will be done in `mshadow::TBlob` structure.
+Before you learn more about the SimpleOp interface, we recommend that you review the [mshadow
+library guide](https://github.com/dmlc/mshadow/tree/master/guide) because  calculations 
+will be done in the `mshadow::TBlob` structure.
 
-In this example, we will create a operator functioning as smooth l1 loss, which is a mixture 
+In the following example, we'll create an operator functioning as smooth l1 loss, which is a mixture 
 of l1 loss and l2 loss. The loss itself can be written as:
+
 ```
-loss = outside_weight .* f(inside_weight .* (data - label))
-grad = outside_weight .* inside_weight .* f'(inside_weight .* (data - label))
+    loss = outside_weight .* f(inside_weight .* (data - label))
+    grad = outside_weight .* inside_weight .* f'(inside_weight .* (data -    label))
 ```
-where `.*` stands for element wise multiplication and `f`, `f'` is the smooth l1 loss function, 
-which we suppose we have in `mshadow` for now. At first glance, it is impossible to implement 
-this particular loss as an unary or binary operator. But we have automatic differentiation in 
-the symbolic execution. That would simplify the loss to `f` and `f'` directly. In this way, this 
-loss is no more complex than a `sin` or a `abs` function and can certainly be implemented as a 
+ `.*` stands for element-wise multiplication, and `f`, `f'` is the smooth l1 loss function, 
+which we are assuming is in `mshadow` for now. At first glance, it's impossible to implement 
+this particular loss as an unary or binary operator. But we have automatic differentiation in symbolic execution. That simplifies the loss to `f` and `f'` directly. This 
+loss is no more complex than a `sin` or a `abs` function, and can certainly be implemented as a 
 unary operator.
 
-## SimpleOp: the Unified Operator API
+## SimpleOp: The Unified Operator API
 ### Define Shapes
-`mshadow` library require explicit memory allocation. As a consequence, all data shape
-must be provided before any calculation. Before we proceed to define functions and gradient, 
-we would like to check input data shape consistency and provide output shape.
-```cpp
-typedef TShape (*UnaryShapeFunction)(const TShape& src,
-                                     const EnvArguments& env);
-typedef TShape (*BinaryShapeFunction)(const TShape& lhs,
-                                      const TShape& rhs,
-                                      const EnvArguments& env);
-```
-We can use `mshadow::TShape` to check input data shape and designate the output data shape.
-When this function is not defined, the default output shape will be the same as input shape.
-In the case of binary operator, the shape of `lhs` and `rhs` is checked to be the same by default.
+The `mshadow` library requires explicit memory allocation. As a consequence, all data shapes
+must be provided before any calculation occurs. Before we proceed with defining functions and gradient, 
+let's check input data shape consistency and provide output shape.
 
-Shape functions can also be used to check if any additional arguments and resources are present.
-Please refer to additional usages on `EnvArguments` to achieve this aim.
+```cpp
+    typedef TShape (*UnaryShapeFunction)(const TShape& src,
+                                         const EnvArguments& env);
+    typedef TShape (*BinaryShapeFunction)(const TShape&                                         const TShape& rhs,lhs,
+  
+                                          const EnvArguments& env);
+```
+You can use `mshadow::TShape` to check input data shape and designate output data shape.
+If you don't define this function, the default output shape is the same as the input shape.
+In the case of binary operator, the shape of `lhs` and `rhs` is checked as the same by default.
+
+You can also use shape functions to check if any additional arguments and resources are present.
+Refer to the additional usages of `EnvArguments` to accomplish this.
 
 Before we start on our smooth l1 loss example, we define a `XPU` to `cpu` or `gpu` in the header 
 `smooth_l1_unary-inl.h` implementation so that we reuse the same code in `smooth_l1_unary.cc` and 
 `smooth_l1_unary.cu`.
-```cpp
-#include <mxnet/operator_util.h>
-#if defined(__CUDACC__)
-#define XPU gpu
-#else
-#define XPU cpu
-#endif
-```
 
-In our smooth l1 loss example, it is okay for the default behavior of same output shape as source. 
-Written explicitly, it is 
 ```cpp
-inline TShape SmoothL1Shape_(const TShape& src,
-                             const EnvArguments& env) {
-  return TShape(src);
+    #include <mxnet/operator_util.h>
+    #if defined(__CUDACC__)
+    #define XPU gpu
+    #else
+    #define XPU cpu
+    #endif
+```
+In our smooth l1 loss example, it's okay to use the default behavior whereby the output has the same shape as the source. 
+Written explicitly, it is:
+ 
+```cpp
+    inline TShape SmoothL1Shape_(const TShape& src,
+                                 const EnvArguments& env) {
+      return TShape(src);
 ```
 
 ### Define Functions
-Create an unary or binary function with one output `mshadow::TBlob`.
+Create a unary or binary function with one output: `mshadow::TBlob`.
+
 ```cpp
-typedef void (*UnaryFunction)(const TBlob& src,
-                              const EnvArguments& env,
-                              TBlob* ret,
-                              OpReqType req,
-                              RunContext ctx);
-typedef void (*BinaryFunction)(const TBlob& lhs,
-                               const TBlob& rhs,
-                               const EnvArguments& env,
-                               TBlob* ret,
-                               OpReqType req,
-                               RunContext ctx);
+    typedef void (*UnaryFunction)(const TBlob& src,
+                                  const EnvArguments& env,
+                                  TBlob* ret,
+                                  OpReqType req,
+                                  RunContext ctx);
+    typedef void (*BinaryFunction)(const TBlob& lhs,
+                                   const TBlob& rhs,
+                                   const EnvArguments& env,
+                                   TBlob* ret,
+                                   OpReqType req,
+                                   RunContext ctx);
 ```
 * Functions are differentiated by the types of input arguments.
-* `RunContext ctx` contains information needed in runtime for actual execution.
+* `RunContext ctx` contains information needed during runtime for execution.
 
-  ```cpp
-  struct RunContext {
-    void *stream;  // the stream of the device, can be NULL or Stream<gpu>* in GPU mode
-    template<typename xpu> inline mshadow::Stream<xpu>* get_stream() // get mshadow stream from Context
-  }  // namespace mxnet
-  ```
+```cpp
+        struct RunContext {
+          void *stream;  // the stream of the device, can be NULL or Stream<gpu>* in GPU mode
+          template<typename xpu> inline mshadow::Stream<xpu>* get_stream() // get mshadow stream from Context
+        }  // namespace mxnet
+```
   `mshadow::stream<xpu> *s = ctx.get_stream<xpu>();` is an example of obtaining a stream from `ctx`.
 * `OpReqType req` denotes how computation results are written into `ret`.
 
-  ```cpp
-  enum OpReqType {
-    kNullOp,  // no operation, do not write anything
-    kWriteTo,  // write gradient to provided space
-    kWriteInplace,  // perform an inplace write
-    kAddTo  // add to the provided space
-  };
-  ```
-  There is a macro defined in `operator_util.h` for a simplified use of `OpReqType`. 
-  `ASSIGN_DISPATCH(out, req, exp)` will check `req` and perform an assignment.
+```cpp
+        enum OpReqType {
+          kNullOp,  // no operation, do not write anything
+          kWriteTo,  // write gradient to provided space
+          kWriteInplace,  // perform an inplace write
+          kAddTo  // add to the provided space
+        };
+```
+  A macro is defined in `operator_util.h` for a simplified use of `OpReqType`. 
+  `ASSIGN_DISPATCH(out, req, exp)` checks `req` and performs an assignment.
 
 In our smooth l1 loss example, we use `UnaryFunction` to define the function of this operator.
+
 ```cpp
-template<typename xpu>
-void SmoothL1Forward_(const TBlob& src,
-                      const EnvArguments& env,
-                      TBlob *ret,
-                      OpReqType req,
-                      RunContext ctx) {
-  using namespace mshadow;
-  using namespace mshadow::expr;
-  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  real_t sigma2 = env.scalar * env.scalar;
-  MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
-    mshadow::Tensor<xpu, 2, DType> out = ret->get<xpu, 2, DType>(s);
-    mshadow::Tensor<xpu, 2, DType> in = src.get<xpu, 2, DType>(s);
-    ASSIGN_DISPATCH(out, req,
-                    F<mshadow_op::smooth_l1_loss>(in, ScalarExp<DType>(sigma2)));
-  });
-}
+    template<typename xpu>
+    void SmoothL1Forward_(const TBlob& src,
+                          const EnvArguments& env,
+                          TBlob *ret,
+                          OpReqType req,
+                          RunContext ctx) {
+      using namespace mshadow;
+      using namespace mshadow::expr;
+      mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+      real_t sigma2 = env.scalar * env.scalar;
+      MSHADOW_TYPE_SWITCH(ret->type_flag_, DType, {
+        mshadow::Tensor<xpu, 2, DType> out = ret->get<xpu, 2, DType>(s);
+        mshadow::Tensor<xpu, 2, DType> in = src.get<xpu, 2, DType>(s);
+        ASSIGN_DISPATCH(out, req,
+                        F<mshadow_op::smooth_l1_loss>(in, ScalarExp<DType>(sigma2)));
+      });
+    }
 ```
 After obtaining `mshadow::Stream` from `RunContext`, we get `mshadow::Tensor` from `mshadow::TBlob`. 
-`mshadow::F` is a shortcut to initiate a `mshadow` expression. The macro `MSHADOW_TYPE_SWITCH(type, DType, ...)` 
-handles details on different types and the macro `ASSIGN_DISPATCH(out, req, exp)` checks `OpReqType` and 
-performs actions accordingly. `sigma2` is a special parameter in this loss, which we will cover in additional usages. 
+`mshadow::F` is a shortcut to initiate an `mshadow` expression. The macro `MSHADOW_TYPE_SWITCH(type, DType, ...)` 
+handles details on different types, and the macro `ASSIGN_DISPATCH(out, req, exp)` checks `OpReqType` and 
+performs actions accordingly. `sigma2` is a special parameter in this loss, which we will cover later. 
 
-### Define Gradients (optional)
+### Define Gradients (Optional)
 Create a gradient function with various types of inputs.
+
 ```cpp
-// depending only on out_grad
-typedef void (*UnaryGradFunctionT0)(const OutputGrad& out_grad,
-                                    const EnvArguments& env,
-                                    TBlob* in_grad,
-                                    OpReqType req,
-                                    RunContext ctx);
-// depending only on out_value
-typedef void (*UnaryGradFunctionT1)(const OutputGrad& out_grad,
-                                    const OutputValue& out_value,
-                                    const EnvArguments& env,
-                                    TBlob* in_grad,
-                                    OpReqType req,
-                                    RunContext ctx);
-// depending only on in_data
-typedef void (*UnaryGradFunctionT2)(const OutputGrad& out_grad,
-                                    const Input0& in_data0,
-                                    const EnvArguments& env,
-                                    TBlob* in_grad,
-                                    OpReqType req,
-                                    RunContext ctx);
+    // depending only on out_grad
+    typedef void (*UnaryGradFunctionT0)(const OutputGrad& out_grad,
+                                        const EnvArguments& env,
+                                        TBlob* in_grad,
+                                        OpReqType req,
+                                        RunContext ctx);
+    // depending only on out_value
+    typedef void (*UnaryGradFunctionT1)(const OutputGrad& out_grad,
+                                        const OutputValue& out_value,
+                                        const EnvArguments& env,
+                                        TBlob* in_grad,
+                                        OpReqType req,
+                                         RunContext ctx);
+    // depending only on in_data
+    typedef void (*UnaryGradFunctionT2)(const OutputGrad& out_grad,
+                                        const Input0& in_data0,
+                                        const EnvArguments& env,
+                                        TBlob* in_grad,
+                                        OpReqType req,
+                                        RunContext ctx);
 ```
-Gradient functions of binary operator have similar structures except `Input`, `TBlob`, `OpReqType`
+Gradient functions of binary operators have similar structures, except that `Input`, `TBlob`, and `OpReqType`
 are doubled.
-* `GradFunctionArgument`
-  The `Input0`, `Input`, `OutputValue` and `OutputGrad` all share the structure of `GradFunctionArgument`, 
+
+`GradFunctionArgument`
+
+  `Input0`, `Input`, `OutputValue`, and `OutputGrad` all share the structure of `GradFunctionArgument`, 
   which is defined as:
+
   ```cpp
-  struct GradFunctionArgument {
-      TBlob data;
-  }
+      struct GradFunctionArgument {
+          TBlob data;
+      }
   ```
 
-In our smooth l1 loss example, note that it is a `f'(x)`, which utilize input for gradient calculation, 
-so the `UnaryGradFunctionT2` is suitable. To enable chain rule of gradient, we also need to multiply 
-`out_grad` from top to the result of `in_grad`. 
+In our smooth l1 loss example, note that it's an `f'(x)`, which utilizes input for the gradient calculation, 
+so the `UnaryGradFunctionT2` is suitable. To enable the chain rule of gradient, we also need to multiply 
+`out_grad` from the top to the result of `in_grad`.
+ 
 ```cpp
-template<typename xpu>
-void SmoothL1BackwardUseIn_(const OutputGrad& out_grad,
-                            const Input0& in_data0,
-                            const EnvArguments& env,
-                            TBlob *in_grad,
-                            OpReqType req,
-                            RunContext ctx) {
-  using namespace mshadow;
-  using namespace mshadow::expr;
-  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  real_t sigma2 = env.scalar * env.scalar;
-  MSHADOW_TYPE_SWITCH(in_grad->type_flag_, DType, {
-    mshadow::Tensor<xpu, 2, DType> src = in_data0.data.get<xpu, 2, DType>(s);
-    mshadow::Tensor<xpu, 2, DType> ograd = out_grad.data.get<xpu, 2, DType>(s);
-    mshadow::Tensor<xpu, 2, DType> igrad = in_grad->get<xpu, 2, DType>(s);
-    ASSIGN_DISPATCH(igrad, req,
-                    ograd * F<mshadow_op::smooth_l1_gradient>(src, ScalarExp<DType>(sigma2)));
-  });
-}
+    template<typename xpu>
+    void SmoothL1BackwardUseIn_(const OutputGrad& out_grad,
+                                const Input0& in_data0,
+                                const EnvArguments& env,
+                                TBlob *in_grad,
+                                OpReqType req,
+                                RunContext ctx) {
+      using namespace mshadow;
+      using namespace mshadow::expr;
+      mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+      real_t sigma2 = env.scalar * env.scalar;
+      MSHADOW_TYPE_SWITCH(in_grad->type_flag_, DType, {
+        mshadow::Tensor<xpu, 2, DType> src = in_data0.data.get<xpu, 2, DType>(s);
+        mshadow::Tensor<xpu, 2, DType> ograd = out_grad.data.get<xpu, 2, DType>(s);
+        mshadow::Tensor<xpu, 2, DType> igrad = in_grad->get<xpu, 2, DType>(s);
+         ASSIGN_DISPATCH(igrad, req,
+                        ograd * F<mshadow_op::smooth_l1_gradient>(src, ScalarExp<DType>(sigma2)));
+      });
+    }
 ```
 
 ### Register SimpleOp to MXNet
-After creating shape, function and gradient, it is sufficient to restore them into both NDArray operator and 
-Symbolic operator. There is a registration macro defined in `operator_util.h` to simplify this process.
+After creating the shape, function, and gradient, restore them into both an NDArray operator and 
+a symbolic operator. To simplify this process, use the registration macro defined in `operator_util.h`.
+
 ```cpp
-MXNET_REGISTER_SIMPLE_OP(Name, DEV)
-.set_shape_function(Shape)
-.set_function(DEV::kDevMask, Function<XPU>, SimpleOpInplaceOption)
-.set_gradient(DEV::kDevMask, Gradient<XPU>, SimpleOpInplaceOption)
-.describe("description");
+    MXNET_REGISTER_SIMPLE_OP(Name, DEV)
+    .set_shape_function(Shape)
+    .set_function(DEV::kDevMask, Function<XPU>, SimpleOpInplaceOption)
+    .set_gradient(DEV::kDevMask, Gradient<XPU>, SimpleOpInplaceOption)
+    .describe("description");
 ```
 `SimpleOpInplaceOption` is defined as:
+
 ```cpp
-enum SimpleOpInplaceOption {
-  kNoInplace,  // do not allow inplace in arguments
-  kInplaceInOut,  // allow inplace in with out (unary)
-  kInplaceOutIn,  // allow inplace out_grad with in_grad (unary)
-  kInplaceLhsOut,  // allow inplace left operand with out (binary)
-  kInplaceOutLhs  // allow inplace out_grad with lhs_grad (binary)
-};
+    enum SimpleOpInplaceOption {
+      kNoInplace,  // do not allow inplace in arguments
+      kInplaceInOut,  // allow inplace in with out (unary)
+      kInplaceOutIn,  // allow inplace out_grad with in_grad (unary)
+      kInplaceLhsOut,  // allow inplace left operand with out (binary)
+      kInplaceOutLhs  // allow inplace out_grad with lhs_grad (binary)
+    };
 ```
 
-In our example, we have a gradient function that relies on input data, so the function can not be written in 
-place. The output gradient is useless after gradient computation, so the gradient can be written inplace. 
+In our example, we have a gradient function that relies on input data, so the function can't be written in 
+place. The output gradient has no purpose after gradient computation, so the gradient can be written in place.
+ 
 ```cpp
-MXNET_REGISTER_SIMPLE_OP(smooth_l1, XPU)
-.set_function(XPU::kDevMask, SmoothL1Forward_<XPU>, kNoInplace)
-.set_gradient(XPU::kDevMask, SmoothL1BackwardUseIn_<XPU>, kInplaceOutIn)
-.set_enable_scalar(true)
-.describe("Calculate Smooth L1 Loss(lhs, scalar)");
+    MXNET_REGISTER_SIMPLE_OP(smooth_l1, XPU)
+    .set_function(XPU::kDevMask, SmoothL1Forward_<XPU>, kNoInplace)
+    .set_gradient(XPU::kDevMask, SmoothL1BackwardUseIn_<XPU>, kInplaceOutIn)
+    .set_enable_scalar(true)
+    .describe("Calculate Smooth L1 Loss(lhs, scalar)");
 ```
-Remember from shape functions that a default behavior without `set_shape_function` will be forcing the inputs 
-(if binary) to be of the same shape and yield the same shape for output. The `set_enable_scalar` will be 
-discussed in additional information.
+Remember from the discussion of shape functions that a default behavior without `set_shape_function` forces the inputs 
+(if they're binary) to be the same shape and yield the same shape for output. We'll discuss `set_enable_scalar` later.
 
-### All in a List
-* Create a shape function for determining the output shape
-* Create a function as the forward routine by choosing a suitable function type
-* Create a gradient as the backward routine by choosing a suitable gradient type
-* Register the operator using registration process
+### NDArray Operator Summary
+* Create a shape function for determining the output shape.
+* Create a function as the forward routine by choosing a suitable function type.
+* Create a gradient as the backward routine by choosing a suitable gradient type.
+* Register the operator using the registration process.
 
 ## Additional Information on SimpleOp
-### Usage on `EnvArguments`
-Some operations may need a scalar as input, such as gradient scale, a set of keyword arguments 
-controlling behavior or a temporary space to speed up calculations.
-`EnvArguments` provide additional arguments and resources to make calculations more scalable 
+### Using SimpleOp on EnvArguments
+Some operations might need a scalar as input, such as a  gradient scale, a set of keyword arguments 
+controlling behavior, or a temporary space to speed up calculations.`EnvArguments` provides additional arguments and resources to make calculations more scalable 
 and efficient.
+
 ```cpp
-struct EnvArguments {
-  real_t scalar;  // scalar argument, if enabled
-  std::vector<std::pair<std::string, std::string> > kwargs;  // keyword arguments
-  std::vector<Resource> resource;  // pointer to the resources requested
-};
+    struct EnvArguments {
+      real_t scalar;  // scalar argument, if enabled
+      std::vector<std::pair<std::string, std::string> > kwargs;  // keyword arguments
+      std::vector<Resource> resource;  // pointer to the resources requested
+    };
 ```
 
-More registration parameters are required to enable these additional features. `scalar` and `kwargs` 
-can not be present at the same time to prevent confusions on parameters. To enable `scalar`, use 
-`set_enable_scalar(bool enable_scalar)` in registration. Then in forward function and gradients, 
-this `scalar` can be accessed from `env.scalar` as in function parameter `EnvArguments env`.
+More registration parameters are required to enable these additional features. To prevent confusion on parameters, `scalar` and `kwargs` 
+can't be present at the same time. To enable `scalar`, use 
+`set_enable_scalar(bool enable_scalar)` in registration. Then, in forward functions and gradients, the `scalar` can be accessed from `env.scalar` as in the function parameter `EnvArguments env`.
 
-To enable `kwargs`, use `set_enable_kwargs(bool enable_kwargs)` in registration. Then in forward 
+To enable `kwargs`, use `set_enable_kwargs(bool enable_kwargs)` in registration. Then, in forward 
 functions and gradients, additional arguments are contained in `env.kwarg`, which is defined as 
-`std::vector<std::pair<std::string, std::string> >`. The DMLC parameter structure can be used to 
-simplify parsing keyword arguments. Refer to the [guide on parameter structure](https://github.com/dmlc/dmlc-core/blob/master/doc/parameter.md)
-for more details.
+`std::vector<std::pair<std::string, std::string> >`. Use the DMLC parameter structure to 
+simplify parsing keyword arguments. For more details, see the [guide on parameter structure](https://github.com/dmlc/dmlc-core/blob/master/doc/parameter.md).
 
 Additional resources like `mshadow::Random<xpu>` and temporary memory space can also be requested and 
 accessed from `EnvArguments.resource`. The registration routine is `set_resource_request(ResourceRequest req)` 
-or `set_resource_request(const std::vector<ResourceRequest>)`, where `mxnet::ResourceRequest` is defined as in:
-```cpp
-struct ResourceRequest {
-  enum Type {  // Resource type, indicating what the pointer type is
-    kRandom,  // mshadow::Random<xpu> object
-    kTempSpace  // A dynamic temp space that can be arbitrary size
-  };
-  Type type;  // type of resources
-};
-```
-The registration will request the declared resource requests from `mxnet::ResourceManager` and place resources 
-in `std::vector<Resource> resource` in `EnvArguments`. To access resources, write:
-```cpp
-auto tmp_space_res = env.resources[0].get_space(some_shape, some_stream);
-auto rand_res = env.resources[0].get_random(some_stream);
-```
-Refer to `src/operator/loss_binary_op-inl.h` for a concrete example.
+or `set_resource_request(const std::vector<ResourceRequest>)`, where `mxnet::ResourceRequest` is defined as:
 
-In our smooth l1 loss example, a scalar input is needed to mark the turning point of loss function. Therefore 
-in the registration process, we use `set_enable_scalar(true)` and use `env.scalar` in function and gradient 
+```cpp
+    struct ResourceRequest {
+      enum Type {  // Resource type, indicating what the pointer type is
+        kRandom,  // mshadow::Random<xpu> object
+        kTempSpace  // A dynamic temp space that can be arbitrary size
+      };
+      Type type;  // type of resources
+    };
+```
+Registration will request the declared resource requests from `mxnet::ResourceManager`, and place resources 
+in `std::vector<Resource> resource` in `EnvArguments`. To access resources, use the following:
+
+```cpp
+    auto tmp_space_res = env.resources[0].get_space(some_shape, some_stream);
+    auto rand_res = env.resources[0].get_random(some_stream);
+```
+For an example, see `src/operator/loss_binary_op-inl.h`.
+
+In our smooth l1 loss example, a scalar input is needed to mark the turning point of loss function. Therefore, 
+in the registration process, we use `set_enable_scalar(true)`, and use `env.scalar` in function and gradient 
 declarations. 
 
 ### Crafting a Tensor Operation
-Since actual computation utilize `mshadow` library and sometimes we don't have functions readily available, it is 
-possible to craft such tensor operations in operator implementations. If such functions are elementwise defined, we 
-can implement them as a `mxnet::op::mshadow_op`. `src/operator/mshadow_op.h` contains a lot of `mshadow_op`, serving 
-as a good example. `mshadow_op` are expression mappers and deal with the scalar case of desired functions. Refer to 
-[mshadow expression API guide](https://github.com/dmlc/mshadow/tree/master/doc) for details.
+Because computation utilizes the `mshadow` library and we sometimes don't have functions readily available, we  
+can craft tensor operations in operator implementations. If you define such functions as element-wise, you 
+can implement them as an `mxnet::op::mshadow_op`. `src/operator/mshadow_op.h` that contains a lot of `mshadow_op`, 
+for example. `mshadow_op` are expression mappers. They deal with the scalar case of desired functions. For details, see 
+[mshadow expression API guide](https://github.com/dmlc/mshadow/tree/master/doc).
 
-It could also be possible that the operation cannot be done in an element wise way, like the softmax loss and gradient. 
-Then there is a need to create a new tensor operation. Then we need to create a `mshadow` function and a `mshadow::cuda`
-function directly. Please refer to `mshadow` library for details or `src/operator/roi_pooling.cc` for an example.
+If an operation can't be done in an element-wise way, like the softmax loss and gradient, then you need to create a new tensor operation. You need to create as `mshadow` function and as `mshadow::cuda`
+function directly. For details, see the `mshadow` library. For an example, see `src/operator/roi_pooling.cc`.
 
 In our smooth l1 loss example, we create two mappers, namely the scalar cases of smooth l1 loss and gradient.
+
 ```cpp
-namespace mshadow_op {
-struct smooth_l1_loss {
-  // a is x, b is sigma2
-  MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
-    if (a > 1.0f / b) {
-      return a - 0.5f / b;
-    } else if (a < -1.0f / b) {
-      return -a - 0.5f / b;
-    } else {
-      return 0.5f * a * a * b;
+    namespace mshadow_op {
+    struct smooth_l1_loss {
+      // a is x, b is sigma2
+      MSHADOW_XINLINE static real_t Map(real_t a, real_t b) {
+        if (a > 1.0f / b) {
+          return a - 0.5f / b;
+        } else if (a < -1.0f / b) {
+          return -a - 0.5f / b;
+        } else {
+          return 0.5f * a * a * b;
+        }
+      }
+    };
     }
-  }
-};
-}
 ```
-The gradient is similar, which can be found in `src/operator/smooth_l1_unary-inl.h`.
+The gradient, which can be found in `src/operator/smooth_l1_unary-inl.h`, is similar.
 
 ### Beyond Two Operands
-This new unified API is designed to fulfil the fundamentals of an operation. For operators with more than two inputs, 
-more than one outputs, or in need of more features, please refer to the original [Operator API](operator.md).
+The new unified API is designed to fulfill the fundamentals of an operation. For operators with more than two inputs, 
+more than one output, or that need more features, see the original [Operator API](operator.md).
 
-## KVStore: Multi-devices and multi-machines
-
-### Introduction
+## KVStore: Multiple Devices and Multiple Computers
 
 MXNet uses a two-level *parameter server* for data synchronization.
 
 <img src=https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/multi-node/ps_arch.png width=400/>
 
 - On the first layer, data are synchronized over multiple devices within a
-  single worker machine. A device could be a GPU card, CPU, or other computational
-  units. We often use sequential consistency model, also known as BSP, on this
+  single worker machine. A device could be a GPU card, CPU card, or other computational
+  unit. We often use the sequential consistency model, also known as BSP, on this
   level.
 
-- On the second layer, data are synchronize over multiple workers via server
-  machines. We can either use a sequential consistency model for guaranteed
-  convergence or an (partial)-asynchronous model for better system performance.
+- On the second layer, data are synchronize over multiple workers by way of servers. We can use either a sequential consistency model for guaranteed
+  convergence or a (partial)-asynchronous model for better system performance.
 
 ### KVStore
 
 MXNet implemented the two-level parameter server in class *KVStore*. We
-currently provide the following three types. Given the batch size *b*:
+currently provide the following three types. Given the batch size *b*.
 
 ```eval_rst
-============  ======== ======== ============== ============== =========
-kvstore type  #devices #workers #ex per device #ex per update max delay
-============  ======== ======== ============== ============== =========
-`local`       *k*       1           *b / k*        *b*         *0*
-`dist_sync`   *k*       *n*       *b / k*       *b × n*       *0*
-`dist_async`  *k*       *n*       *b / k*        *b*           inf
-============  ======== ======== ============== ============== =========
+    ============  ======== ======== ============== ============== =========
+    kvstore type  #devices #workers #ex per device #ex per update max delayN
+    `dist_sync`   *k*       *n*       *b / k*       *b × n*       *0*
+    `dist_async`  *k*       *n*       *b / k*       *b*           inf
+    ============  ======== ======== ============== ============== =========
 ```
 
-where the number of devices *k* used on a worker could vary for different
-workers. And
+The number of devices *k* used on a worker could vary for different
+workers. 
 
-- **number examples per update** : for each update, the number of examples used to
-  calculate the averaged gradients. Often the larger, the slower the convergence.
-- **number examples per device** : the number of examples batched to one device
-  each time. Often the larger, the better the performance.
-- **max delay** : The maximal delay of the weight a worker can get. Given a worker,
-  a delay *d* for weight *w* means when this worker uses *w* (to calculate the
-  gradient), *w* have been already updated by *d* times on some other places. A
-  larger delay often improves the performance, but may slows down the
+- **Number examples per update**: For each update, the number of examples used to
+  calculate the averaged gradients. Often, the larger, the slower the convergence.
+- **Number examples per device**: The number of examples batched to one device
+  each time. Often, the larger, the better the performance.
+- **Max delay** : The maximum delay of the weight for a worker. Given a worker,
+  a delay *d* for weight *w* means that when this worker uses *w* (to calculate the
+  gradient), *w* has been already updated by *d* times  in some other places. A
+  larger delay often improves the performance, but can slow 
   convergence.
 
-### Multiple devices on a single machine
+### Multiple Devices on a Single Computer
 
-KV store `local` synchronizes data over multiple devices on a single machine.
-It gives the same results (e.g. model accuracy) as the single device case. But
-comparing to the latter, assume there are *k* devices, then each device only
-processes *1 / k* examples each time (also consumes *1 / k* device memory). We
+KV store `local` synchronizes data over multiple devices on a single computer.
+It produces the same results (e.g., model accuracy) as when running a single device. But
+compared to the latter, assume there are *k* devices, and that each device
+processes only *1 / k* examples each time (and consumes *1 / k* of device memory). We
 often increase the batch size *b* for better system performance.
 
-When using `local`, the system will automatically chooses one of the following
-three types. Their differences are on where to average
+When you use `local`, the system automatically chooses one of the following
+three types. They differ on where to average
 the gradients over all devices, and where to update the weight.
 
 ```eval_rst
-=======================  ================   ==============
- kvstore type            average gradient   perform update
-=======================  ================   ==============
-`local_update_cpu`       CPU                 CPU
-`local_allreduce_cpu`    CPU                 all devices
-`local_allreduce_device` a device            all devices
-=======================  ================   ==============
+    =======================  ================   ==============
+     kvstore type            average gradient   perform update
+    =======================  ================   ==============
+    `local_update_cpu`       CPU                 CPU
+    `local_allreduce_cpu`    CPU                 all devices
+    `local_allreduce_device` a device            all devices
+    =======================  ================   ==============
 ```
 
-They produce (almost) the same results, but may vary on speed.
+They produce (almost) the same results, but can vary on speed.
 
-- `local_update_cpu`, gradients are first copied to main memory, next averaged on CPU,
-  and then update the weight on CPU. It is suitable when the average size of
-  weights are not large and there are a large number of weight. For example the
-  GOOGLE Inception network.
+- `local_update_cpu`, gradients are first copied to main memory, averaged on the CPU,
+  and then they update the weight on the CPU. This is suitable when the average size of
+  weights isn't large and there are a large number of weights. Example: the
+  Google Inception network.
 
-- `local_allreduce_cpu` is similar to `local_update_cpu` except that the
+- `local_allreduce_cpu` is similar to `local_update_cpu`, except that the
   averaged gradients are copied back to the devices, and then weights are
-  updated on devices. It is faster than 1 when the weight size is large so we
-  can use the device to accelerate the computation (but we increase the workload
-  by *k* times). Examples are AlexNet on Imagenet.
+  updated on devices. When weight size is large, it's faster than the first option; you
+  can use the device to accelerate computation (but you increase the workload
+  by *k* times). Example: AlexNet on ImageNet.
 
 - `local_allreduce_device` is similar to `local_allreduce_cpu` except that the
-  gradient are averaged on a chosen device. It may take advantage of the
-  possible device-to-device communication, and may accelerate the averaging
-  step. It is faster than 2 when the gradients are huge. But it requires more
+  gradients are averaged on a chosen device. It might take advantage of device-to-device communication, and might accelerate averaging. When the gradients are huge, it's faster than the second option, but it requires more
   device memory.
 
-### Multiple machines
+### Multiple Computers
 
-Both `dist_async` and `dist_sync` can handle the multiple machines
-situation. But they are different on both semantic and performance.
+Both `dist_async` and `dist_sync` can handle using  multiple computers. But they differ in both semantics and performance.
 
-- `dist_sync`: the gradients are first averaged on the servers, and then send to
-  back to workers for updating the weight. It is similar to `local` and
-  `update_on_kvstore=false` if we treat a machine as a device.  It guarantees
-  almost identical convergence with the single machine single device situation
-  if reduces the batch size to *b / n*. However, it requires synchronization
-  between all workers, and therefore may harm the system performance.
+- `dist_sync`: The gradients are first averaged on the servers, and then sent back to workers for updating weight. If you treat a computer as a device, it's similar to `local` and
+  `update_on_kvstore=false`.  If you reduce the batch size to *b / n*, it guarantees
+  almost identical convergence as the single computer, single device scenario. However, it requires synchronization
+  between all workers, and, therefore, might affect system performance.
 
-- `dist_async`: the gradient is sent to the servers, and the weight is updated
-  there. The weights a worker has may be stale. This loose data consistency
-  model reduces the machine synchronization cost and therefore could improve the
-  system performance. But it may harm the convergence speed.
+- `dist_async`: The gradient is sent to the servers, and the weight is updated
+  there. The weights that a worker has might be stale. This loose data consistency
+  model reduces computer synchronization cost and, therefore, could improve
+  system performance. However, it might affect convergence speed.
 
-# Recommended Next Steps
+## Next Steps
 
+* [Analogy to other DL systems](http://mxnet.io/architecture/analogy.html)
 * [How to read MXNet code](http://mxnet.io/architecture/read_code.html)
 * [Develop and hack MXNet](http://mxnet.io/how_to/develop_and_hack.html)

--- a/docs/architecture/program_model.md
+++ b/docs/architecture/program_model.md
@@ -1,68 +1,73 @@
-Programming Models for Deep Learning
-====================================
-There are a lot of deep learning libraries, each comes with its own flavour.
-How can each flavour introduced by each library provide advantages or drawbacks in terms of system optimization and user experience?
-This article aims to compare these flavours in terms of programming models, discuss the fundamental advantages and drawbacks
-introduced by these models, and how we can learn from them.
+# Programming Models for Deep Learning
 
-We will focus on the programming model itself instead of the implementations. So this article is not about benchmarking
-deep learning libraries. Instead, we will divide the libraries into several categories in terms of what user interface they offer,
-and discuss how these styles of interface affect performance and flexibility of deep learning programs.
-The discussion in this article may not be specific to deep learning, but we will keep deep learning applications as our use-cases and goal of optimization.
+There are a lot of deep learning libraries, each with its own flavor.
+What are the advantages and drawbacks of each library in terms of system optimization and user experience?
+This topic compares the programming models, discusses the fundamental advantages and drawbacks
+introduced by the models, and explores how we can learn from them.
 
-Symbolic vs Imperative Programs
--------------------------------
-This is the first section to get started, the first thing we are going to compare is symbolic style programs vs imperative style programs.
-If you are a python or c++ programmer, it is likely you are already familiar with imperative programs.
-Imperative style programs conduct the computation as we run them. Most code you write in python is imperative,
-for example, the following numpy snippet.
+This article isn't about benchmarking
+deep learning libraries. We'll focus on the programming models themselves, instead of the implementations.  We divide the libraries into several categories according to the user interface they offer,
+and discuss how interface style affects performance and flexibility of deep learning programs.
+The discussion might not be specific to deep learning, but we will use deep learning applications as our use cases and the goal of optimization.
+
+## Symbolic vs. Imperative Programs
+
+First let's compare symbolic-style programs vs. imperative-style programs.
+If you are a Python or C++ programmer, it is likely you are already familiar with imperative programs.
+Imperative-style programs conduct computation as we run them. Most code you write in Python is imperative,
+as is the following NumPpy snippet.
+
 ```python
-import numpy as np
-a = np.ones(10)
-b = np.ones(10) * 2
-c = b * a
-d = c + 1
+    import numpy as np
+    a = np.ones(10)
+    b = np.ones(10) * 2
+    c = b * a
+    d = c + 1
 ```
-When the programs execute to ```c = b * a```, it runs the actual computation. Symbolic programs are a bit different.
-The following snippet is an equivalent symbolic style program you can write to achieve the same goal of calculating ```d```.
+When the program executes ```c = b * a```, it runs the actual computation. 
+
+Symbolic programs are a bit different.
+The following snippet is an equivalent symbolic-style program that achieves the same goal of calculating ```d```.
+
 ```python
-A = Variable('A')
-B = Variable('B')
-C = B * A
-D = C + Constant(1)
-# compiles the function
-f = compile(D)
-d = f(A=np.ones(10), B=np.ones(10)*2)
+    A = Variable('A')
+    B = Variable('B')
+    C = B * A
+    D = C + Constant(1)
+    # compiles the function
+    f = compile(D)
+    d = f(A=np.ones(10), B=np.ones(10)*2)
 ```
-The difference in symbolic programs is when ```C = B * A``` is executed, there is no actual computation happening.
+The difference in symbolic programs is that when ```C = B * A``` is executed, no computation occurs.
 Instead, these operations generate a computation graph (symbolic graph) that represents the computation it described.
-The following picture gives a computation graph to compute ```D```.
+The following figure shows a computation graph to compute ```D```.
 
 ![Comp Graph](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/prog_model/comp_graph.png)
 
-Most symbolic style programs contain, either explicitly or implicitly, a ```compile``` step.
+Most symbolic-style programs contain, either explicitly or implicitly, a ```compile``` step.
 This converts the computation graph into a function that can be called.
-Then the real computation happens at the last step of the code. The major characteristic of symbolic programs
-is the clear separation between the computation graph definition step, and the compile, running step.
+Computation occurs in the last step of the code. The major characteristic of symbolic programs
+is the clear separation between defining the computation graph and compiling.
 
-Examples of imperative style deep learning libraries include Torch, Chainer and Minerva.
-While the examples of symbolic style deep learning libraries include Theano, CGT and Tensorflow.
-Libraries that use configuration files like cxxnet, caffe can also be viewed as symbolic style libraries,
-where the configuration file content defines the computation graph.
+Examples of imperative-style deep learning libraries include Torch, Chainer, and Minerva.
+Examples of symbolic-style deep learning libraries include Theano, CGT, and Tensorflow.
+Libraries that use configuration files, like CXXNet and Caffe, can also be viewed as symbolic-style libraries,
+where the content in the configuration file defines the computation graph.
 
-Now you know the two different programming models, let us start to compare them!
+Now that you understand the two different programming models, let's start to compare them.
 
-### Imperative Programs are More Flexible
+### Imperative Programs Are More Flexible
 
-This is a general statement that may not apply strictly, but indeed imperative programs are usually more flexible than symbolic programs.
-If you are writing an imperative style programs in python, you are writing in python. However, if you are writing a symbolic program,
-it is different. Consider the following imperative program, think how you can translate this into a symbolic program.
+This is a general statement that might not apply strictly, but, indeed, imperative programs are usually more flexible than symbolic programs.
+If you are writing an imperative-style program in Python, you are writing in Python. If you are writing a symbolic program,
+it is different. Consider the following imperative program, and think about how you can translate this into a symbolic program.
+
 ```python
-a = 2
-b = a + 1
-d = np.zeros(10)
-for i in range(d):
-    d += np.zeros(10)
+    a = 2
+    b = a + 1
+    d = np.zeros(10)
+    for i in range(d):
+        d += np.zeros(10)
 ```
 You can find it is actually not easy, because there is a python for-loop that may not readily supported by the symbolic API.
 If you are writing a symbolic programs in python, you are NOT writing in python.
@@ -73,19 +78,19 @@ In that sense, the config-file input libraries are all symbolic.
 Because imperative programs are actually more ```native``` than the symbolic ones, it is easier to use native language features
 and inject them into computation flow. Such as printing out the values in the middle of computation, and use conditioning and loop in host language.
 
-### Symbolic Programs are More Efficient
+### Symbolic Programs Are More Efficient
 
 As we can see from the discussion in previous section, imperative programs are usually more flexible and native to the host language.
 Why larger portion of deep learning libraries chose to be symbolic instead? The main reason is efficiency, both in terms of memory and runtime.
 Let us consider the same toy example used in the beginning of this section.
 
 ```python
-import numpy as np
-a = np.ones(10)
-b = np.ones(10) * 2
-c = b * a
-d = c + 1
-...
+    import numpy as np
+    a = np.ones(10)
+    b = np.ones(10) * 2
+    c = b * a
+    d = c + 1
+    ...
 ```
 
 ![Comp Graph](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/prog_model/comp_graph.png)
@@ -95,11 +100,11 @@ Let us do some math, we need memory for 4 arrays of size 10, that means we will 
 to execute the computation graph, we can re-use memory of C and D, to do the last computation in-place, this will give us ```3 * 10 * 8 = 240```
 bytes instead.
 
-Symbolic programs are more ***restricted***. When the user call ```compile``` on D, the user tells the system that only the value of
+Symbolic programs are more *restricted*. When the user call ```compile``` on D, the user tells the system that only the value of
 ```D``` is needed. The intermediate values of computation, in our case ```C``` is invisible to the user.
 This allows the symbolic programs to safely re-use the memory to do in-place computation.
 
-Imperative programs, on the other hand, need to ***be prepared for all possible futures***. If the above programs is executed in a python console,
+Imperative programs, on the other hand, need to *be prepared for all possible futures*. If the above programs is executed in a python console,
 there is a possibility that any of these variables could be used in the future, this prevents the system to share the memory space of these variables.
 
 Of course this argument is a bit idealized, since garbage collection can happen in imperative programs when things runs out of scope, and memory could be re-used.
@@ -116,63 +121,64 @@ We cannot do that in imperative programs. Because the intermediate value can be 
 some point in the future. The reason that such optimization is possible in symbolic programs, is that we get the entire computation graph, and a clear
 boundary on which value is needed and which is not. While imperative programs only operates on local operations and do not have such a clear boundary.
 
-### Case Study on Backprop and AutoDiff
+### Case Study: Backprop and AutoDiff
 
 In this section, we will compare the two programming models on the problem of auto differentiation, or backpropagation. Gradient calculation is actually
 the problem that all the deep learning library need to solve. It is possible to do gradient calculation in both imperative and symbolic style.
 
 Let us start with the imperative programs. The following snippet is a minimum python code that does automatic differentiation on the toy example we discussed.
+
 ```python
-class array(object) :
-    """Simple Array object that support autodiff."""
-    def __init__(self, value, name=None):
-        self.value = value
-        if name:
-            self.grad = lambda g : {name : g}
+    class array(object) :
+        """Simple Array object that support autodiff."""
+        def __init__(self, value, name=None):
+            self.value = value
+            if name:
+                self.grad = lambda g : {name : g}
 
-    def __add__(self, other):
-        assert isinstance(other, int)
-        ret = array(self.value + other)
-        ret.grad = lambda g : self.grad(g)
-        return ret
+        def __add__(self, other):
+            assert isinstance(other, int)
+            ret = array(self.value + other)
+            ret.grad = lambda g : self.grad(g)
+            return ret
 
-    def __mul__(self, other):
-        assert isinstance(other, array)
-        ret = array(self.value * other.value)
-        def grad(g):
-            x = self.grad(g * other.value)
-            x.update(other.grad(g * self.value))
-            return x
-        ret.grad = grad
-        return ret
+        def __mul__(self, other):
+            assert isinstance(other, array)
+            ret = array(self.value * other.value)
+            def grad(g):
+                x = self.grad(g * other.value)
+                x.update(other.grad(g * self.value))
+                return x
+            ret.grad = grad
+            return ret
 
-# some examples
-a = array(1, 'a')
-b = array(2, 'b')
-c = b * a
-d = c + 1
-print d.value
-print d.grad(1)
-# Results
-# 3
-# {'a': 2, 'b': 1}
+    # some examples
+    a = array(1, 'a')
+    b = array(2, 'b')
+    c = b * a
+    d = c + 1
+    print d.value
+    print d.grad(1)
+    # Results
+    # 3
+    # {'a': 2, 'b': 1}
 ```
 
-In the above program, each array object contains a grad function(it is actually a closure).
-When we run ```d.grad```, it recursively invoke grad function of its inputs, backprops the gradient value back,
+In the preceding program, each array object contains a grad function (it is actually a closure).
+When we run ```d.grad```, it recursively invokes grad function of its inputs, backprops the gradient value back,
 returns the gradient value of each inputs. This may looks a bit complicated. Let us consider the gradient calculation for
 symbolic programs. The program below is an example of doing symbolic gradient calculation of the same task.
 
 ```python
-A = Variable('A')
-B = Variable('B')
-C = B * A
-D = C + Constant(1)
-# get gradient node.
-gA, gB = D.grad(wrt=[A, B])
-# compiles the gradient function.
-f = compile([gA, gB])
-grad_a, grad_b = f(A=np.ones(10), B=np.ones(10)*2)
+    A = Variable('A')
+    B = Variable('B')
+    C = B * A
+    D = C + Constant(1)
+    # get gradient node.
+    gA, gB = D.grad(wrt=[A, B])
+    # compiles the gradient function.
+    f = compile([gA, gB])
+    grad_a, grad_b = f(A=np.ones(10), B=np.ones(10)*2)
 ```
 
 The grad function of D generate a backward computation graph, and return a gradient node ```gA, gB```.
@@ -212,14 +218,14 @@ to switch the gradient calculation off. This brings a bit more restriction into 
 in trading for efficiency.
 
 ```python
-with context.NoGradient():
-    a = array(1, 'a')
-    b = array(2, 'b')
-    c = b * a
-    d = c + 1
+    with context.NoGradient():
+        a = array(1, 'a')
+        b = array(2, 'b')
+        c = b * a
+        d = c + 1
 ```
 
-However, the above example still have many possible futures, which means we cannot do the inplace calculation
+However, the above example still have many possible futures, which means we cannot do the in-place calculation
 to re-use the memory in forward pass(a trick commonly used to reduce GPU memory usage).
 The techniques introduced in this section generates explicit backward pass.
 On some of the tool-kits such as Caffe, CXXNet. Backprop is done implicitly on the same graph.
@@ -240,16 +246,16 @@ Being able to checkpoint the configuration is a plus for symbolic programs. Beca
 we can directly serialize the computation graph, and load it back later, this solves the save configuration problem without introducing an additional layer.
 
 ```python
-A = Variable('A')
-B = Variable('B')
-C = B * A
-D = C + Constant(1)
-D.save('mygraph')
-...
-D2 = load('mygraph')
-f = compile([D2])
-# more operations
-...
+    A = Variable('A')
+    B = Variable('B')
+    C = B * A
+    D = C + Constant(1)
+    D.save('mygraph')
+    ...
+    D2 = load('mygraph')
+    f = compile([D2])
+    # more operations
+    ...
 ```
 
 Because imperative programs executes as it describes the computation. We will have to save the code itself as the ```configuration```, or build another
@@ -266,7 +272,7 @@ It is usually easier to write the parameter updates in imperative styles, especi
 For symbolic programs, the update statement is also executed as we call them. So in that sense, most existing symbolic deep learning libraries
 also falls back to the imperative way to perform the updates, while using the symbolic way to do the gradient calculation.
 
-### There is no Strict Boundary
+### There Is No Strict Boundary
 
 We have made the comparison between two programming styles. Some of the arguments made may not be strictly true, and there is no clear boundaries between
 the programming styles. For example, we can make a (JIT)compiler of python to compile imperative python programs, which gives us some of the advantage of global
@@ -274,32 +280,35 @@ information hold in the symbolic programs. However, most of the principles holds
 libraries.
 
 
-Big vs Small Operations
------------------------
+## Big vs. Small Operations
+
 Now we have pass through the battlefield between symbolic and imperative programs. Let us start to talk about the operations supported by deep learning libraries.
 Usually there are two types of operations supported by different deep learning libraries.
 - The big layer operations such as FullyConnected, BatchNormalize
 - The small operations such as element wise addition, multiplications.
 The libraries like CXXNet, Caffe support layer level operations. While the libraries like Theano, Minerva support fine grained operations.
 
-### Smaller Operations can be More Flexible
+### Smaller Operations Can Be More Flexible
 This is quite natural, in a sense that we can always use smaller operations to compose bigger operations.
 For example, the sigmoid unit can be simply be composed by division and exponential.
+
 ```python
-sigmoid(x) = 1.0 / (1.0 + exp(-x))
+    sigmoid(x) = 1.0 / (1.0 + exp(-x))
 ```
 If we have the smaller operations as building blocks, we can express most of the problems we want.
 For readers who are more familiar with CXXNet, Caffe style layers. These operations is not different from a layer, except that they are smaller.
+
 ```python
-SigmoidLayer(x) = EWiseDivisionLayer(1.0, AddScalarLayer(ExpLayer(-x), 1.0))
+    SigmoidLayer(x) = EWiseDivisionLayer(1.0, AddScalarLayer(ExpLayer(-x), 1.0))
 ```
 So the above expression becomes composition of three layers, with each defines their forward and backward(gradient) function.
 This offers us an advantage to build new layers quickly, because we only need to compose these things together.
 
-### Big Operations are More Efficient
+### Big Operations Are More Efficient
 As you can see directly composing up sigmoid layers means we need to have three layers of operation, instead of one.
+
 ```python
-SigmoidLayer(x) = EWiseDivisionLayer(1.0, AddScalarLayer(ExpLayer(-x), 1.0))
+    SigmoidLayer(x) = EWiseDivisionLayer(1.0, AddScalarLayer(ExpLayer(-x),   1.0))
 ```
 This will create overhead in terms of computation and memory (which could be optimized, with cost).
 
@@ -342,8 +351,8 @@ however we have only seen this trick in C++ so far.
 The expression template libraries creates a middle ground between python operations and hand crafted big kernels. To allow C++ users to craft efficient big
 operations by composing smaller operations together. Which is also a choice worth considering.
 
-Mix The Flavours Together
--------------------------
+## Mix The Flavours Together
+
 Now we have compared the programming models, now comes the question of which you might want to choose.
 Before we doing so, we should emphasize the the comparison made in this article may not necessary have big impact
 depending on where the problems are.
@@ -372,15 +381,16 @@ while the gradient calculations can be done more effectively in symbolic program
 
 The mix of programs is actually happening in existing symbolic libraries, because python itself is imperative.
 For example, the following program mixes the symbolic part together with numpy(which is imperative).
+
 ```python
-A = Variable('A')
-B = Variable('B')
-C = B * A
-D = C + Constant(1)
-# compiles the function
-f = compile(D)
-d = f(A=np.ones(10), B=np.ones(10)*2)
-d = d + 1.0
+    A = Variable('A')
+    B = Variable('B')
+    C = B * A
+    D = C + Constant(1)
+    # compiles the function
+    f = compile(D)
+    d = f(A=np.ones(10), B=np.ones(10)*2)
+    d = d + 1.0
 ```
 The idea is that the symbolic graphs are compiled into a function that can be executed imperatively. Whose internal is a blackbox to the user.
 This is exactly like writing c++ programs and exposing them to python, which we commonly do.
@@ -389,9 +399,9 @@ However, using numpy as imperative component might be undesirable, as the parame
 
 ### Small and Big Operations
 
-Combining small and big operations is also possible, and actually we might have a good reason to do it. Consider applications such as changing
-a loss function or adding a few customized layers to an existing structure. What we usually can do is use big operations to compose up the existing
-components, and use smaller operations to build up the new parts.
+It's also possible to combine small and big operations, and there might be a good reason to do it. Consider applications such as changing
+a loss function or adding a few customized layers to an existing structure. What we usually can do is use big operations to compose the existing
+components, and use smaller operations to build the new parts.
 
 Recall Amdahl's law, usually these new components may not be the bottleneck of computation. As the performance critical part is already optimized by
 the bigger operations, it is even OK that we do not optimize these additional small operations at all, or only do a few memory optimization instead
@@ -399,16 +409,16 @@ of operation fusion and directly running them.
 
 ### Choose your Own Flavours
 
-As we have compare the flavours of deep learning programs. The goal of this article is to list these choices and compare their trade-off.
-There may not be a universal solution for all. But you can always choose your flavour, or combine the flavours you like to create
+As we have compare the flavours of deep learning programs. The goal of this topic is to list these choices and compare their trade-offs.
+There may not be a universal solution, but you can always choose your flavour, or combine the flavours you like to create
 more interesting and intelligent deep learning libraries.
 
-Contribution to this Note
--------------------------
-This note is part of our effort to [open-source system design notes](index.md)
-for deep learning libraries. You are more than welcome to contribute to this Note, by submitting a pull request.
+## Contribute to this Topic
 
-# Recommended next steps
+This topic is part of our effort to provide [open-source system design notes](index.md)
+for deep learning libraries. We welcome your contributions.
+
+## Next Steps
 
 * [Dependency Engine for Deep Learning](http://mxnet.io/architecture/note_engine.html)
 * [Squeeze the Memory Consumption of Deep Learning](http://mxnet.io/architecture/note_memory.html)

--- a/docs/architecture/read_code.md
+++ b/docs/architecture/read_code.md
@@ -1,21 +1,21 @@
 # Read MXNet Code
-- All the module interface are listed in [include](../../include), these
+- All of the module interfaces are listed in [include](../../include). The
   interfaces are heavily documented.
-- You read the
+- Read the
   [Doxygen Version](https://mxnet.readthedocs.org/en/latest/doxygen) of the
   document.
-- Each module will only depend on other module by the header files in
+- Each module depends on other modules as defined in the header files in
   [include](../../include).
-- The implementation of module is in [src](../../src) folder.
-- Each source code only sees the file within its folder,
+- Module implementation is in the  [src](../../src) folder.
+- Source code sees only the file within its folder,
   [src/common](../../src/common) and [include](../../include).
 
-Most modules are mostly self-contained, with interface dependency on engine.  So
-you are free to pick the one you are interested in, and read that part.
+Most modules are mostly self-contained, with interface dependency on the engine. 
+You're free to pick the one you are interested in, and read that part.
 
-# Other resources
-* [Doxygen Version of C++ API](https://mxnet.readthedocs.org/en/latest/doxygen) gives a comprehensive document of C++ API.
+## Other Resources
+* [Doxygen Version of C++ API](https://mxnet.readthedocs.org/en/latest/doxygen) comprehensively documents the C++ API.
 
-# Recommended Next Steps
+## Next Steps
 
-* [Develop and hack MXNet](http://mxnet.io/how_to/develop_and_hack.html)
+* [Develop and Hack MXNet](http://mxnet.io/how_to/develop_and_hack.html)

--- a/docs/architecture/rnn_interface.md
+++ b/docs/architecture/rnn_interface.md
@@ -1,91 +1,91 @@
-# Survey of existing interfaces and implementations
+# Survey of Existing Interfaces and Implementations
 
-Some commonly used deep learning libraries with good RNN / LSTM support include [Theano](http://deeplearning.net/software/theano/library/scan.html) and its wrappers [Lasagne](http://lasagne.readthedocs.org/en/latest/modules/layers/recurrent.html) and [Keras](http://keras.io/layers/recurrent/); [CNTK](https://cntk.codeplex.com/); [TensorFlow](https://www.tensorflow.org/versions/master/tutorials/recurrent/index.html); and various implementations in Torch like [char-rnn](https://github.com/karpathy/char-rnn), [this](https://github.com/Element-Research/rnn) and [this](https://github.com/wojzaremba/lstm).
+Commonly used deep learning libraries with good RNN /LSTM support include [Theano](http://deeplearning.net/software/theano/library/scan.html) and its wrappers [Lasagne](http://lasagne.readthedocs.org/en/latest/modules/layers/recurrent.html) and [Keras](http://keras.io/layers/recurrent/); [CNTK](https://cntk.codeplex.com/); [TensorFlow](https://www.tensorflow.org/versions/master/tutorials/recurrent/index.html); and various implementations in Torch, like [char-rnn](https://github.com/karpathy/char-rnn), [this](https://github.com/Element-Research/rnn), and [this](https://github.com/wojzaremba/lstm).
 
 ## Theano
 
-RNN support in Theano is provided by its [scan operator](http://deeplearning.net/software/theano/library/scan.html), which allows construction of a loop where the number of iterations is specified via a runtime value of a symbolic variable. An official example of LSTM implementation with scan can be found [here](http://deeplearning.net/tutorial/lstm.html).
+RNN support in Theano is provided by its [scan operator](http://deeplearning.net/software/theano/library/scan.html), which allows construction of a loop where the number of iterations is specified as a runtime value of a symbolic variable. You can find an official example of an LSTM implementation with scan [here](http://deeplearning.net/tutorial/lstm.html).
 
 ### Implementation
 
-I'm not very familiar with the Theano internals, but it seems from [theano/scan_module/scan_op.py#execute](https://github.com/Theano/Theano/blob/master/theano/scan_module/scan_op.py#L1225) that the scan operator is implemented with a loop in Python that perform one iteration at a time:
+I'm not very familiar with the Theano internals, but it seems from [theano/scan_module/scan_op.py#execute](https://github.com/Theano/Theano/blob/master/theano/scan_module/scan_op.py#L1225) that the scan operator is implemented with a loop in Python that performs one iteration at a time:
 
 ```python
-fn = self.fn.fn
+    fn = self.fn.fn
 
-while (i < n_steps) and cond:
-    # ...
-    fn()
+    while (i < n_steps) and cond:
+        # ...
+        fn()
 ```
 
 The `grad` function in Theano constructs a symbolic graph for computing gradients. So the `grad` for the scan operator is actually implemented by [constructing another scan operator](https://github.com/Theano/Theano/blob/master/theano/scan_module/scan_op.py#L2527):
 
 ```python
-local_op = Scan(inner_gfn_ins, inner_gfn_outs, info)
-outputs = local_op(*outer_inputs)
+    local_op = Scan(inner_gfn_ins, inner_gfn_outs, info)
+    outputs = local_op(*outer_inputs)
 ```
 
-The [performance guide](http://deeplearning.net/software/theano/library/scan.html#optimizing-scan-s-performance) for Theano's scan operator suggests minimizing the usage of scan. This might be due to the fact that the loop is executed in Python, which might be a bit slow (due to context switching, and performance of Python itself). Moreover, since no unrolling is performed, the graph optimizer cannot see the big picture here.
+The [performance guide](http://deeplearning.net/software/theano/library/scan.html#optimizing-scan-s-performance) for Theano's scan operator suggests minimizing the usage of scan. This might be due to the fact that the loop is executed in Python, which might be a bit slow (due to context switching and the performance of Python itself). Moreover, because no unrolling is performed, the graph optimizer can't see the big picture.
 
-If I understand correctly, when multiple RNN/LSTM layers are stacked, instead of a single loop with each iteration computing the whole feedforward network operation, the computation goes by doing a separate loop for each of the layer that uses the scan operator, sequentially. This is fine if all the intermediate values are stored to support computing the gradients. But otherwise, using a single loop could be more memory efficient.
+If I understand correctly, when multiple RNN/LSTM layers are stacked, instead of a single loop with each iteration computing the whole feedforward network operation, the computation sequentially does a separate loop for each layer that uses the scan operator. If all of the intermediate values are stored to support computing the gradients, this is fine. Otherwise, using a single loop could be more memory efficient.
 
 ### Lasagne
 
-The documentation for RNN in Lasagne can be found [here](http://lasagne.readthedocs.org/en/latest/modules/layers/recurrent.html). In Lasagne, a recurrent layer is just like standard layers, except that the input shape is expected to be `(batch_size, sequence_length, feature_dimension)`. The output shape is then `(batch_size, sequence_length, output_dimension)`.
+The documentation for RNN in Lasagne can be found [here](http://lasagne.readthedocs.org/en/latest/modules/layers/recurrent.html). In Lasagne, a recurrent layer is just like a standard layer, except that the input shape is expected to be `(batch_size, sequence_length, feature_dimension)`. The output shape is then `(batch_size, sequence_length, output_dimension)`.
 
-Both `batch_size` and `sequence_length` are specified as `None`, and inferred from the data. Alternative, when memory is enough and the (maximum) sequence length is known a prior, the user can set `unroll_scan` to `False`. Then Lasagne will unroll the graph explicitly, instead of using Theano `scan` operator. Explicitly unrolling is implemented in [utils.py#unroll_scan](https://github.com/Lasagne/Lasagne/blob/master/lasagne/utils.py#L340).
+Both `batch_size` and `sequence_length` are specified as `None`, and inferred from the data. Alternatively, when memory is sufficient and the (maximum) sequence length is known beforehand, you can set `unroll_scan` to `False`. Then Lasagne will unroll the graph explicitly, instead of using the Theano `scan` operator. Explicitly unrolling is implemented in [utils.py#unroll_scan](https://github.com/Lasagne/Lasagne/blob/master/lasagne/utils.py#L340).
 
-The recurrent layer also accept a `mask_input`, to support the case of variable length sequences (e.g. sequences could be of different length even within a mini-batch). The mask is of shape `(batch_size, sequence_length)`.
+The recurrent layer also accepts a `mask_input`, to support variable length sequences (e.g., when sequences within a mini-batch have different lengths. The mask has the shape `(batch_size, sequence_length)`.
 
 ### Keras
 
-The documentation for RNN in Keras can be found [here](http://keras.io/layers/recurrent/). The interface in Keras is similar to Lasagne. The input is expected to be of shape `(batch_size, sequence_length, feature_dimension)`, and the output shape (if `return_sequences` is `True`) is `(batch_size, sequence_length, feature_dimension)`.
+The documentation for RNN in Keras can be found [here](http://keras.io/layers/recurrent/). The interface in Keras is similar to the interface in Lasagne. The input is expected to be of shape `(batch_size, sequence_length, feature_dimension)`, and the output shape (if `return_sequences` is `True`) is `(batch_size, sequence_length, feature_dimension)`.
 
-Keras currently supports both Theano and TensorFlow backend. RNN for the Theano backend is [implemented with the scan operator](https://github.com/fchollet/keras/blob/master/keras/backend/theano_backend.py#L432). For TensorFlow, it seem to be [implemented via explicitly unrolling](https://github.com/fchollet/keras/blob/master/keras/backend/tensorflow_backend.py#L396). The documentation says for TensorFlow backend, the sequence length must be specified a prior, and masking is currently not working (because `tf.reduce_any` is not functioning yet).
+Keras currently supports both a Theano and a TensorFlow back end. RNN for the Theano back end is [implemented with the scan operator](https://github.com/fchollet/keras/blob/master/keras/backend/theano_backend.py#L432). For TensorFlow, it seem to be [implemented via explicitly unrolling](https://github.com/fchollet/keras/blob/master/keras/backend/tensorflow_backend.py#L396). The documentation says that for the TensorFlow back end, the sequence length must be specified beforehand, and masking is currently not working (because `tf.reduce_any` is not functioning yet).
 
 ## Torch
 
-[karpathy/char-rnn](https://github.com/karpathy/char-rnn) is implemented via [explicitly unrolling](https://github.com/karpathy/char-rnn/blob/master/model/RNN.lua#L15). [Element-Research/rnn](https://github.com/Element-Research/rnn), on the contrary, run the sequence iteration in Lua. It actually has a very modular design:
+[karpathy/char-rnn](https://github.com/karpathy/char-rnn) is implemented by [explicitly unrolling](https://github.com/karpathy/char-rnn/blob/master/model/RNN.lua#L15). On the contrary, [Element-Research/rnn](https://github.com/Element-Research/rnn) runs sequence iteration in Lua. It actually has a very modular design:
 
-* The basic RNN/LSTM modules only run *one* time step upon one call of `forward` (and accumulate / store necessary information to support backward computation if needed). So the users could have detailed control when using this API directly.
-* A collection of `Sequencer` are defined to model common scenarios like forward sequence, bi-directional sequence, attention models, etc.
-* Other utility modules like masking to support variable length sequences, etc.
+* The basic RNN/LSTM modules run only *one* time step per one call of `forward` (and accumulate/store necessary information to support backward computation, if needed). You could have detailed control when using this API directly.
+* A collection of `Sequencer`s are defined to model common scenarios, like forward sequence, bi-directional sequence, attention models, etc.
+* There are other utility modules, like masking to support variable length sequences, etc.
 
 ## CNTK
 
-CNTK looks quite different from other common deep learning libraries. I cannot understand it very well. I will talk with Yu to get more details.
+CNTK looks quite different from other common deep learning libraries. I don't understand it very well. I will talk with Yu to get more details.
 
-It seems the basic data types are matrices (although there is also a `TensorView` utility class). The mini-batch data for sequence data is packed in a matrix with N-row being `feature_dimension` and N-column being `sequence_length * batch_size` (see Figure 2.9 at page 50 of the [CNTKBook](http://research.microsoft.com/pubs/226641/CNTKBook-20151201.pdf)).
+It seems that the basic data types are matrices (although there is also a `TensorView` utility class). The mini-batch data for sequence data is packed in a matrix with N-row being `feature_dimension` and N-column being `sequence_length * batch_size` (see Figure 2.9 on page 50 of the [CNTKBook](http://research.microsoft.com/pubs/226641/CNTKBook-20151201.pdf)).
 
-Recurrent networks is a first-class citizen in CNTK. In section 5.2.1.8 of the CNTKBook, we can see an example of customized computation node. The node need to explicitly define function for standard forward and forward with a time index, which is used for RNN evaluation:
+Recurrent networks are first-class citizens in CNTK. In section 5.2.1.8 of the CNTKBook, you can see an example of a customized computation node. The node needs to explicitly define the functions for standard forward and forward with a time index, which is used for RNN evaluation:
 
 ```cpp
-virtual void EvaluateThisNode()
-{
-    EvaluateThisNodeS(FunctionValues(), Inputs(0)->
-        FunctionValues(), Inputs(1)->FunctionValues());
-}
-virtual void EvaluateThisNode(const size_t timeIdxInSeq)
-{
-    Matrix<ElemType> sliceInputValue = Inputs(1)->
-        FunctionValues().ColumnSlice(timeIdxInSeq *
-        m_samplesInRecurrentStep, m_samplesInRecurrentStep);
-    Matrix<ElemType> sliceOutputValue = m_functionValues.
-        ColumnSlice(timeIdxInSeq * m_samplesInRecurrentStep,
-        m_samplesInRecurrentStep);
-    EvaluateThisNodeS(sliceOutputValue, Inputs(0)->
-        FunctionValues(), sliceInput1Value);
-}
+    virtual void EvaluateThisNode()
+    {
+        EvaluateThisNodeS(FunctionValues(), Inputs(0)->
+            FunctionValues(), Inputs(1)->FunctionValues());
+    }
+    virtual void EvaluateThisNode(const size_t timeIdxInSeq)
+    {
+        Matrix<ElemType> sliceInputValue = Inputs(1)->
+            FunctionValues().ColumnSlice(timeIdxInSeq *
+            m_samplesInRecurrentStep, m_samplesInRecurrentStep);
+        Matrix<ElemType> sliceOutputValue =    m_functionValues.
+            ColumnSlice(timeIdxInSeq * m_samplesInRecurrentStep,
+            m_samplesInRecurrentStep);
+        EvaluateThisNodeS(sliceOutputValue, Inputs(0)->
+            FunctionValues(), sliceInput1Value);
+    }
 ```
 
-The function `ColumnSlice(start_col, num_col)` takes out the packed data for that time index as described above (here `m_samplesInRecurrentStep` must be mini-batch size).
+The function `ColumnSlice(start_col, num_col)` takes out the packed data for that time index, as described above (here `m_samplesInRecurrentStep` must be the mini-batch size).
 
-The low-level API for recurrent connection seem to be a *delay node*. But I'm not sure how to use this low level API. The [example of ptb language model](https://cntk.codeplex.com/SourceControl/latest#Examples/Text/PennTreebank/Config/rnn.config) uses very high-level API (simply setting `recurrentLayer = 1` in the config).
+The low-level API for recurrent connection seem to be a *delay node*. But I'm not sure how to use this low-level API. The [example of ptb language model](https://cntk.codeplex.com/SourceControl/latest#Examples/Text/PennTreebank/Config/rnn.config) uses a very high-level API (simply setting `recurrentLayer = 1` in the config).
 
 ## TensorFlow
 
-The [current example of RNNLM](https://www.tensorflow.org/versions/master/tutorials/recurrent/index.html#recurrent-neural-networks) in TensorFlow use explicit unrolling for a predefined number of time steps. The white paper mentioned advanced control flow API (Theano's scan-like) coming in the future.
+The [current example of RNNLM](https://www.tensorflow.org/versions/master/tutorials/recurrent/index.html#recurrent-neural-networks) in TensorFlow uses explicit unrolling for a predefined number of time steps. The whitepaper mentions that an advanced control flow API (Theano's scan-like) is planned.
 
-# Recommended next steps
+## Next Steps
 
 * [MXNet System Overview](http://mxnet.io/architecture/overview.html)

--- a/docs/get_started/index.md
+++ b/docs/get_started/index.md
@@ -82,7 +82,7 @@ Without a hidden layer, the MLP predicts the label probabilities as follows:
 
  ```eval_rst
     .. math ::
-    \textrm{softmax}(W x + b)
+		\textrm{softmax}(W x + b)
  ```
 
 *W* is a 784-by-10 weight matrix and *b* is a 10-length bias vector. The

--- a/docs/get_started/setup.md
+++ b/docs/get_started/setup.md
@@ -165,11 +165,12 @@ Install the dependencies with the following commands:
 ```
 And then: 
 ```bash
-brew update
-brew install git
-brew tap homebrew/science
-brew info opencv
-brew install opencv
+	brew update
+	brew install pkg-config
+	brew install git
+	brew tap homebrew/science
+	brew info opencv
+	brew install opencv
 ```
 After you have installed the dependencies, use one of the following options to pull the MXNet source code from Git and build MXNet. Both options produce a library called ```libmxnet.so```.
 

--- a/docs/packages/c++/index.rst
+++ b/docs/packages/c++/index.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/c++/index.html'

--- a/docs/packages/julia/index.rst
+++ b/docs/packages/julia/index.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/julia/index.html'

--- a/docs/packages/python/index.rst
+++ b/docs/packages/python/index.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/index.html'

--- a/docs/packages/python/io.rst
+++ b/docs/packages/python/io.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/io.html'

--- a/docs/packages/python/kvstore.rst
+++ b/docs/packages/python/kvstore.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/kvstore.html'

--- a/docs/packages/python/model.rst
+++ b/docs/packages/python/model.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/model.html'

--- a/docs/packages/python/module.rst
+++ b/docs/packages/python/module.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/module.html'

--- a/docs/packages/python/ndarray.rst
+++ b/docs/packages/python/ndarray.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/ndarray.html'

--- a/docs/packages/python/symbol.rst
+++ b/docs/packages/python/symbol.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/symbol.html'

--- a/docs/packages/python/symbol_in_pictures.rst
+++ b/docs/packages/python/symbol_in_pictures.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/symbol_in_pictures.html'

--- a/docs/packages/python/tutorial.rst
+++ b/docs/packages/python/tutorial.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/python/tutorial.html'

--- a/docs/packages/r/CallbackFunctionTutorial.rst
+++ b/docs/packages/r/CallbackFunctionTutorial.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/r/CallbackFunctionTutorial.html'

--- a/docs/packages/r/CharRnnModel.rst
+++ b/docs/packages/r/CharRnnModel.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/r/CharRnnModel.html'

--- a/docs/packages/r/classifyRealImageWithPretrainedModel.rst
+++ b/docs/packages/r/classifyRealImageWithPretrainedModel.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/r/classifyRealImageWithPretrainedModel.html'

--- a/docs/packages/r/fiveMinutesNeuralNetwork.rst
+++ b/docs/packages/r/fiveMinutesNeuralNetwork.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/r/fiveMinutesNeuralNetwork.html'

--- a/docs/packages/r/index.rst
+++ b/docs/packages/r/index.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/r/index.html'

--- a/docs/packages/r/mnistCompetition.rst
+++ b/docs/packages/r/mnistCompetition.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/r/mnistCompetition.html'

--- a/docs/packages/r/ndarrayAndSymbolTutorial.rst
+++ b/docs/packages/r/ndarrayAndSymbolTutorial.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/r/ndarrayAndSymbolTutorial.html'

--- a/docs/packages/scala/index.rst
+++ b/docs/packages/scala/index.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/api/scala/index.html'

--- a/docs/system/engine.rst
+++ b/docs/system/engine.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/note_engine.html'

--- a/docs/system/index.rst
+++ b/docs/system/index.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/index.html'

--- a/docs/system/multi_node.rst
+++ b/docs/system/multi_node.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/overview.html'

--- a/docs/system/note_data_loading.rst
+++ b/docs/system/note_data_loading.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/note_data_loading.html'

--- a/docs/system/note_engine.rst
+++ b/docs/system/note_engine.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/note_engine.html'

--- a/docs/system/note_memory.rst
+++ b/docs/system/note_memory.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/note_memory.html'

--- a/docs/system/operator.rst
+++ b/docs/system/operator.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/overview.html#operators-in-mxnet'

--- a/docs/system/operator_util.rst
+++ b/docs/system/operator_util.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/overview.html#simpleop-the-unified-operator-api'

--- a/docs/system/program_model.rst
+++ b/docs/system/program_model.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/program_model.html'

--- a/docs/system/rnn_interface.rst
+++ b/docs/system/rnn_interface.rst
@@ -1,0 +1,2 @@
+.. meta::
+    :http-equiv=refresh: 0;URL='http://mxnet.io/architecture/rnn_interface.html'

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,7 +8,7 @@ Applications that intelligently modify, classify and segment images and video.
 
 #### Python
 
--[Handwritten Digit Classification](http://mxnet.io/tutorials/python/mnist.html)
+- [Handwritten Digit Classification](http://mxnet.io/tutorials/python/mnist.html)
 *A simple example of classifying handwritten digits from the MNIST dataset using a MLP and convolutional network*
 
 - [Image Classification](http://mxnet.io/tutorials/computer_vision/image_classification.html) 


### PR DESCRIPTION
* Grammar and language correction to pages under architecture
* Fixing broken links. 
* Adding redirection place holders for old "packages" and "system" sections to redirect to "api" and "architecture" sections.