### PR TITLE
Fix amalgamation scipt.

### DIFF
--- a/amalgamation/README.md
+++ b/amalgamation/README.md
@@ -18,6 +18,8 @@ Dependency
 ----------
 The only dependency is a BLAS library.
 
+Make sure to disable all other dependencies in the `config.mk` file.
+
 Acknowledgement
 ---------------
 This module is created by [Jack Deng](https://github.com/jdeng).

--- a/amalgamation/amalgamation.py
+++ b/amalgamation/amalgamation.py
@@ -7,7 +7,8 @@ blacklist = [
     'glog/logging.h', 'io/azure_filesys.h', 'io/hdfs_filesys.h', 'io/s3_filesys.h',
     'kvstore_dist.h', 'mach/clock.h', 'mach/mach.h',
     'malloc.h', 'mkl.h', 'mkl_cblas.h', 'mkl_vsl.h', 'mkl_vsl_functions.h',
-    'nvml.h', 'opencv2/opencv.hpp', 'sys/stat.h', 'sys/types.h', 'cuda.h', 'cuda_fp16.h'
+    'nvml.h', 'opencv2/opencv.hpp', 'sys/stat.h', 'sys/types.h', 'cuda.h', 'cuda_fp16.h',
+    'omp.h'
     ]
 
 if len(sys.argv) < 4:
@@ -87,7 +88,10 @@ def expand(x, pending):
         h = m.groups()[0].strip('./')
         source = find_source(h, x)
         if not source:
-            if h not in blacklist and h not in sysheaders: sysheaders.append(h)
+            if (h not in blacklist and
+                h not in sysheaders and
+                'mkl' not in h and
+                'nnpack' not in h): sysheaders.append(h)
         else:
             expand(source, pending + [x])
     print >>out, "//===== EXPANDED: %s =====\n" %x


### PR DESCRIPTION
Fix amalgamation scipt and document that all other dependencies shall be disabled in config.mk.

This includes the changes proposed in https://github.com/dmlc/mxnet/issues/3667#issuecomment-265118194.

Without these changes, calling e.g. `make MIN=1 libmxnet_predict.js` in the amalgamation folder will fail due to unresolved dependencies (e.g. `#include <mkl/mkl_batch_norm-inl.h>`)