### PR TITLE
pointing pretrained models link to predict_imagenet notebook.

### DIFF
--- a/docs/how_to/index.md
+++ b/docs/how_to/index.md
@@ -7,7 +7,7 @@ This topic provides links to guidelines for using MXNet.
 - [How to train with multiple GPUs in model parallelism - train LSTM](model_parallel_lstm.md)
 - [How to run MXNet on smart or mobile devices](smart_device.md)
 - [How to set up MXNet on the AWS Cloud using Amazon EC2 and Amazon S3](cloud.md)
-- [How to use pre-trained models](pretrained.md)
+- [How to use pre-trained models](http://mxnet.io/tutorials/python/predict_imagenet.html)
 - [How to use MXNet on variable input length/size (bucketing)](bucketing.md)
 - [How to improve MXNet performance](perf.md)
 

--- a/docs/how_to/pretrained.md
+++ b/docs/how_to/pretrained.md
@@ -1,7 +1,0 @@
-Pretrained Model Gallery
-========================
-This topic provides links to the pretrained MXNet models.
-
-* [89.9% Top-5 Validation Accuracy for ImageNet 1,000 Classes Challenge](https://github.com/dmlc/mxnet-model-gallery/blob/master/imagenet-1k-inception-bn.md)
-* [37.2% Top-1 Training Accuracy for Full ImageNet 21,841 Classes](https://github.com/dmlc/mxnet-model-gallery/blob/master/imagenet-21k-inception.md)
-

--- a/docs/tutorials/computer_vision/image_classification.md
+++ b/docs/tutorials/computer_vision/image_classification.md
@@ -96,7 +96,7 @@ program, see this [tutorial](http://mxnet.io/how_to/multi_devices.html).
 ## Generating Predictions
 You have several options for generating predictions:
 
-- [Use a pre-trained model](../notebooks/predict-with-pretrained-model.ipynb). More pre-trained models are provided in the [model gallery](https://github.com/dmlc/mxnet-model-gallery).
+- [Use a pre-trained model](http://mxnet.io/how_to/pretrained.html). More pre-trained models are provided in the [model gallery](https://github.com/dmlc/mxnet-model-gallery).
 - Use your own datasets.
 - You can also easily run the prediction on various devices, such as
 [Android/iOS](http://dmlc.ml/mxnet/2015/11/10/deep-learning-in-a-single-file-for-smart-device.html).
@@ -162,7 +162,7 @@ recommend using CUDNN.
 
 
 * If you are using more than one GPU, the right `kvstore`. For more information, see
-  [doc/developer-guide/multi_node.md](../../doc/developer-guide/multi_node.md).
+  [this guide](http://mxnet.io/how_to/multi_devices.html#distributed-training-with-multiple-machines).
 
 
 	- For a single computer, the default `local` is often sufficient. For models bigger than 100 MB, such as AlexNet

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -104,6 +104,6 @@ Applications using traditional methods to model classification and regression pr
 *Using a simple multi-layer perceptron to do classification and regression tasks on the mlbench dataset*
 
 ## Other Resources
-- Collection of MXNet Tutorials for NVidia GTC 2016. [MXNet GTC 15 Tutorials](https://github.com/dmlc/mxnet-gtc-tutorial)
 - Collection of [MXNet Code Examples](https://github.com/dmlc/mxnet/tree/master/example)
+- Collection of MXNet Tutorials for NVidia GTC 2016. [MXNet GTC 15 Tutorials](https://github.com/dmlc/mxnet-gtc-tutorial)
 

--- a/docs/tutorials/speech_recognition/speech_lstm.md
+++ b/docs/tutorials/speech_recognition/speech_lstm.md
@@ -5,20 +5,20 @@ You can get the source code for these examples on [GitHub](https://github.com/dm
 
 The examples folder contains examples for speech recognition:
 
-- [lstm_proj.py](lstm.py): Functions for building an LSTM network with and without a projection layer.
-- [io_util.py](io_util.py): Wrapper functions for `DataIter` over speech data.
-- [train_lstm_proj.py](train_lstm_proj.py): A script for training an LSTM acoustic model.
-- [decode_mxnet.py](decode_mxnet.py): A script for decoding an LSTMP acoustic model.
-- [default.cfg](default.cfg): Configuration for training on the `AMI` SDM1 dataset. You can use it as a template for writing other configuration files.
-- [python_wrap](python_wrap): C wrappers for Kaldi C++ code, built into an .so file. Python code that loads the .so file and calls the C wrapper functions in `io_func/feat_readers/reader_kaldi.py`.
+- [lstm_proj.py](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/lstm_proj.py): Functions for building an LSTM network with and without a projection layer.
+- [io_util.py](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/io_util.py): Wrapper functions for `DataIter` over speech data.
+- [train_lstm_proj.py](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/train_lstm_proj.py): A script for training an LSTM acoustic model.
+- [decode_mxnet.py](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/decode_mxnet.py): A script for decoding an LSTMP acoustic model.
+- [default.cfg](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/default.cfg): Configuration for training on the `AMI` SDM1 dataset. You can use it as a template for writing other configuration files.
+- [python_wrap](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/python_wrap): C wrappers for Kaldi C++ code, built into an .so file. Python code that loads the .so file and calls the C wrapper functions in `io_func/feat_readers/reader_kaldi.py`.
 
 Connect to Kaldi:
 
-- [decode_mxnet.sh](decode_mxnet.sh): Called by Kaldi to decode an acoustic model trained by MXNet (select the `simple` method for decoding).
+- [decode_mxnet.sh](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/decode_mxnet.sh): Called by Kaldi to decode an acoustic model trained by MXNet (select the `simple` method for decoding).
 
 A full receipt:
 
-- [run_ami.sh](run_ami.sh): A full receipt to train and decode an acoustic model on AMI. It takes features and alignment from Kaldi to train an acoustic model and decode it.
+- [run_ami.sh](https://github.com/dmlc/mxnet/tree/master/example/speech-demo/run_ami.sh): A full receipt to train and decode an acoustic model on AMI. It takes features and alignment from Kaldi to train an acoustic model and decode it.
 
 To create the speech acoustic modeling example, use the following steps.
 


### PR DESCRIPTION
This page is underdeveloped, and isn't a how-to despite being listed as a how-to: http://mxnet.io/how_to/pretrained.html

This is much better: http://mxnet.io/tutorials/python/predict_imagenet.html -- I have a PR in mxnet notebooks that updates this and links to the MXNet model gallery: https://github.com/dmlc/mxnet-notebooks/pull/11