### PR TITLE
Add prelu layer support for caffe convert tool

### DIFF
--- a/tools/caffe_converter/convert_model.py
+++ b/tools/caffe_converter/convert_model.py
@@ -60,7 +60,15 @@ def main():
     first_conv = True
     
     for layer_name, layer_type, layer_blobs in iter:
-        if layer_type == 'Convolution' or layer_type == 'InnerProduct' or layer_type == 4 or layer_type == 14:
+        if layer_type == 'Convolution' or layer_type == 'InnerProduct' or layer_type == 4 or layer_type == 14 \
+                or layer_type == 'PReLU':
+            if layer_type == 'PReLU':
+                assert(len(layer_blobs) == 1)
+                wmat = layer_blobs[0].data
+                weight_name = layer_name + '_gamma'
+                arg_params[weight_name] = mx.nd.zeros(wmat.shape)
+                arg_params[weight_name][:] = wmat
+                continue
             assert(len(layer_blobs) == 2)
             wmat_dim = []
             if getattr(layer_blobs[0].shape, 'dim', None) is not None:

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -165,6 +165,10 @@ def proto2script(proto_file):
             type_string = 'mx.symbol.BatchNorm'
             param = layer[i].batch_norm_param
             param_string = 'use_global_stats=%s' % param.use_global_stats
+        if layer[i].type == 'PReLU':
+            type_string = 'mx.symbol.LeakyReLU'
+            param_string = "act_type='prelu'"
+            need_flatten[name] = need_flatten[mapping[layer[i].bottom[0]]]
         if type_string == '':
             raise Exception('Unknown Layer %s!' % layer[i].type)
         if type_string != 'split':

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -167,7 +167,8 @@ def proto2script(proto_file):
             param_string = 'use_global_stats=%s' % param.use_global_stats
         if layer[i].type == 'PReLU':
             type_string = 'mx.symbol.LeakyReLU'
-            param_string = "act_type='prelu'"
+            param = layer[i].prelu_param
+            param_string = "act_type='prelu', slope=%f" % param.filler.value
             need_flatten[name] = need_flatten[mapping[layer[i].bottom[0]]]
         if type_string == '':
             raise Exception('Unknown Layer %s!' % layer[i].type)


### PR DESCRIPTION
I add the support for prelu layer for the caffe convert tool, and use the code to convert the center loss(https://github.com/ydwen/caffe-face/blob/caffe-face/face_example/face_deploy.prototxt) model to mxnet model, which use prelu as its nonlinear activation function. And get the same output between mxnet and caffe.