### PR TITLE
R-package: Fixed a typo in document of function "mx.symbol.Activation" & Refined the format a bit

### DIFF
--- a/R-package/R/mxnet_generated.R
+++ b/R-package/R/mxnet_generated.R
@@ -607,7 +607,7 @@ mx.io.MNISTIter <- function(...) {
   mx.varg.io.MNISTIter(list(...))
 }
 
-#' Apply activation function to input
+#' Apply Activation Function to Input
 #'
 #' Apply activation function to input. Softmax Activation is only available with CUDNN on GPU and will be computed at each location across channel if input is 4D.
 #' 

--- a/R-package/R/mxnet_generated.R
+++ b/R-package/R/mxnet_generated.R
@@ -607,7 +607,9 @@ mx.io.MNISTIter <- function(...) {
   mx.varg.io.MNISTIter(list(...))
 }
 
-#' Apply activation function to input.Softmax Activation is only available with CUDNN on GPUand will be computed at each location across channel if input is 4D.
+#' Apply activation function to input
+#'
+#' Apply activation function to input. Softmax Activation is only available with CUDNN on GPU and will be computed at each location across channel if input is 4D.
 #' 
 #' @param data  Symbol
 #'     Input data to activation function.

--- a/R-package/man/mx.symbol.Activation.Rd
+++ b/R-package/man/mx.symbol.Activation.Rd
@@ -2,7 +2,10 @@
 % Please edit documentation in R/mxnet_generated.R
 \name{mx.symbol.Activation}
 \alias{mx.symbol.Activation}
-\title{Apply activation function to input.Softmax Activation is only available with CUDNN on GPUand will be computed at each location across channel if input is 4D.}
+\title{Apply Activation Function to Input}
+\description{
+Apply activation function to input. Softmax Activation is only available with CUDNN on GPU and will be computed at each location across channel if input is 4D.
+}
 \usage{
 mx.symbol.Activation(...)
 }
@@ -19,7 +22,3 @@ Name of the resulting symbol.}
 \value{
 out The result mx.symbol
 }
-\description{
-Apply activation function to input.Softmax Activation is only available with CUDNN on GPUand will be computed at each location across channel if input is 4D.
-}
-


### PR DESCRIPTION
A very MINOR change to fix the typo in the document of function "mx.symbol.Activation". Also tried to make the format nicer.