### PR TITLE
Fix Underflow Bug in GPUPooledStorageManager::Alloc()

### DIFF
--- a/src/storage/pooled_storage_manager.h
+++ b/src/storage/pooled_storage_manager.h
@@ -71,7 +71,8 @@ void* GPUPooledStorageManager::Alloc(size_t size) {
   if (reuse_it == memory_pool_.end() || reuse_it->second.size() == 0) {
     size_t free, total;
     cudaMemGetInfo(&free, &total);
-    if (size > free - total*reserve_/100) ReleaseAll();
+    if (free <= total * reserve_ / 100 || size > free - total * reserve_ / 100)
+      ReleaseAll();
 
     void* ret = nullptr;
     cudaError_t e = cudaMalloc(&ret, size);


### PR DESCRIPTION
The two variables `free` and `total` are of `size_t` type, i.e. they are unsigned integers. When performing subtraction, if the value of `free` is smaller than that of `total * reserve_ / 100`, underflow happens and the result will be an extremely large integer, which will prevent the memory release but it is actually required. This causes "out of memory" problems in the FCN example.