### PR TITLE
adding r html docs

### DIFF
--- a/R-package/man/build_html.r
+++ b/R-package/man/build_html.r
@@ -1,0 +1,12 @@
+"Helper function to generate HTML from .rd files for docs build. Courtesy of http://yihui.name/en/2012/10/build-static-html-help/"
+static_help = function(pkg, links = tools::findHTMLlinks()) {
+  pkgRdDB = tools:::fetchRdDB(file.path(find.package(pkg), 'help', pkg))
+  force(links); topics = names(pkgRdDB)
+  for (p in topics) {
+    tools::Rd2HTML(pkgRdDB[[p]], paste(p, 'html', sep = '.'),
+                   package = pkg, Links = links, no_links = is.null(links))
+  }
+}
+
+static_help("mxnet")
+

--- a/docs/api/r/html_docs/make_markdown.sh
+++ b/docs/api/r/html_docs/make_markdown.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Removing this so a previous index.md doesn't get appended to.
+rm -f index.md
+
+echo -e "# MXNet - R API HTML Documentation" >> index.md
+
+for f in `ls | grep .*html | grep -v 'mxnet\.html'`
+do
+    echo -e "## $f\n" | sed 's/\.html//' >> index.md
+    html2text $f | tail -n+6 | grep -v "* * *" | grep -v "Package _mxnet_" >> index.md
+done

--- a/docs/api/r/index.md
+++ b/docs/api/r/index.md
@@ -23,6 +23,7 @@ You can perform tensor or matrix computation in R:
 ```
 ## Resources
 
+* [MXNet R HTML Documentation](http://mxnet.io/api/r/html_docs/index.html)
 * [MXNet R Reference Manual](http://mxnet.io/api/r/mxnet-r-reference-manual.pdf)
 * [MXNet for R Tutorials](http://mxnet.io/tutorials/index.html#R-Tutorials)
 

--- a/docs/sphinx_util.py
+++ b/docs/sphinx_util.py
@@ -16,13 +16,17 @@ def run_build_mxnet(folder):
     except OSError as e:
         sys.stderr.write("build execution failed: %s" % e)
 
-def build_r_docs(root_path):
+def build_r_pdf_docs(root_path):
     r_root = os.path.join(root_path, 'R-package')
     pdf_path = os.path.join(root_path, 'docs', 'api', 'r', 'mxnet-r-reference-manual.pdf')
     subprocess.call('cd ' + r_root +'; R CMD Rd2pdf . --no-preview -o ' + pdf_path, shell = True)
     dest_path = os.path.join(root_path, 'docs', '_build', 'html', 'api', 'r')
     subprocess.call('mkdir -p ' + dest_path, shell = True)
     subprocess.call('mv ' + pdf_path + ' ' + dest_path, shell = True)
+
+def build_r_html_docs():
+    subprocess.call('mkdir -p api/r/html_docs', shell = True)
+    subprocess.call('cd api/r/html_docs; Rscript ../../../../R-package/man/build_html.r; bash make_markdown.sh', shell = True)
 
 def build_scala_docs(root_path):
     scala_path = os.path.join(root_path, 'scala-package', 'core', 'src', 'main', 'scala', 'ml', 'dmlc', 'mxnet')
@@ -47,7 +51,8 @@ curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 root_path = os.path.join(curr_path, '..')
 run_build_mxnet(root_path)
 
-build_r_docs(root_path)
+build_r_pdf_docs(root_path)
+build_r_html_docs()
 
 build_scala_docs(root_path)
 
@@ -57,3 +62,4 @@ from recommonmark import parser, transform
 
 MarkdownParser = parser.CommonMarkParser
 AutoStructify = transform.AutoStructify
+


### PR DESCRIPTION
@mli This uses https://github.com/aaronsw/html2text, so you'll need to python setup.py install that on the build server.

Adding R html docs. Currently all on one page under api/r/html_docs/index.html.

This converts the .rd files to HTML, then converts those to markdown and does some post processing. There isn't a good way to convert .rd files to markdown directly, as far as I can tell. We need them in markdown for Sphinx to apply the CSS and JS -- the HTML that Rd2HTML makes is just plain HTML pages.