### PR TITLE
Torch plugin update for chages of MXNet and Torch

### DIFF
--- a/plugin/torch/torch_base.cc
+++ b/plugin/torch/torch_base.cc
@@ -43,10 +43,8 @@ void TorchState::SetStream(mshadow::Stream<mshadow::cpu>* s) {
 
 template<>
 void TorchState::SetStream(mshadow::Stream<mshadow::gpu>* s) {
-  // CudaState()->currentStream = mshadow::Stream<gpu>::GetStream(s);
-    auto* thc_stream = THCState_getStream(CudaState());
-    thc_stream->stream = mshadow::Stream<gpu>::GetStream(s);
-    THCState_setStream(CudaState(), thc_stream);
+  cudaStream_t cs = THCState_getCurrentStream(CudaState());
+  cs = mshadow::Stream<gpu>::GetStream(s);
 }
 #endif  // MXNET_USE_CUDA
 }  // namespace mxnet

--- a/plugin/torch/torch_base.cc
+++ b/plugin/torch/torch_base.cc
@@ -40,9 +40,13 @@ void TorchState::SetStream(mshadow::Stream<mshadow::cpu>* s) {
 }
 
 #if MXNET_USE_CUDA
+
 template<>
 void TorchState::SetStream(mshadow::Stream<mshadow::gpu>* s) {
-  CudaState()->currentStream = mshadow::Stream<gpu>::GetStream(s);
+  // CudaState()->currentStream = mshadow::Stream<gpu>::GetStream(s);
+    auto* thc_stream = THCState_getStream(CudaState());
+    thc_stream->stream = mshadow::Stream<gpu>::GetStream(s);
+    THCState_setStream(CudaState(), thc_stream);
 }
 #endif  // MXNET_USE_CUDA
 }  // namespace mxnet

--- a/plugin/torch/torch_base.h
+++ b/plugin/torch/torch_base.h
@@ -21,6 +21,7 @@ extern "C" {
 #include <THC/THCStorage.h>
 #include <THC/THCTensor.h>
 #include <THC/THCTensorCopy.h>
+#include <THC/THCStream.h>
 }
 #endif  // MXNET_USE_CUDA
 

