### PR TITLE
fixed the main() function of convert_symbol.py

### DIFF
--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -200,7 +200,7 @@ def proto2symbol(proto_file):
     return ret, input_dim
 
 def main():
-    symbol_string, output_name = proto2script(sys.argv[1])
+    symbol_string, output_name, input_dim = proto2script(sys.argv[1])
     if len(sys.argv) > 2:
         with open(sys.argv[2], 'w') as fout:
             fout.write(symbol_string)


### PR DESCRIPTION
This error is occurred when execute tools/caffe_converter/convert_symbol.py 

Traceback (most recent call last):
  File "convert_symbol.py", line 211, in <module>
    main()
  File "convert_symbol.py", line 203, in main
    symbol_string, output_name = proto2script(sys.argv[1])
ValueError: too many values to unpack

I fixed the main() function of convert_symbol.py (#4121)