### PR TITLE
fix segmentation faults in c api

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1328,7 +1328,7 @@ MXNET_DLL int MXRecordIOWriterFree(RecordIOHandle handle);
  * \param size size of buffer
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOWriterWriteRecord(RecordIOHandle *handle,
+MXNET_DLL int MXRecordIOWriterWriteRecord(RecordIOHandle handle,
                                           const char *buf, size_t size);
 
 /**
@@ -1337,7 +1337,7 @@ MXNET_DLL int MXRecordIOWriterWriteRecord(RecordIOHandle *handle,
  * \param pos handle to output position
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOWriterTell(RecordIOHandle *handle, size_t *pos);
+MXNET_DLL int MXRecordIOWriterTell(RecordIOHandle handle, size_t *pos);
 
 /**
  * \brief Create a RecordIO reader object
@@ -1352,7 +1352,7 @@ MXNET_DLL int MXRecordIOReaderCreate(const char *uri, RecordIOHandle *out);
  * \param handle handle to RecordIO object
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOReaderFree(RecordIOHandle *handle);
+MXNET_DLL int MXRecordIOReaderFree(RecordIOHandle handle);
 
 /**
  * \brief Write a record to a RecordIO object
@@ -1361,7 +1361,7 @@ MXNET_DLL int MXRecordIOReaderFree(RecordIOHandle *handle);
  * \param size point to size of buffer
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOReaderReadRecord(RecordIOHandle *handle,
+MXNET_DLL int MXRecordIOReaderReadRecord(RecordIOHandle handle,
                                         char const **buf, size_t *size);
 
 /**
@@ -1370,7 +1370,7 @@ MXNET_DLL int MXRecordIOReaderReadRecord(RecordIOHandle *handle,
  * \param pos target position
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOReaderSeek(RecordIOHandle *handle, size_t pos);
+MXNET_DLL int MXRecordIOReaderSeek(RecordIOHandle handle, size_t pos);
 
 /**
  * \brief Create a MXRtc object

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1396,7 +1396,7 @@ int MXRecordIOWriterFree(RecordIOHandle handle) {
   API_END();
 }
 
-int MXRecordIOWriterWriteRecord(RecordIOHandle *handle,
+int MXRecordIOWriterWriteRecord(RecordIOHandle handle,
                                 const char *buf, size_t size) {
   API_BEGIN();
   MXRecordIOContext *context =
@@ -1405,7 +1405,7 @@ int MXRecordIOWriterWriteRecord(RecordIOHandle *handle,
   API_END();
 }
 
-int MXRecordIOWriterTell(RecordIOHandle *handle, size_t *pos) {
+int MXRecordIOWriterTell(RecordIOHandle handle, size_t *pos) {
   API_BEGIN();
   MXRecordIOContext *context =
     reinterpret_cast<MXRecordIOContext*>(handle);
@@ -1426,7 +1426,7 @@ int MXRecordIOReaderCreate(const char *uri,
   API_END();
 }
 
-int MXRecordIOReaderFree(RecordIOHandle *handle) {
+int MXRecordIOReaderFree(RecordIOHandle handle) {
   API_BEGIN();
   MXRecordIOContext *context =
     reinterpret_cast<MXRecordIOContext*>(handle);
@@ -1436,7 +1436,7 @@ int MXRecordIOReaderFree(RecordIOHandle *handle) {
   API_END();
 }
 
-int MXRecordIOReaderReadRecord(RecordIOHandle *handle,
+int MXRecordIOReaderReadRecord(RecordIOHandle handle,
                               char const **buf, size_t *size) {
   API_BEGIN();
   MXRecordIOContext *context =
@@ -1451,7 +1451,7 @@ int MXRecordIOReaderReadRecord(RecordIOHandle *handle,
   API_END();
 }
 
-int MXRecordIOReaderSeek(RecordIOHandle *handle, size_t pos) {
+int MXRecordIOReaderSeek(RecordIOHandle handle, size_t pos) {
   API_BEGIN();
   MXRecordIOContext *context =
     reinterpret_cast<MXRecordIOContext*>(handle);


### PR DESCRIPTION
We tried to use the c api to create recordio files and observed segmentation faults.  This should fix it. The root of the problem was the usage of void** instead of void* in the api interface.