### PR TITLE
change ctcComputeInfo  to ctcOptions for latest warp ctc

### DIFF
--- a/plugin/warpctc/warpctc-inl.h
+++ b/plugin/warpctc/warpctc-inl.h
@@ -120,7 +120,7 @@ class WarpCTCOp : public Operator {
     TBlob data = in_data[warpctc_enum::kData];
     TBlob label = in_data[warpctc_enum::kLabel];
     CHECK_EQ(data.shape_.ndim(), 2) << "input data shape should be 2 (t*n, p)";
-    ctcComputeInfo info;
+    ctcOptions info;
     if (data.dev_mask_ == cpu::kDevMask) {
       info.loc = CTC_CPU;
       info.num_threads = 1;


### PR DESCRIPTION
the parameter name changed from ctcComputeInfo  to ctcOption in warp ctc.