### PR TITLE
[OP] Implementations for prod, nansum and nanprod

### DIFF
--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -134,6 +134,36 @@ def assert_almost_equal(a, b, threshold=None):
         raise Exception(msg)
     return rel
 
+def almost_equal_ignore_nan(a, b, rtol=None, atol=None):
+    """Test that two numpy arrays are almost equal (ignoring NaN in either array).
+    Combines a relative and absolute measure of approximate eqality.
+    If either the relative or absolute check passes, the arrays are considered equal.
+    Including an absolute check resolves issues with the relative check where all
+    array values are close to zero.
+
+    Parameters
+    ----------
+    a : np.ndarray
+    b : np.ndarray
+    rtol : None or float
+        The relative threshold. Default threshold will be used if set to None
+    atol : None or float
+        The absolute threshold. Default threshold will be used if set to None
+    """
+    a = np.copy(a)
+    b = np.copy(b)
+    nan_mask = np.logical_or(np.isnan(a), np.isnan(b))
+    a[nan_mask] = 0
+    b[nan_mask] = 0
+
+    rtol = rtol or default_numerical_threshold()
+    atol = atol or default_numerical_threshold()
+
+    rel_approx_equal = reldiff(a, b) <= rtol
+    abs_approx_equal = np.sum(np.abs(a - b) > atol) == 0
+
+    return rel_approx_equal or abs_approx_equal
+
 
 def simple_forward(sym, ctx=None, is_train=False, **inputs):
     """A simple forward function for a symbol.

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -806,7 +806,7 @@ namespace isnan_typed {
   MSHADOW_XINLINE bool IsNan(volatile mshadow::half::half_t val) {
     return (val.half_ & 0x7fff) > 0x7c00;
   }
-};
+};  // namespace isnan_typed
 
 /*! \brief sum reducer that ignores NaN values in the input */
 struct nansum {
@@ -854,8 +854,7 @@ struct nanprod {
       } else {
         dst = src;
       }
-    }
-    else {
+    } else {
       if (isnan_typed::IsNan(src)) {
         dst = dst;
       } else {

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -760,6 +760,125 @@ struct smooth_l1_gradient {
   }
 };  // struct smooth_l1_derivative
 
+/*! \brief product reducer */
+struct product {
+  /*! \brief do reduction into dst */
+  template<typename DType>
+  MSHADOW_XINLINE static void Reduce(volatile DType& dst, volatile DType src) { // NOLINT(*)
+    dst *= src;
+  }
+  /*!
+  *\brief calculate gradient of redres with respect to redsrc,
+  * redres: reduced result, redsrc: one of reduction element
+  */
+  template<typename DType>
+  MSHADOW_XINLINE static DType PartialGrad(DType redres, DType redsrc) {
+    return redres / redsrc;
+  }
+  /*!
+  *\brief set the initial value during reduction
+  */
+  template<typename DType>
+  MSHADOW_XINLINE static void SetInitValue(DType &initv) { // NOLINT(*)
+    initv = 1;
+  }
+};
+
+namespace isnan_typed {
+  template<typename DType>
+  MSHADOW_XINLINE bool IsNan(volatile DType val) {
+    return false;
+  }
+  template<>
+  MSHADOW_XINLINE bool IsNan(volatile float val) {
+    return isnan(val);
+  }
+  template<>
+  MSHADOW_XINLINE bool IsNan(volatile double val) {
+    return isnan(val);
+  }
+  template<>
+  MSHADOW_XINLINE bool IsNan(volatile long double val) {
+    return isnan(val);
+  }
+
+  template<>
+  MSHADOW_XINLINE bool IsNan(volatile mshadow::half::half_t val) {
+    return (val.half_ & 0x7fff) > 0x7c00;
+  }
+};
+
+/*! \brief sum reducer that ignores NaN values in the input */
+struct nansum {
+  /*! \brief do reduction into dst */
+  template<typename DType>
+  MSHADOW_XINLINE static void Reduce(volatile DType& dst, volatile DType src) { // NOLINT(*)
+    if (isnan_typed::IsNan(dst)) {
+      if (isnan_typed::IsNan(src)) {
+        dst = DType(0);
+      } else {
+        dst = src;
+      }
+    } else {
+      if (isnan_typed::IsNan(src)) {
+        dst = dst;
+      } else {
+        dst += src;
+      }
+    }
+  }
+  /*!
+  *\brief set the initial value during reduction
+  */
+  template<typename DType>
+  MSHADOW_XINLINE static void SetInitValue(DType & initv) { // NOLINT(*)
+      initv = 0;
+  }
+};
+
+struct nansum_grad {
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return isnan_typed::IsNan(a) ? DType(0) : DType(1);
+  }
+};
+
+/*! \brief product reducer that ignores NaN values in the input */
+struct nanprod {
+  /*! \brief do reduction into dst */
+  template<typename DType>
+  MSHADOW_XINLINE static void Reduce(volatile DType& dst, volatile DType src) { // NOLINT(*)
+    if (isnan_typed::IsNan(dst)) {
+      if (isnan_typed::IsNan(src)) {
+        dst = DType(1);
+      } else {
+        dst = src;
+      }
+    }
+    else {
+      if (isnan_typed::IsNan(src)) {
+        dst = dst;
+      } else {
+        dst *= src;
+      }
+    }
+  }
+  /*!
+  *\brief set the initial value during reduction
+  */
+  template<typename DType>
+  MSHADOW_XINLINE static void SetInitValue(DType & initv) { // NOLINT(*)
+    initv = 1;
+  }
+};
+
+struct nanprod_grad {
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return isnan_typed::IsNan(a) ? DType(0) : b / a;
+  }
+};
+
 }  // namespace mshadow_op
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -22,6 +22,36 @@ MXNET_OPERATOR_REGISTER_REDUCE_BACKWARD(_backward_sum)
 .set_num_inputs(1)
 .set_attr<FCompute>("FCompute<cpu>", ReduceAxesBackwardUseNone<cpu>);
 
+MXNET_OPERATOR_REGISTER_REDUCE(prod)
+.MXNET_DESCRIBE("Compute product of src along axis. "
+"If axis is empty, global reduction is performed")
+.set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute< cpu, mshadow_op::product>)
+.set_attr<nnvm::FGradient>("FGradient", ReduceGrad{ "_backward_prod" });
+
+MXNET_OPERATOR_REGISTER_REDUCE_BACKWARD(_backward_prod)
+.set_num_inputs(3)
+.set_attr<FCompute>("FCompute<cpu>", ReduceAxesBackwardUseInOut< cpu, mshadow_op::rdiv>);
+
+MXNET_OPERATOR_REGISTER_REDUCE(nansum)
+.MXNET_DESCRIBE("Sum src along axis, ignoring NaN values. "
+"If axis is empty, global reduction is performed")
+.set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow_op::nansum>)
+.set_attr<nnvm::FGradient>("FGradient", ReduceGrad{ "_backward_nansum" });
+
+MXNET_OPERATOR_REGISTER_REDUCE_BACKWARD(_backward_nansum)
+.set_num_inputs(3)
+.set_attr<FCompute>("FCompute<cpu>", ReduceAxesBackwardUseInOut<cpu, mshadow_op::nansum_grad>);
+
+MXNET_OPERATOR_REGISTER_REDUCE(nanprod)
+.MXNET_DESCRIBE("Compute product of src along axis, ignoring NaN values. "
+"If axis is empty, global reduction is performed")
+.set_attr<FCompute>("FCompute<cpu>", ReduceAxesCompute<cpu, mshadow_op::nanprod>)
+.set_attr<nnvm::FGradient>("FGradient", ReduceGrad{ "_backward_nanprod" });
+
+MXNET_OPERATOR_REGISTER_REDUCE_BACKWARD(_backward_nanprod)
+.set_num_inputs(3)
+.set_attr<FCompute>("FCompute<cpu>", ReduceAxesBackwardUseInOut<cpu, mshadow_op::nanprod_grad>);
+
 MXNET_OPERATOR_REGISTER_REDUCE(max)
 .add_alias("max_axis")
 .MXNET_DESCRIBE("Compute max along axis. If axis is empty, global reduction is performed")

--- a/src/operator/tensor/broadcast_reduce_op_value.cu
+++ b/src/operator/tensor/broadcast_reduce_op_value.cu
@@ -13,6 +13,24 @@ NNVM_REGISTER_OP(sum)
 NNVM_REGISTER_OP(_backward_sum)
 .set_attr<FCompute>("FCompute<gpu>", ReduceAxesBackwardUseNone<gpu>);
 
+NNVM_REGISTER_OP(prod)
+.set_attr<FCompute>("FCompute<gpu>", ReduceAxesCompute<gpu, mshadow_op::product>);
+
+NNVM_REGISTER_OP(_backward_prod)
+.set_attr<FCompute>("FCompute<gpu>", ReduceAxesBackwardUseInOut<gpu, mshadow_op::rdiv>);
+
+NNVM_REGISTER_OP(nansum)
+.set_attr<FCompute>("FCompute<gpu>", ReduceAxesCompute<gpu, mshadow_op::nansum>);
+
+NNVM_REGISTER_OP(_backward_nansum)
+.set_attr<FCompute>("FCompute<gpu>", ReduceAxesBackwardUseInOut<gpu, mshadow_op::nansum_grad>);
+
+NNVM_REGISTER_OP(nanprod)
+.set_attr<FCompute>("FCompute<gpu>", ReduceAxesCompute<gpu, mshadow_op::nanprod>);
+
+NNVM_REGISTER_OP(_backward_nanprod)
+.set_attr<FCompute>("FCompute<gpu>", ReduceAxesBackwardUseInOut<gpu, mshadow_op::nanprod_grad>);
+
 NNVM_REGISTER_OP(max)
 .set_attr<FCompute>("FCompute<gpu>", ReduceAxesCompute<gpu, mshadow::red::maximum>);
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1005,9 +1005,10 @@ def test_reshape():
 
 def test_reduce():
     sample_num = 200
-    def test_reduce_inner(numpy_reduce_func, numpy_reduce_grad_func, mx_reduce_sym):
+    def test_reduce_inner(numpy_reduce_func, numpy_reduce_grad_func, mx_reduce_sym, nan_prob = 0):
         for i in range(sample_num):
             # Generate random data that has ndim between 1-7 and all the shape dims between 1-5
+            # Insert a NaN with probability equal to nan_prob
             ndim = np.random.randint(1, 6)
             shape = np.random.randint(1, 6, size=(ndim,))
             axis_num = np.random.randint(0, ndim, size=1)
@@ -1029,6 +1030,8 @@ def test_reduce():
             else:
                 b = mx_reduce_sym(a, axis=axes, keepdims=keepdims)
             dat_npy = np.random.rand(*shape)
+            if nan_prob > 0:
+                dat_npy[np.random.rand(*shape) < nan_prob] = np.nan
             sum_groundtruth = np.array(numpy_reduce_func(dat_npy, axis=axes, keepdims=keepdims))
             if sum_groundtruth.shape == ():
                 sum_groundtruth = np.array([sum_groundtruth])
@@ -1044,15 +1047,29 @@ def test_reduce():
                          args_grad={'a': grad_nd})
             net.forward(is_train=True)
 
-            err_forward = reldiff(net.outputs[0].asnumpy(), sum_groundtruth)
-            assert err_forward < 1E-4
+            equal_forward = almost_equal_ignore_nan(net.outputs[0].asnumpy(), sum_groundtruth, 1E-4, 1E-4)
+            assert equal_forward
+
             net.backward(out_grads=mx.nd.array(outgrad_npy))
-            err_backward = reldiff(grad_nd.asnumpy(), grad_groundtruth)
-            assert err_backward < 1E-4
+            bc_grad_groundtruth = np.broadcast_to(grad_groundtruth, grad_nd.shape)
+            equal_backward = almost_equal_ignore_nan(grad_nd.asnumpy(), bc_grad_groundtruth, 1E-4, 1E-4)
+            assert equal_backward
     test_reduce_inner(lambda data, axis, keepdims:np_reduce(data, axis, keepdims, np.sum),
                       lambda outgrad, data, outdata, axis, keepdims, keepdim_shape:
                         outgrad.reshape(keepdim_shape),
                       mx.symbol.sum)
+    test_reduce_inner(lambda data, axis, keepdims:np_reduce(data, axis, keepdims, np.prod),
+                      lambda outgrad, data, outdata, axis, keepdims, keepdim_shape:
+                        outgrad.reshape(keepdim_shape) * (outdata.reshape(keepdim_shape) / data),
+                      mx.symbol.prod)
+    test_reduce_inner(lambda data, axis, keepdims:np_reduce(data, axis, keepdims, np.nansum),
+                      lambda outgrad, data, outdata, axis, keepdims, keepdim_shape:
+                        np.where(np.isnan(data), 0, outgrad.reshape(keepdim_shape)),
+                      mx.symbol.nansum, 0.3)
+    test_reduce_inner(lambda data, axis, keepdims:np_reduce(data, axis, keepdims, np.nanprod),
+                      lambda outgrad, data, outdata, axis, keepdims, keepdim_shape:
+                        np.where(np.isnan(data), 0, outgrad.reshape(keepdim_shape) * (outdata.reshape(keepdim_shape) / data)),
+                      mx.symbol.nanprod, 0.3)
     test_reduce_inner(lambda data, axis, keepdims:np_reduce(data, axis, keepdims, np.max),
                       lambda outgrad, data, outdata, axis, keepdims, keepdim_shape:
                         outgrad.reshape(keepdim_shape) * (np.equal(data, outdata.reshape(keepdim_shape)).astype(np.float)),


### PR DESCRIPTION
Added ops and test cases: prod, nansum and nanprod (see issue #3201)

Added test utility function for checking array equality (almost_equal_combo) because reldiff does not work well when all the elements of both arrays are close to zero. For global reductions of prod() the results are often in the order of ground truth = [1e-20], op output = [0]. For this case, reldiff gives a result of 1.0

Instead, almost_equal_combo uses an element-wise threshold in addition to reldiff - if either of them indicate the op output is close to ground truth then the test passes.

Additionally, almost_equal_combo ignores cells in *both* arrays if the corresponding cell in either array is NaN. This allows it to be used to verify the gradients of nansum and nanprod, where what we care about is getting the gradient of non-NaN inputs correct.