### PR TITLE
[Python] Python2/3 Support for example/image-classification

### DIFF
--- a/example/image-classification/benchmark.py
+++ b/example/image-classification/benchmark.py
@@ -1,3 +1,4 @@
+
 import logging
 import argparse
 import os
@@ -12,7 +13,7 @@ import importlib
 import collections
 import threading
 import copy
-
+from past.builtins import xrange
 '''
 Setup Logger and LogLevel
 '''
@@ -81,8 +82,8 @@ def parse_args():
         def validate(self, attrs):
             args = attrs.split(':')
             if len(args) != 3 or isinstance(args[0], str) == False:
-                print 'expected network attributes in format network_name:batch_size:image_size \
-                \nThe network_name is a valid model defined as network_name.py in the image-classification/symbol folder.'
+                print('expected network attributes in format network_name:batch_size:image_size \
+                \nThe network_name is a valid model defined as network_name.py in the image-classification/symbol folder.')
                 sys.exit(1)
             try:
                 #check if the network exists
@@ -91,9 +92,9 @@ def parse_args():
                 img_size = int(args[2])
                 return Network(name=args[0], batch_size=batch_size, img_size=img_size)
             except Exception as e:
-                print 'expected network attributes in format network_name:batch_size:image_size \
-                \nThe network_name is a valid model defined as network_name.py in the image-classification/symbol folder.'
-                print e
+                print('expected network attributes in format network_name:batch_size:image_size \
+                \nThe network_name is a valid model defined as network_name.py in the image-classification/symbol folder.')
+                print(e)
                 sys.exit(1)
         def __init__(self, *args, **kw):
             kw['nargs'] = '+'

--- a/example/image-classification/symbol/resnet.py
+++ b/example/image-classification/symbol/resnet.py
@@ -124,11 +124,11 @@ def get_symbol(num_classes, num_layers, image_shape, conv_workspace=256, **kwarg
     if height <= 28:
         num_stages = 3
         if (num_layers-2) % 9 == 0 and num_layers >= 164:
-            per_unit = [(num_layers-2)/9]
+            per_unit = [(num_layers-2)//9]
             filter_list = [16, 64, 128, 256]
             bottle_neck = True
         elif (num_layers-2) % 6 == 0 and num_layers < 164:
-            per_unit = [(num_layers-2)/6]
+            per_unit = [(num_layers-2)//6]
             filter_list = [16, 16, 32, 64]
             bottle_neck = False
         else:

--- a/example/image-classification/test_score.py
+++ b/example/image-classification/test_score.py
@@ -21,7 +21,7 @@ def test_imagenet1k_resnet(args):
         (speed,) = score(model=m, data_val='data/val-5k-256.rec',
                          rgb_mean='0,0,0', metrics=acc, **vars(args))
         r = acc.get()[1]
-        print 'testing %s, acc = %f, speed = %f img/sec' % (m, r, speed)
+        print('testing %s, acc = %f, speed = %f img/sec' % (m, r, speed))
         assert r > g and r < g + .1
 
 def test_imagenet1k_inception_bn(args):
@@ -32,7 +32,7 @@ def test_imagenet1k_inception_bn(args):
                      data_val='data/val-5k-256.rec',
                      rgb_mean='123.68,116.779,103.939', metrics=acc, **vars(args))
     r = acc.get()[1]
-    print 'Tested %s acc = %f, speed = %f img/sec' % (m, r, speed)
+    print('Tested %s acc = %f, speed = %f img/sec' % (m, r, speed))
     assert r > g and r < g + .1
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding python2/3 compatible support for example/image-classification
I have tested on python 3.5.2 and python 2.7.12 for train_mnist.py, train_cifar10.py, train_imagenet.py with benchmark on/off, gpus on/off. 
Let me know if there any questions.
This is related to issue #4071 