### PR TITLE
[Profiler] support native engine

### DIFF
--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -5,7 +5,9 @@
  */
 #include <vector>
 #include <atomic>
+#include <thread>
 #include "./engine_impl.h"
+#include "./profiler.h"
 
 namespace mxnet {
 namespace engine {
@@ -19,12 +21,23 @@ class NaiveEngine final : public Engine {
     std::vector<VarHandle> mutable_vars;
     FnProperty prop;
     const char* opr_name;
+    /*! \brief indicate whether to profile this operator */
+    bool profiling{false};
+    /*! \brief operator execution statistics */
+    OprExecStat *opr_stat;
   };
 
   NaiveEngine() {
   }
   // virtual destructor
   virtual ~NaiveEngine() {
+#if MXNET_USE_PROFILER
+  // dump trace file if profiler is enabled when engine is destructed.
+  Profiler* profiler = Profiler::Get();
+  if (profiler->IsEnableOutput()) {
+    profiler->DumpProfile();
+  }
+#endif
 #if MXNET_USE_CUDA
     LOG(INFO) << "Engine shutdown";
     for (size_t i = 0; i < streams_.size(); ++i) {
@@ -42,6 +55,7 @@ class NaiveEngine final : public Engine {
     size_t v = ++counter_;
     return reinterpret_cast<VarHandle>(v);
   }
+
   OprHandle NewOperator(AsyncFn fn,
                         std::vector<VarHandle> const& const_vars,
                         std::vector<VarHandle> const& mutable_vars,
@@ -55,20 +69,41 @@ class NaiveEngine final : public Engine {
     opr->opr_name = opr_name;
     return opr;
   }
+
   void DeleteOperator(OprHandle op) override {
     NaiveOpr *opr = op->Cast<NaiveOpr>();
     delete opr;
   }
+
   void Push(OprHandle op, Context exec_ctx, int priority = 0, bool profiling = false) override {
     NaiveOpr *opr = op->Cast<NaiveOpr>();
-    this->PushAsync(opr->fn,
-                    exec_ctx,
-                    opr->const_vars,
-                    opr->mutable_vars,
-                    opr->prop,
-                    priority,
-                    PROFILER_MESSAGE(opr->opr_name));
+    opr->profiling = profiling;
+    this->PushAsync([&](RunContext ctx, CallbackOnComplete on_complete) {
+#if MXNET_USE_PROFILER
+        if (opr->profiling) {
+          opr->opr_stat = Profiler::Get()->AddOprStat(exec_ctx.dev_type, exec_ctx.dev_id);
+          uint64_t id = std::hash<std::thread::id>()(std::this_thread::get_id());
+          opr->opr_stat->thread_id = id;
+          opr->opr_stat->opr_name  = std::string(opr->opr_name);
+          CallbackOnComplete callback = CreateCallback(NaiveEngine::OnComplete, opr);
+          // record operator start timestamp
+          SetOprStart(opr->opr_stat);
+          opr->fn(ctx, callback);
+        } else {
+          opr->fn(ctx, on_complete);
+        }
+#else
+        opr->fn(ctx, on_complete);
+#endif
+      },
+      exec_ctx,
+      opr->const_vars,
+      opr->mutable_vars,
+      opr->prop,
+      priority,
+      PROFILER_MESSAGE(opr->opr_name));
   }
+
   void PushAsync(AsyncFn exec_fun,
                  Context exec_ctx,
                  std::vector<VarHandle> const& const_vars,
@@ -102,14 +137,18 @@ class NaiveEngine final : public Engine {
     CHECK(this->req_completed_)
         << "NaiveEngine only support synchronize Push so far";
   }
+
   void DeleteVariable(SyncFn delete_fn, Context exec_ctx, VarHandle var) override {
     this->PushSync(delete_fn, exec_ctx, {}, {var},
                    FnProperty::kNormal, 0, PROFILER_MESSAGE("DeleteVariable"));
   }
+
   void WaitForVar(VarHandle var) override {
   }
+
   void WaitForAll() override {
   }
+
   void NotifyShutdown() override {
     shutdown_phase_.store(true);
   }
@@ -118,6 +157,15 @@ class NaiveEngine final : public Engine {
   // callback to oncomplete
   static void OnComplete(Engine *engine, void *param) {
     static_cast<NaiveEngine*>(engine)->req_completed_ = true;
+#if MXNET_USE_PROFILER
+    if (param != nullptr) {
+      NaiveOpr *opr = static_cast<NaiveOpr*>(param);
+      if (opr->profiling && opr->opr_name) {
+        // record operator end timestamp
+        SetOprEnd(opr->opr_stat);
+      }
+    }
+#endif
   }
   // runtime contetxt
   RunContext ctx_;


### PR DESCRIPTION
we need pass flag `profiling` to `PushAsync()`, but `interface of `PushAsync()` is non-changable `, so we pass a lamda function to `PushAsync()`, and it needs to see `NaiveEngine::OnComplete` in capture list, so use `&` there.

now we can use profiler to  analyze native engine, here is the one example:
![image](https://cloud.githubusercontent.com/assets/5860892/20966971/f602e484-bcb7-11e6-8d49-af9c803e73f3.png)

@ZihengJiang @piiswrong 