### PR TITLE
fix variable initialization

### DIFF
--- a/src/nnvm/legacy_json_util.cc
+++ b/src/nnvm/legacy_json_util.cc
@@ -90,8 +90,14 @@ Graph UpgradeJSON_FixParsing(Graph g) {
 
 Graph UpgradeJSON_Parse(Graph g) {
   nnvm::DFSVisit(g.outputs, [](const std::shared_ptr<Node>& n) {
-      if (n->op() != nullptr && n->op()->attr_parser != nullptr)
-        n->op()->attr_parser(&(n->attrs));
+      if (n->op() != nullptr) {
+        if (n->op()->attr_parser != nullptr)
+          n->op()->attr_parser(&(n->attrs));
+      } else {
+        // ugly workaround due to VariableParam is not exposed.
+        n->attrs.parsed =
+          nnvm::Symbol::CreateVariable("").outputs[0].node->attrs.parsed;
+      }
     });
   return g;
 }


### PR DESCRIPTION
Fix:
sym, arg_params, aux_params = mx.model.load_checkpoint('resnet-50', 0)
all_layers = sym.get_internals()