--- a/plugin/torch/torch_function.cc
+++ b/plugin/torch/torch_function.cc
@@ -70,13 +70,13 @@ MXNET_REGISTER_TORCH_TENARY_FUN(_th_addbmm, addbmm);
 MXNET_REGISTER_TORCH_TENARY_FUN(_th_baddbmm, baddbmm);
 
 struct TorchMMShape {
-  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+  static std::vector<TShape> GetShape(NDArray **u,
     const std::map<std::string, std::string>& param) {
     CHECK_EQ(u[0]->shape().ndim(), 2);
     CHECK_EQ(u[1]->shape().ndim(), 2);
     CHECK_EQ(u[0]->shape()[1], u[1]->shape()[0]);
     index_t shape[] = {u[0]->shape()[0], u[1]->shape()[1]};
-    mshadow::TShape tshape(shape, shape+2);
+    TShape tshape(shape, shape+2);
     return {tshape};
   }
   static constexpr const char* fname = "mm";
@@ -86,13 +86,13 @@ struct TorchMMShape {
 MXNET_REGISTER_TORCH_FUN(_th_mm, TorchMMShape);
 
 struct TorchMVShape {
-  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+  static std::vector<TShape> GetShape(NDArray **u,
     const std::map<std::string, std::string>& param) {
     CHECK_EQ(u[0]->shape().ndim(), 2);
     CHECK_EQ(u[1]->shape().ndim(), 1);
     CHECK_EQ(u[0]->shape()[1], u[1]->shape()[0]);
     index_t shape[] = {u[0]->shape()[0]};
-    mshadow::TShape tshape(shape, shape+1);
+    TShape tshape(shape, shape+1);
     return {tshape};
   }
   static constexpr const char* fname = "mv";
@@ -103,14 +103,14 @@ MXNET_REGISTER_TORCH_FUN(_th_mv, TorchMVShape);
 
 
 struct TorchBMMShape {
-  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+  static std::vector<TShape> GetShape(NDArray **u,
     const std::map<std::string, std::string>& param) {
     CHECK_EQ(u[0]->shape().ndim(), 3);
     CHECK_EQ(u[1]->shape().ndim(), 3);
     CHECK_EQ(u[0]->shape()[0], u[1]->shape()[0]);
     CHECK_EQ(u[0]->shape()[2], u[1]->shape()[1]);
     index_t shape[] = {u[0]->shape()[1], u[1]->shape()[2]};
-    mshadow::TShape tshape(shape, shape+2);
+    TShape tshape(shape, shape+2);
     return {tshape};
   }
   static constexpr const char* fname = "bmm";
@@ -120,12 +120,12 @@ struct TorchBMMShape {
 MXNET_REGISTER_TORCH_FUN(_th_bmm, TorchBMMShape);
 
 struct TorchGERShape {
-  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+  static std::vector<TShape> GetShape(NDArray **u,
     const std::map<std::string, std::string>& param) {
     CHECK_EQ(u[0]->shape().ndim(), 1);
     CHECK_EQ(u[1]->shape().ndim(), 1);
     index_t shape[] = {u[0]->shape()[0], u[1]->shape()[0]};
-    mshadow::TShape tshape(shape, shape+2);
+    TShape tshape(shape, shape+2);
     return {tshape};
   }
   static constexpr const char* fname = "ger";

--- a/plugin/torch/torch_function.h
+++ b/plugin/torch/torch_function.h
@@ -68,7 +68,7 @@ void TorchRunOp(std::vector<NDArray> arr_in,
 template<typename OP>
 void TorchOp(NDArray **u, real_t *s, NDArray **out,
              const std::map<std::string, std::string>& param) {
-  std::vector<mshadow::TShape> shapes = OP::GetShape(u, param);
+  std::vector<TShape> shapes = OP::GetShape(u, param);
   CHECK_EQ(shapes.size(), OP::num_outputs)
     << "Too many output shapes for TorchOp " << OP::fname;
   Context ctx;
@@ -141,14 +141,14 @@ void TorchOp(NDArray **u, real_t *s, NDArray **out,
 }
 
 struct TorchFirstShape {
-  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+  static std::vector<TShape> GetShape(NDArray **u,
     const std::map<std::string, std::string>& param) {
     return {u[0]->shape()};
   }
 };
 
 struct TorchConstructorShape {
-  static std::vector<mshadow::TShape> GetShape(NDArray **u,
+  static std::vector<TShape> GetShape(NDArray **u,
     const std::map<std::string, std::string>& param) {
     std::vector<index_t> shape;
     std::string format = param.at("format");
@@ -161,7 +161,7 @@ struct TorchConstructorShape {
       std::getline(args, val, ',');
       shape.push_back(std::stoi(val));
     }
-    mshadow::TShape tshape(shape.begin(), shape.end());
+    TShape tshape(shape.begin(), shape.end());
     return {tshape};
   }
   static const int num_inputs = 0;


### PR DESCRIPTION
Hi,
Torch plugin is unable to compile with latest MXNet and Torch because there are some changes.

## MXNet side
TShape was moved from mshadow to mxnet
https://github.com/dmlc/mxnet/pull/2906/files#diff-3182059d3b0e272b01119635baa09eb3

## Torch side
THCState does not have a cudaStream_t currentStream field anymore. 
Instead of that, I used `cudaStream_t THCState_getCurrentStream(THCState *state)`.

## remaining issues
I have tested running `torch_function.py` and `torch_module.py` in examples/torch with ctx=mx.cpu(0)/mx.gpu(0)/mx.gpu(1).
but sometimes, not always,  only `torch_module.py` with ctx=mx.gpu raised errors as follows

```
[11:03:05] src/io/iter_mnist.cc:91: MNISTIter: load 60000 images, shuffle=1, shape=(100,784)
[11:03:05] src/io/iter_mnist.cc:91: MNISTIter: load 10000 images, shuffle=1, shape=(100,784)
INFO:root:Start training with [gpu(0)]
INFO:root:Epoch[0] Resetting Data Iterator
INFO:root:Epoch[0] Time cost=0.652
INFO:root:Epoch[0] Validation-accuracy=0.949200
[11:03:10] [11:03:10] /home/skarita/tool/mxnet/dmlc-core/include/dmlc/logging.h:235: /home/skarita/tool/mxnet/dmlc-core/include/dmlc/logging.h:[11:03:10] /home/skarita/tool/mxnet/mshadow/mshadow/./stream_gpu-inl.h:45: Check failed: e == cudaSuccess CUDA: misaligned address
235: [11:03:10] /home/skarita/tool/mxnet/mshadow/mshadow/./stream_gpu-inl.h:45: Check failed: e == cudaSuccess CUDA: misaligned address
[11:03:10] /home/skarita/tool/mxnet/dmlc-core/include/dmlc/logging.h:235: [11:03:10] src/engine/./threaded_engine.h:306: [11:03:10] /home/skarita/tool/mxnet/mshadow/mshadow/./stream_gpu-inl.h:45: Check failed: e == cudaSuccess CUDA: misaligned address
An fatal error occurred in asynchronous engine operation. If you do not know what caused this error, you can try set environment variable MXNET_ENGINE_TYPE to NaiveEngine and run with debugger (i.e. gdb). This will force all operations to be synchronous and backtrace will give you the series of calls that lead to this error. Remember to set MXNET_ENGINE_TYPE back to empty after debugging.
[11:03:10] /home/skarita/tool/mxnet/dmlc-core/include/dmlc/logging.h:235: [11:03:10] src/engine/./threaded_engine.h:306: [11:03:10] /home/skarita/tool/mxnet/mshadow/mshadow/./stream_gpu-inl.h:45: Check failed: e == cudaSuccess CUDA: misaligned address
An fatal error occurred in asynchronous engine operation. If you do not know what caused this error, you can try set environment variable MXNET_ENGINE_TYPE to NaiveEngine and run with debugger (i.e. gdb). This will force all operations to be synchronous and backtrace will give you the series of calls that lead to this error. Remember to set MXNET_ENGINE_TYPE back to empty after debugging.
terminate called recursively
terminate called after throwing an instance of 'dmlc::Error'
[1]    32245 abort (core dumped)  python ./data/torch_module_gpu.py
```