### PR TITLE
checking if args has a "benchmark" attribute

### DIFF
--- a/example/image-classification/train_model.py
+++ b/example/image-classification/train_model.py
@@ -88,8 +88,7 @@ def fit(args, network, data_loader, batch_end_callback=None):
             batch_end_callback = [batch_end_callback]
     else:
         batch_end_callback = []
-
-    if args.benchmark:
+    if hasattr(args, 'benchmark') and args.benchmark:
         batch_end_callback.append(mx.callback.Speedometer(args.batch_size, 10))
         # don't run evaluation for benchmark
         model.fit(


### PR DESCRIPTION
The commit adding benchmarks for imagenet broke the python MNIST example due to the args.benchmark check. The argparse Namespace module holds its arguments as attributes, so the simple 'if falsey' check doesn't work since there's no 'benchmark' attribute unless it's explicitly passed in, which would otherwise have to be added to all python examples calling train_model's fit function.

(also adding a newline at the end of the file)