### PR TITLE
Adding How To for visualizing network graphs. Updating install guide to install graphviz and jupyter

### DIFF
--- a/docs/get_started/amazonlinux_setup.md
+++ b/docs/get_started/amazonlinux_setup.md
@@ -64,8 +64,8 @@ Install these dependencies using the following commands:
       # Reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/compile-software.html
       # Install Python, Numpy, Scipy and set up tools.
       sudo yum groupinstall -y "Development Tools"
-      sudo yum install -y python27 python27-setuptools python27-tools
-      sudo yum install -y python27-numpy python27-scipy python27-nose python27-matplotlib
+      sudo yum install -y python27 python27-setuptools python27-tools python-pip
+      sudo yum install -y python27-numpy python27-scipy python27-nose python27-matplotlib graphviz
 
       # Install OpenBLAS at /usr/local/openblas
       git clone https://github.com/xianyi/OpenBLAS
@@ -82,9 +82,21 @@ Install these dependencies using the following commands:
       cmake -D BUILD_opencv_gpu=OFF -D WITH_EIGEN=ON -D WITH_TBB=ON -D WITH_CUDA=OFF -D WITH_1394=OFF -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..
       sudo make PREFIX=/usr/local install
 
+      # Install Graphviz for visualization and Jupyter notebook for running examples and tutorials
+      sudo pip install graphviz
+      sudo pip install jupyter
+      
       # Export env variables for pkg config
       export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
 ```
+
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for the programming language of your choice:
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
 
 ### Install the MXNet Package for R
 Run the following commands to install the MXNet dependencies and build the MXNet R package.

--- a/docs/get_started/osx_setup.md
+++ b/docs/get_started/osx_setup.md
@@ -14,11 +14,11 @@ Install the dependencies, required for MXNet, with the following commands:
 - [Homebrew](http://brew.sh/) (to install dependencies)
 
 ```bash
-# Paste this command in Mac terminal to install Homebrew
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	# Paste this command in Mac terminal to install Homebrew
+	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-# Insert the Homebrew directory at the top of your PATH environment variable
-export PATH=/usr/local/bin:/usr/local/sbin:$PATH
+	# Insert the Homebrew directory at the top of your PATH environment variable
+	export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 ```
 - openblas and homebrew/science (for linear algebraic operations)
 - OpenCV (for computer vision operations)
@@ -26,9 +26,16 @@ export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 ```bash
 	brew update
 	brew install pkg-config
+	brew install graphviz
 	brew install openblas
 	brew tap homebrew/science
 	brew install opencv
+	# For getting pip
+	brew install python
+	# For visualization of network graphs
+	pip install graphviz
+	# Jupyter notebook
+	pip install jupyter
 ```
 After you have installed the dependencies, use one of the following options to pull the MXNet source code from Git and build MXNet. Both options produce a library called ```libmxnet.so```.
 
@@ -40,7 +47,7 @@ After you have installed the dependencies, use one of the following options to p
   cp make/osx.mk ./config.mk
   echo "USE_BLAS = openblas" >> ./config.mk
   echo "ADD_CFLAGS += -I/usr/local/opt/openblas/include" >> ./config.mk
-  echo "ADD_LDFLAGS += -L/usr/local/opt/openblas/lib" >> ./config.mk
+  echo "ADD_LDFLAGS += -L/usr/local/opt/openblas/lib:/usr/local/lib/graphviz/" >> ./config.mk
   make -j$(sysctl -n hw.ncpu)
 ```
 **Note:** To change build parameters, edit ```config.mk```.
@@ -60,6 +67,15 @@ After running the ```cmake``` command, use Xcode to open ```mxnet.xcodeproj```, 
 2. Optimisation Level = Fastest[-O3]
 
 Both sets of commands produce a library called ```libmxnet.so```.
+
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for the programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
 
 ## Install the MXNet Package for Python
 

