### PR TITLE
fix cmake build with vs2015+cuda8.0+win7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories("mshadow")
 include_directories("dmlc-core/include")
 
 if(MSVC)
+  add_definitions(-DWIN32_LEAN_AND_MEAN)
   add_definitions(-DDMLC_USE_CXX11)
   add_definitions(-DMSHADOW_IN_CXX11)
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)


### PR DESCRIPTION
related to https://github.com/dmlc/mxnet/issues/2924 
win7 + vs2015 + cuda8.0 + cuDNN5.1(cpu build is ok), log is: 
![1](https://cloud.githubusercontent.com/assets/5860892/21416960/0b0a0fe2-c852-11e6-93b7-2f2bd2b6e7ee.png)

the error happens in  
``` C:\Program Files (x86)\Windows Kits\8.1\Include\um\combaseapi.h(229): error : identifier "IUnknown" is undefined [C:\gadgetron\projects\compiling\gadgetron\toolboxes\nfft\gpu\gadgetron_toolbox_gpunfft.vcxproj]```
![2](https://cloud.githubusercontent.com/assets/5860892/21416964/15e05462-c852-11e6-9df8-332dc3029ee3.png)

after add one line ```add_definitions(-DWIN32_LEAN_AND_MEAN)``` in CMakeList.txt, it will build ok.
@yajiedesign @piiswrong 