### PR TITLE
Fix two grad

### DIFF
--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -102,7 +102,7 @@ struct tanh {
 struct tanh_grad {
   template<typename DType>
   MSHADOW_XINLINE static DType Map(DType a) {
-    return DType(DType(1.0f) - a * a);
+    return DType(DType(1.0f) - tanhf(a) * tanhf(a));
   }
 };
 
@@ -261,7 +261,7 @@ struct square_root {
 struct square_root_grad {
   template<typename DType>
   MSHADOW_XINLINE static DType Map(DType a) {
-    return DType(DType(0.5f) / a);
+    return DType(DType(0.5f) / sqrtf(a));
   }
 };
 


### PR DESCRIPTION
The `tanh_grad` and `square_root_grad`  seem wrong, because
<img width="178" alt="screen shot 2016-12-20 at 11 58 18 pm" src="https://cloud.githubusercontent.com/assets/1547093/21377939/5075df04-c710-11e6-9ac3-afa5b696b704.png">

@piiswrong 