### PR TITLE
Introduce a developer mode option in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ include $(DMLC_CORE)/make/dmlc.mk
 WARNFLAGS= -Wall
 CFLAGS = -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
 
+ifeq ($(DEV), 1)
+	CFLAGS += -g -Werror
+endif
+
 # CFLAGS for debug
 ifeq ($(DEBUG), 1)
 	CFLAGS += -g -O0 -DDMLC_LOG_FATAL_THROW=0

--- a/make/config.mk
+++ b/make/config.mk
@@ -24,6 +24,9 @@ export CC = gcc
 export CXX = g++
 export NVCC = nvcc
 
+# whether compile with options for MXNet developer
+DEV = 0
+
 # whether compile with debug
 DEBUG = 0
 

--- a/make/osx.mk
+++ b/make/osx.mk
@@ -24,6 +24,9 @@ export CC = gcc
 export CXX = g++
 export NVCC = nvcc
 
+# whether compile with options for MXNet developer
+DEV = 0
+
 # whether compile with debug
 DEBUG = 0
 

--- a/src/operator/pad-inl.h
+++ b/src/operator/pad-inl.h
@@ -163,7 +163,7 @@ class PadProp : public OperatorProperty {
     const TShape &dshape = (*in_shape)[pad_enum::kData];
     if (dshape.ndim() == 0) return false;
     TShape oshape = dshape;
-    for (int i = 0; i < dshape.ndim(); ++i) {
+    for (size_t i = 0; i < dshape.ndim(); ++i) {
       oshape[i] =
           param_.pad_width[2 * i] + param_.pad_width[2 * i + 1] + dshape[i];
     }

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -27,7 +27,7 @@ std::vector<nnvm::NodeEntry> ElementWiseSumGrad(
   CHECK_EQ(ograds.size(), 1);
   std::vector<nnvm::NodeEntry> ret;
   nnvm::NodeEntry n_out{n, 0, 0};
-  for (auto& h : n->inputs) {
+  for (size_t i = 0; i < n->inputs.size(); i++) {
     nnvm::NodePtr id_node = nnvm::Node::Create();
     id_node->attrs.op = copy_op;
     id_node->inputs = {ograds[0]};

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -74,7 +74,7 @@ inline bool ReshapeShape(const nnvm::NodeAttrs& attrs,
       dshape_vec.push_back(dshape[i]);
     }
     std::vector<int> tmp;
-    int src_idx = 0;
+    size_t src_idx = 0;
     int inf_idx = -1;
     size_t new_size = dshape.Size();
     if (param_.reverse) {


### PR DESCRIPTION
this option will enable two addtionals for now:
1. Create symbol even for optimized build
2. Enforce warning as error

while I am here, clean up all warnings so that I can get a clean build in developer mode.