### PR TITLE
Fix memory leak bug in Monitor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -119,3 +119,4 @@ List of Contributors
 * [Chi Zhang](https://github.com/WellyZhang)
 * [Wei Wu](https://github.com/lazyparser)
 * [Shishi Duan](https://github.com/burness)
+* [Yu Du](https://github.com/Answeror)

--- a/python/mxnet/monitor.py
+++ b/python/mxnet/monitor.py
@@ -46,10 +46,10 @@ class Monitor(object):
         self.sort = sort
         def stat_helper(name, array):
             """wrapper for executor callback"""
-            if not self.activated or not self.re_prog.match(py_str(name)):
-                return
             array = ctypes.cast(array, NDArrayHandle)
             array = NDArray(array, writable=False)
+            if not self.activated or not self.re_prog.match(py_str(name)):
+                return
             self.queue.append((self.step, py_str(name), self.stat_func(array)))
         self.stat_helper = stat_helper
 


### PR DESCRIPTION
NDArray allocated in `src/symbol/graph_executor.cc` won't be freed if monitor pattern not match.