### PR TITLE
add a fine-tune link in how-to

### DIFF
--- a/docs/how_to/index.md
+++ b/docs/how_to/index.md
@@ -3,11 +3,12 @@
 This topic provides links to guidelines for using MXNet.
 
 ## Use MXNet on Specific Tasks
+- [How to use pre-trained models](http://mxnet.io/tutorials/python/predict_imagenet.html)
+- [How to use Fine-tune with Pre-trained Models](http://mxnet.io/how_to/finetune.html)
 - [How to train with multiple CPU/GPUs with data parallelism](multi_devices.md)
 - [How to train with multiple GPUs in model parallelism - train LSTM](model_parallel_lstm.md)
 - [How to run MXNet on smart or mobile devices](smart_device.md)
 - [How to set up MXNet on the AWS Cloud using Amazon EC2 and Amazon S3](cloud.md)
-- [How to use pre-trained models](http://mxnet.io/tutorials/python/predict_imagenet.html)
 - [How to use MXNet on variable input length/size (bucketing)](bucketing.md)
 - [How to improve MXNet performance](perf.md)
 - [How to use MXNet within a Matlab environment](https://github.com/dmlc/mxnet/tree/master/matlab)


### PR DESCRIPTION
just add a missing link for fine-tune

[发现how-to中没有连接到fine-tune的地方，而notebook里面有，因此增加之。另外，觉得pre-train与fine-tune对初学者更有用，因此放到最前面]