--- a/docs/get_started/setup.md
+++ b/docs/get_started/setup.md
@@ -41,6 +41,9 @@ You must have the following:
   * [openblas](http://www.openblas.net/)
   * [Intel MKL](https://software.intel.com/en-us/node/528497)
 
+- [Graphviz](http://www.graphviz.org/) for visualizing the network graphs.
+- [Jupyter Notebook](http://jupyter.readthedocs.io/en/latest/) for running examples and tutorials of MXNet.
+
 ## Requirements for Using GPUs
 
 * A GPU with support for Compute Capability 2.0 or higher.
@@ -130,6 +133,30 @@ To build OpenCV from source code, you need the ```cmake``` library .
 	```
 # Common Installation Problems
 This section provides solutions for common installation problems.
+## General
+**Message:** ImportError: No module named _graphviz
+
+**Cause:** Graphviz is not installed.
+
+**Solution:**
+On Mac, You can install Graphviz with below command
+```bash
+  brew install graphviz
+```
+Or, using pip
+```bash
+  brew install python
+  pip install graphviz
+```
+**Message:** RuntimeError: failed to execute ['dot', '-Tsvg'], make sure the Graphviz executables are on your systems' path
+
+**Cause:** Graphviz executable (lib) path is currently not in the system path and program is unable to use Graphviz for plotting the graph
+
+**Solution:** Add Graphviz executable (lib) path to your system path.
+On Mac/Linux machines, Graphviz is generally installed in - ```/usr/local/lib/graphviz/``` or ```/usr/lib/graphviz/``` or ```/usr/lib64/graphviz/``` and on Windows - ```C:\Program Files (x86)\Graphviz2.38\bin```.
+
+**Note** If you are using Jupyter notebook, you may need to restart the kernel to refresh the system path and find Graphviz executable.
+
 ## Mac OS X Error Message
 **Message:** link error ld: library not found for -lgomp
 

--- a/docs/get_started/ubuntu_setup.md
+++ b/docs/get_started/ubuntu_setup.md
@@ -76,6 +76,21 @@ After you have downloaded and installed the dependencies, use the following comm
 
 Executing these commands creates a library called ```libmxnet.so```.
 
+Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](jupyter.readthedocs.io) used for running MXNet tutorials and examples.
+
+```bash
+    sudo apt-get install -y python-pip
+    sudo pip install graphviz
+    sudo pip install Jupyter
+```
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for programming language of your choice:
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
+
 ### Install the MXNet Package for R
 
 Run the following commands to install the MXNet dependencies and build the MXNet R package.

--- a/docs/get_started/windows_setup.md
+++ b/docs/get_started/windows_setup.md
@@ -40,6 +40,23 @@ After you have installed all of the required dependencies, build the MXNet sourc
 3. In Visual Studio, open the solution file,```.sln```, and compile it.
 These commands produce a library called ```mxnet.dll``` in the ```./build/Release/``` or ```./build/Debug folder```.
 
+
+
+&nbsp;
+Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](jupyter.readthedocs.io) used for running MXNet tutorials and examples.
+- Install ```graphviz``` by downloading MSI installer from [Graphviz Download Page](http://www.graphviz.org/Download_windows.php).
+**Note** Make sure to add graphviz executable path to PATH environment variable. Refer [here for more details](http://stackoverflow.com/questions/35064304/runtimeerror-make-sure-the-graphviz-executables-are-on-your-systems-path-aft)
+- Install ```Jupyter``` by installing [Anaconda for Python 2.7](https://www.continuum.io/downloads)
+**Note** Do not install Anaconda for Python 3.5. MXNet has few compatibility issue with Python 3.5.
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
+
 ## Install MXNet for Python
 
 1. Install ```Python``` using windows installer available [here](https://www.python.org/downloads/release/python-2712/).

--- a/docs/how_to/index.md
+++ b/docs/how_to/index.md
@@ -5,6 +5,7 @@ This topic provides links to guidelines for using MXNet.
 ## Use MXNet on Specific Tasks
 - [How to use pre-trained models](http://mxnet.io/tutorials/python/predict_imagenet.html)
 - [How to use Fine-tune with Pre-trained Models](http://mxnet.io/how_to/finetune.html)
+- [How to visualize Neural Networks as computation graph](http://mxnet.io/how_to/visualize_graph.html)
 - [How to train with multiple CPU/GPUs with data parallelism](multi_devices.md)
 - [How to train with multiple GPUs in model parallelism - train LSTM](model_parallel_lstm.md)
 - [How to run MXNet on smart or mobile devices](smart_device.md)

--- a/docs/how_to/visualize_graph.md
+++ b/docs/how_to/visualize_graph.md
@@ -1,0 +1,55 @@
+# How to visualize Neural Networks as computation graph
+
+This topic demonstrates how to use ```mx.viz.plot_network``` in MXNet for visualizing your Neural Networks built on MXNet. ```mx.viz.plot_network``` helps to represent the Neural Network as a computation graph of nodes; with input nodes, where the computation starts, and output nodes, where the result can be read.
+
+## Prerequisites
+You need [Jupyter Notebook](jupyter.readthedocs.io) and [Graphviz](http://www.graphviz.org/) library to visualize the network. Please Make sure you have followed [installation instructions](http://mxnet.io/get_started/setup.html) in setting up above dependencies along with setting up MXNet.
+
+## Visualize the sample Neural Network
+
+```mx.viz.plot_network``` takes [Symbol](http://mxnet.io/api/python/symbol.html), with your Network definition, and optional node_attrs, parameters for shape of node in the graph,  as input and generates a computation graph.
+
+We will now try to visualize a sample Neural Network for linear matrix factorization:
+- Start Jupyter notebook server
+```bash
+  $ jupyter notebook
+```
+- Aceess Jupyter Notebook in your browser - http://localhost:8888/.
+- Create a new notebook - "File -> New Notebook -> Python 2"
+- Copy and and run below code to visualize a sample network.
+
+```python
+  import mxnet as mx
+  user = mx.symbol.Variable('user')
+  item = mx.symbol.Variable('item')
+  score = mx.symbol.Variable('score')
+
+  # Set dummy dimensions
+  k = 64
+  max_user = 100
+  max_item = 50
+
+  # user feature lookup
+  user = mx.symbol.Embedding(data = user, input_dim = max_user, output_dim = k)
+
+  # item feature lookup
+  item = mx.symbol.Embedding(data = item, input_dim = max_item, output_dim = k)
+
+  # predict by the inner product, which is elementwise product and then sum
+  net = user * item
+  net = mx.symbol.sum_axis(data = net, axis = 1)
+  net = mx.symbol.Flatten(data = net)
+
+  # loss layer
+  net = mx.symbol.LinearRegressionOutput(data = net, label = score)
+
+  # Visualize your network
+  mx.viz.plot_network(net)
+```
+You should be able to see computation graph something like below:
+<img src=https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/SampleNetworkVisualization.png
+width=400/>
+
+# References
+* [Example MXNet Matrix Factorization](https://github.com/dmlc/mxnet/blob/master/example/recommenders/demo1-MF.ipynb)
+* [Visualizing CNN Architecture of MXNet Tutorials](http://josephpcohen.com/w/visualizing-cnn-architectures-side-by-side-with-mxnet/)

--- a/setup-utils/install-mxnet-amz-linux.sh
+++ b/setup-utils/install-mxnet-amz-linux.sh
@@ -17,7 +17,7 @@ source ~/.profile
 # Reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/compile-software.html
 # Install Python, Numpy, Scipy and set up tools.
 sudo yum groupinstall -y "Development Tools"
-sudo yum install -y python27 python27-setuptools python27-tools
+sudo yum install -y python27 python27-setuptools python27-tools python-pip graphviz
 sudo yum install -y python27-numpy python27-scipy python27-nose python27-matplotlib
 
 # Install OpenBLAS at /usr/local/openblas
@@ -56,5 +56,9 @@ sudo python setup.py install
 # Add MXNet path to ~/.bashrc file
 echo "export PYTHONPATH=$MXNET_HOME/python:$PYTHONPATH" >> ~/.bashrc
 source ~/.bashrc
+
+# Install graphviz for visualizing network graph and jupyter notebook to run tutorials and examples
+sudo pip install graphviz
+sudo pip install jupyter
 
 echo "Done! MXNet for Python installation is complete. Go ahead and explore MXNet with Python :-)"

--- a/setup-utils/install-mxnet-ubuntu-python.sh
+++ b/setup-utils/install-mxnet-ubuntu-python.sh
@@ -8,9 +8,9 @@ set -e
 MXNET_HOME="$HOME/mxnet/"
 echo "MXNet root folder: $MXNET_HOME"
 
-echo "Installing build-essential, libatlas-base-dev, libopencv-dev..."
+echo "Installing build-essential, libatlas-base-dev, libopencv-dev, pip, graphviz ..."
 sudo apt-get update
-sudo apt-get install -y build-essential libatlas-base-dev libopencv-dev
+sudo apt-get install -y build-essential libatlas-base-dev libopencv-dev graphviz
 
 echo "Building MXNet core. This can take few minutes..."
 cd "$MXNET_HOME"
@@ -20,7 +20,7 @@ echo "Installing Numpy..."
 sudo apt-get install python-numpy
 
 echo "Installing Python setuptools..."
-sudo apt-get install python-setuptools
+sudo apt-get install -y python-setuptools python-pip
 
 echo "Installing Python package for MXNet..."
 cd python; sudo python setup.py install
@@ -28,5 +28,11 @@ cd python; sudo python setup.py install
 echo "Adding MXNet path to your ~/.bashrc file"
 echo "export PYTHONPATH=$MXNET_HOME/python:$PYTHONPATH" >> ~/.bashrc
 source ~/.bashrc
+
+echo "Install Graphviz for plotting MXNet network graph..."
+sudo pip install graphviz
+
+echo "Installing Jupyter notebook..."
+sudo pip install jupyter
 
 echo "Done! MXNet for Python installation is complete. Go ahead and explore MXNet with Python :-)"


### PR DESCRIPTION
* Adding How To page for visualizing network graphs. This will help new users to visualize their computation graph.
* Install guide was missing install steps to get "graphviz" and "jupyter". Updated Quick install scripts for Ubuntu, Amazon Linux and also updated standard install guide for other OSes.

We need to add below image to - https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/

<img width="300" alt="samplenetworkvisualization" src="https://cloud.githubusercontent.com/assets/3403674/21209029/b6fa75b2-c226-11e6-8ff6-920dad008123.png">


