### PR TITLE
Add go binding project reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ What's New
 * [MXNet on Mobile Device](http://mxnet.io/how_to/smart_device.html)
 * [Distributed Training](http://mxnet.io/how_to/multi_devices.html)
 * [Guide to Creating New Operators (Layers)](http://mxnet.io/how_to/new_op.html)
-* [Amalgamation and Go Binding for Predictors](https://github.com/jdeng/gomxnet/)
+* [Go binding for inference](https://github.com/songtianyi/go-mxnet-predictor)
 * [Training Deep Net on 14 Million Images on A Single Machine](http://mxnet.io/tutorials/computer_vision/imagenet_full.html)
 
 Contents

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ What's New
 * [Distributed Training](http://mxnet.io/how_to/multi_devices.html)
 * [Guide to Creating New Operators (Layers)](http://mxnet.io/how_to/new_op.html)
 * [Go binding for inference](https://github.com/songtianyi/go-mxnet-predictor)
+* [Amalgamation and Go Binding for Predictors](https://github.com/jdeng/gomxnet/) - Outdated
 * [Training Deep Net on 14 Million Images on A Single Machine](http://mxnet.io/tutorials/computer_vision/imagenet_full.html)
 
 Contents

--- a/example/README.md
+++ b/example/README.md
@@ -31,6 +31,7 @@ If you want to contribute to this list and the examples, please open a new pull 
 * [MXNetR](http://mxnet.readthedocs.io/en/latest/api/r/index.html) - R library
 * [MXNet.jl](http://mxnetjl.readthedocs.org/en/latest/) - Julia library
 * [go-mxnet-predictor](https://github.com/songtianyi/go-mxnet-predictor) - Go binding for inference
+* [gomxnet](https://github.com/jdeng/gomxnet) - Go binding [Outdated]
 * [MXNet JNI](https://github.com/dmlc/mxnet/tree/master/amalgamation/jni) - JNI(Android) library
 * [MXNet Amalgamation](https://github.com/dmlc/mxnet/tree/master/amalgamation) - Amalgamation (entire library in a single file)
 * [MXNet Javascript](https://github.com/dmlc/mxnet.js/) - MXNetJS: Javascript Package for Deep Learning in Browser (without server)

--- a/example/README.md
+++ b/example/README.md
@@ -30,7 +30,7 @@ If you want to contribute to this list and the examples, please open a new pull 
 * [MXNet Python](http://mxnet.readthedocs.io/en/latest/api/python/index.html) - Python library
 * [MXNetR](http://mxnet.readthedocs.io/en/latest/api/r/index.html) - R library
 * [MXNet.jl](http://mxnetjl.readthedocs.org/en/latest/) - Julia library
-* [gomxnet](https://github.com/jdeng/gomxnet) - Go binding
+* [go-mxnet-predictor](https://github.com/songtianyi/go-mxnet-predictor) - Go binding for inference
 * [MXNet JNI](https://github.com/dmlc/mxnet/tree/master/amalgamation/jni) - JNI(Android) library
 * [MXNet Amalgamation](https://github.com/dmlc/mxnet/tree/master/amalgamation) - Amalgamation (entire library in a single file)
 * [MXNet Javascript](https://github.com/dmlc/mxnet.js/) - MXNetJS: Javascript Package for Deep Learning in Browser (without server)

--- a/include/mxnet/c_predict_api.h
+++ b/include/mxnet/c_predict_api.h
@@ -198,8 +198,8 @@ MXNET_DLL int MXNDListGet(NDListHandle handle,
                           const mx_uint** out_shape,
                           mx_uint* out_ndim);
 /*!
- * \brief Free a predictor handle.
- * \param handle The handle of the predictor.
+ * \brief Free a MXAPINDList
+ * \param handle The handle of the MXAPINDList.
  * \return 0 when success, -1 when failure.
  */
 MXNET_DLL int MXNDListFree(NDListHandle handle);


### PR DESCRIPTION
1. Fix typos in include/mxnet/c_predict_api.h
2. Add [go-mxnet-predictor](https://github.com/songtianyi/go-mxnet-predictor) project reference to READMEs

go-mxnet-predictor features:
* more api bindings
* more comments and details in api
* dependency less, no need Amalgamation
* offering docker file to build mxnet&go dev env. So it's easy to build and run inference examples.

I am working at cloud service provider company. Our tech stack is based on go. It's painful to do machine learning in golang with mxnet, even with tensorflow. I am trying to fill the gap.
The prior project [gomxnet](https://github.com/jdeng/gomxnet) is outdated without maintaining.
PLZ review.

