### PR TITLE
filling out scala and r API pages

### DIFF
--- a/docs/api/r/index.md
+++ b/docs/api/r/index.md
@@ -6,8 +6,6 @@ MXNet supports the R programming language. The MXNet R package brings flexible a
 computing and state-of-art deep learning to R. It enables you to write seamless tensor/matrix computation with multiple GPUs in R. It also lets you construct and customize the state-of-art deep learning models in R,
   and apply them to tasks, such as image classification and data science challenges.
 
-## R
-
 You can perform tensor or matrix computation in R:
 
 ```r
@@ -23,7 +21,6 @@ You can perform tensor or matrix computation in R:
    [1,]    2    2    2
    [2,]    2    2    2
 ```
-
 ## Resources
 
 * [MXNet R Reference Manual](http://mxnet.io/api/r/mxnet-r-reference-manual.pdf)

--- a/docs/api/r/index.md
+++ b/docs/api/r/index.md
@@ -1,13 +1,31 @@
 # MXNet - R API
 
+See the [MXNet R Reference Manual](http://mxnet.io/api/r/mxnet-r-reference-manual.pdf).
+
 MXNet supports the R programming language. The MXNet R package brings flexible and efficient GPU
 computing and state-of-art deep learning to R. It enables you to write seamless tensor/matrix computation with multiple GPUs in R. It also lets you construct and customize the state-of-art deep learning models in R,
   and apply them to tasks, such as image classification and data science challenges.
 
-We are working on the MXNet for R API interface documentation. Until it's available, see the following resource to get started.
+## R
+
+You can perform tensor or matrix computation in R:
+
+```r
+   > require(mxnet)
+   Loading required package: mxnet
+   > a <- mx.nd.ones(c(2,3))
+   > a
+        [,1] [,2] [,3]
+   [1,]    1    1    1
+   [2,]    1    1    1
+   > a + 1
+        [,1] [,2] [,3]
+   [1,]    2    2    2
+   [2,]    2    2    2
+```
 
 ## Resources
 
-* [MXNet for R Tutorials](http://mxnet.io/tutorials/index.html#R-Tutorials)
 * [MXNet R Reference Manual](http://mxnet.io/api/r/mxnet-r-reference-manual.pdf)
+* [MXNet for R Tutorials](http://mxnet.io/tutorials/index.html#R-Tutorials)
 

--- a/docs/api/scala/index.md
+++ b/docs/api/scala/index.md
@@ -1,11 +1,31 @@
 # MXNet - Scala API
 
+See the [MXNet Scala API Documentation](http://mxnet.io/api/scala/docs/index.html).
+
 MXNet supports the Scala programming language. The MXNet Scala package brings flexible and efficient GPU
 computing and state-of-art deep learning to Scala. It enables you to write seamless tensor/matrix computation with multiple GPUs in Scala. It also lets you construct and customize the state-of-art deep learning models in Scala,
   and apply them to tasks, such as image classification and data science challenges.
 
+You can perform tensor or matrix computation in pure Scala:
+
+ ```scala
+    scala> import ml.dmlc.mxnet._
+    import ml.dmlc.mxnet._
+
+    scala> val arr = NDArray.ones(2, 3)
+    arr: ml.dmlc.mxnet.NDArray = ml.dmlc.mxnet.NDArray@f5e74790
+
+    scala> arr.shape
+    res0: ml.dmlc.mxnet.Shape = (2,3)
+
+    scala> (arr * 2).toArray
+    res2: Array[Float] = Array(2.0, 2.0, 2.0, 2.0, 2.0, 2.0)
+
+    scala> (arr * 2).shape
+    res3: ml.dmlc.mxnet.Shape = (2,3)
+ ```
+
 ## Resources
 
-* [MXNet Tutorials](http://mxnet.io/tutorials/index.html)
 * [MXNet Scala API Documentation](http://mxnet.io/api/scala/docs/index.html)
-
+* [Neural Style in Scala on MXNet](https://github.com/dmlc/mxnet/blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/NeuralStyle.scala)


### PR DESCRIPTION
They're too bare and the API doc links aren't prominent enough.

Moving API links to top of page, adding the tensor computation code from get_started.

Also adding Neural Style. We don't have any scala tutorials. Made https://github.com/dmlc/mxnet/issues/3892 for this.