### PR TITLE
 sync aux params across devices after each epoch

### DIFF
--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -395,8 +395,11 @@ class BaseModule(object):
             toc = time.time()
             self.logger.info('Epoch[%d] Time cost=%.3f', epoch, (toc-tic))
 
+            # sync aux params across devices
+            arg_params, aux_params = self.get_params()
+            self.set_params(arg_params, aux_params)
+
             if epoch_end_callback is not None:
-                arg_params, aux_params = self.get_params()
                 for callback in _as_list(epoch_end_callback):
                     callback(epoch, self.symbol, arg_params, aux_params)
 

--- a/src/symbol/graph_executor.cc
+++ b/src/symbol/graph_executor.cc
@@ -1111,7 +1111,7 @@ GraphExecutor::CreateCachedSegOpr(size_t topo_start, size_t topo_end) {
         TBlob out_blob = out.data.data();
 #if MKL_EXPERIMENTAL == 1
         out_blob.Mkl_mem_ = out.mkl_mem_;
-#endif        
+#endif
         out_data.push_back(out_blob);
       }
       for (size_t i = 0; i < gnode.addto_index.size(); ++i) {
@@ -1126,7 +1126,7 @@ GraphExecutor::CreateCachedSegOpr(size_t topo_start, size_t topo_end) {
         TBlob aux_blob = aux.data.data();
 #if MKL_EXPERIMENTAL == 1
         aux_blob.Mkl_mem_ = aux.mkl_mem_;
-#endif 
+#endif
         aux_data.push_back(aux_blob);
       }
       // input
@@ -1136,7 +1136,7 @@ GraphExecutor::CreateCachedSegOpr(size_t topo_start, size_t topo_end) {
         TBlob info_blob = info.data.data();
 #if MKL_EXPERIMENTAL == 1
         info_blob.Mkl_mem_ = info.mkl_mem_;
-#endif 
+#endif
         in_data.push_back(info_blob);
       }
       // run the function.


### PR DESCRIPTION
Currently only batchnorm has aux state and it only use it for evaluation.
However if we have ops that use aux during training it might make sense to sync aux every iteration?