### PR TITLE
[OP] add WarpOp

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -120,3 +120,4 @@ List of Contributors
 * [Wei Wu](https://github.com/lazyparser)
 * [Shishi Duan](https://github.com/burness)
 * [Yu Du](https://github.com/Answeror)
+* [Xu Dong](https://github.com/dsqx71)

--- a/src/operator/bilinear_sampling-inl.h
+++ b/src/operator/bilinear_sampling-inl.h
@@ -1,0 +1,205 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file bilinear_sampling-inl.h
+ * \brief
+ * \author Xu Dong
+*/
+#ifndef MXNET_OPERATOR_BILINEAR_SAMPLING_INL_H_
+#define MXNET_OPERATOR_BILINEAR_SAMPLING_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <vector>
+#include <map>
+#include <string>
+#include <utility>
+#include "./operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+namespace bs {
+enum BilinearSamplingOpInputs {kData, kGrid};
+enum BilinearSamplingOpOutputs {kOut, kTmp};
+}
+
+struct BilinearSamplingParam : public dmlc::Parameter<BilinearSamplingParam> {
+  DMLC_DECLARE_PARAMETER(BilinearSamplingParam) {
+  }
+};
+
+template<typename xpu, typename DType>
+class BilinearSamplingOp : public Operator {
+ public:
+  explicit BilinearSamplingOp(BilinearSamplingParam p) {
+    this->param_ = p;
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 2);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+
+    Tensor<xpu, 4, DType> data = in_data[bs::kData].get<xpu, 4, DType>(s);
+    Tensor<xpu, 4, DType> grid = in_data[bs::kGrid].get<xpu, 4, DType>(s);
+    Tensor<xpu, 4, DType> out = out_data[bs::kOut].get<xpu, 4, DType>(s);
+
+    BilinearSamplingForward(out, data, grid);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 2);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+
+    Tensor<xpu, 4, DType> data = in_data[bs::kData].get<xpu, 4, DType>(s);
+    Tensor<xpu, 4, DType> grid = in_data[bs::kGrid].get<xpu, 4, DType>(s);
+    Tensor<xpu, 4, DType> gdata = in_grad[bs::kData].get<xpu, 4, DType>(s);
+    Tensor<xpu, 4, DType> ggrid = in_grad[bs::kGrid].get<xpu, 4, DType>(s);
+    Tensor<xpu, 4, DType> grad = out_grad[bs::kOut].get<xpu, 4, DType>(s);
+    gdata = 0.0f;
+    ggrid = 0.0f;
+    BilinearSamplingBackward(gdata, ggrid, grad, data, grid);
+  }
+
+ private:
+  BilinearSamplingParam param_;
+};  // class BilinearSamplingOp
+
+template<typename xpu>
+Operator* CreateOp(BilinearSamplingParam param, int dtype);
+
+#if DMLC_USE_CXX11
+class BilinearSamplingProp : public OperatorProperty {
+ public:
+  int NumVisibleOutputs() const override {
+    return 1;
+  }
+
+  int NumOutputs() const override {
+    return 2;
+  }
+
+  std::vector<std::string> ListArguments() const override {
+    return {"data", "grid"};
+  }
+
+  std::vector<std::string> ListOutputs() const override {
+    return {"output", "tmp"};
+  }
+
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    CHECK_EQ(in_shape->size(), 2) << "Input:[data, grid]";
+    const TShape &dshape = (*in_shape)[bs::kData];
+    const TShape &lshape = (*in_shape)[bs::kGrid];
+    if (dshape.ndim() == 0) return false;
+    CHECK_EQ(dshape.ndim(), 4) \
+        << "input data should be 4D in batch-num_filter-y-x";
+    if (lshape.ndim() ==  0) return false;
+    CHECK_EQ(lshape.ndim(), 4) \
+      << "sampling grid should be 4D in batch-2-y-x";
+    CHECK_EQ(dshape[0], lshape[0]);
+    CHECK_EQ(lshape[1], 2) << "incorrect grid shape[1], should be 2";
+    // target height
+    CHECK_GT(lshape[2], 0) \
+            << "incorrect grid_shape: " << lshape[2];
+    // target width
+    CHECK_GT(lshape[3], 0) \
+        << "incorrect grid_shape: " << lshape[3];
+    out_shape->clear();
+    // output_shape : (data.shape[0], data.shape[1], grid.shape[2], grid.shape[3])
+    out_shape->push_back(dshape);
+    (*out_shape)[bs::kOut][2] = lshape[2];
+    (*out_shape)[bs::kOut][3] = lshape[3];
+    out_shape->push_back(Shape4(lshape[0], lshape[2], lshape[3], 2));
+    return true;
+  }
+
+  bool InferType(std::vector<int> *in_type,
+                   std::vector<int> *out_type,
+                   std::vector<int> *aux_type) const override {
+      int dtype = -1;
+      for (size_t i = 0; i < in_type->size(); ++i) {
+        if (dtype == -1) {
+          dtype = in_type->at(i);
+        } else {
+          CHECK(in_type->at(i) == dtype ||
+                in_type->at(i) == -1) <<
+                "Non-uniform data type in BilinearSampling";
+        }
+      }
+      if (dtype == -1) {
+        LOG(FATAL) << "Not enough information to infer type in BilinearSampling.";
+        return false;
+      }
+      size_t nin = this->ListArguments().size();
+      in_type->clear();
+      for (size_t i = 0; i < nin; ++i) in_type->push_back(dtype);
+      size_t naux = this->ListAuxiliaryStates().size();
+      aux_type->clear();
+      for (size_t i = 0; i < naux; ++i) aux_type->push_back(dtype);
+      size_t nout = this->ListOutputs().size();
+      out_type->clear();
+      for (size_t i = 0; i < nout; ++i) out_type->push_back(dtype);
+      return true;
+    }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new BilinearSamplingProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "BilinearSampling";
+  }
+
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    return {out_grad[bs::kOut],
+            in_data[bs::kData],
+            out_data[bs::kTmp],
+            in_data[bs::kGrid]};
+  }
+
+  Operator* CreateOperator(Context ctx) const override {
+    LOG(FATAL) << "Not Implemented.";
+    return NULL;
+  }
+
+  Operator* CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
+                             std::vector<int> *in_type) const override;
+
+ private:
+  BilinearSamplingParam param_;
+};  // class BilinearSamplingProp
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_BILINEAR_SAMPLING_INL_H_

--- a/src/operator/bilinear_sampling.cc
+++ b/src/operator/bilinear_sampling.cc
@@ -1,0 +1,165 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file bilinear_sampling.cc
+ * \brief
+ * \author Xu Dong
+*/
+
+#include "./bilinear_sampling-inl.h"
+
+namespace mshadow {
+template<typename DType>
+bool between(DType value, int lowerBound, int upperBound) {
+  return (value >= lowerBound && value <= upperBound);
+}
+template<typename DType>
+inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
+                                    const Tensor<cpu, 4, DType> &input,
+                                    const Tensor<cpu, 4, DType> &grid_src) {
+  DType *out = output.dptr_;
+  const DType *data = input.dptr_;
+  const DType *grid = grid_src.dptr_;
+  int o_n = output.size(0), o_c = output.size(1), o_h = output.size(2), o_w = output.size(3);
+  int i_c = input.size(1), i_h = input.size(2), i_w = input.size(3);
+  for (index_t n = 0; n < o_n; ++n) {
+    for (index_t c = 0; c < o_c; ++c) {
+      for (index_t h = 0; h < o_h; ++h) {
+        for (index_t w = 0; w < o_w; ++w) {
+          index_t out_index = n * o_c * o_h * o_w + c * o_h * o_w + h * o_w + w;
+          index_t grid_index = n * o_h * o_w * 2 + h * o_w + w;
+          DType y_real = (*(grid + grid_index + o_h * o_w) + 1) * (i_h - 1) / 2;
+          DType x_real = (*(grid + grid_index) + 1) * (i_w - 1) / 2;
+          // the way in which cudnnSpatialTfSamplerForward deals with boundaries
+          // is different from here
+          if (between(x_real, 0, i_w-1) && between(y_real, 0, i_h-1)) {
+            // within the boundaries
+            index_t top_left_y = static_cast<int>(floor(y_real));
+            index_t top_left_x = static_cast<int>(floor(x_real));
+            DType top_left_y_w = 1.0 - (y_real - top_left_y);
+            DType top_left_x_w = 1.0 - (x_real - top_left_x);
+            index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w +
+              top_left_y * i_w + top_left_x;
+            DType top_left_v = *(data + data_index);
+            DType top_right_v = *(data + data_index + 1);
+            DType bottom_left_v = *(data + data_index + i_w);
+            DType bottom_right_v = *(data + data_index + i_w + 1);
+            *(out+out_index) = top_left_v * top_left_y_w * top_left_x_w +
+                               top_right_v * top_left_y_w * (1.0 - top_left_x_w) +
+                               bottom_left_v * (1.0 - top_left_y_w) * top_left_x_w +
+                               bottom_right_v * (1.0 - top_left_y_w) * (1.0 - top_left_x_w);
+          }  else {
+            // beyond the boundaries
+            *(out+out_index) = 0;
+          }
+        }
+      }
+    }
+  }
+}
+
+template<typename DType>
+inline void BilinearSamplingBackward(const Tensor<cpu, 4, DType> &gdata,
+                                     const Tensor<cpu, 4, DType> &ggrid,
+                                     const Tensor<cpu, 4, DType> &output_grad,
+                                     const Tensor<cpu, 4, DType> &input_data,
+                                     const Tensor<cpu, 4, DType> &grid) {
+  DType *g_input = gdata.dptr_;
+  DType *grad_grid = ggrid.dptr_;
+  const DType *grid_src = grid.dptr_;
+  const DType *grad = output_grad.dptr_;
+  const DType *data = input_data.dptr_;
+  int o_n = output_grad.size(0), o_c = output_grad.size(1),
+      o_h = output_grad.size(2), o_w = output_grad.size(3);
+  int i_c = input_data.size(1), i_h = input_data.size(2), i_w = input_data.size(3);
+  for (index_t n = 0; n < o_n; ++n) {
+     for (index_t h = 0; h < o_h; ++h) {
+        for (index_t w = 0; w < o_w; ++w) {
+          DType top_left_y_gw = 0.0;
+          DType top_left_x_gw = 0.0;
+          index_t grid_src_index = n * o_h * o_w * 2 + h * o_w + w;
+          DType y_real = (*(grid_src + grid_src_index + o_h * o_w) + 1) * (i_h - 1) / 2;
+          DType x_real = (*(grid_src + grid_src_index) + 1) * (i_w - 1) / 2;
+          // the way in which cudnnSpatialTfSamplerBackward deals with boundaries
+          // is different from here
+          if (between(x_real, 0, i_w-1) && between(y_real, 0, i_h-1)) {
+            // within the boundaries
+            index_t top_left_y = static_cast<int>(floor(y_real));
+            index_t top_left_x = static_cast<int>(floor(x_real));
+            DType top_left_y_w = 1.0 - (y_real - top_left_y);
+            DType top_left_x_w = 1.0 - (x_real - top_left_x);
+            for (index_t c = 0; c < o_c; ++c) {
+              index_t grad_index = n * o_c * o_h * o_w + c * o_h * o_w + h * o_w + w;
+              index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w + top_left_y * i_w
+                                   + top_left_x;
+              // calc 4 vertex value in input data
+              DType top_left_v = *(data + data_index);
+              DType top_right_v = *(data + data_index + 1);
+              DType bottom_left_v = *(data + data_index + i_w);
+              DType bottom_right_v = *(data + data_index + i_w + 1);
+              // calc input grad
+              *(g_input + data_index) += *(grad + grad_index) * top_left_y_w * top_left_x_w;
+              *(g_input + data_index + 1) += *(grad + grad_index) * top_left_y_w
+                                             * (1.0 - top_left_x_w);
+              *(g_input + data_index+ i_w) += *(grad + grad_index) * (1.0 - top_left_y_w)
+                                              * top_left_x_w;
+              *(g_input + data_index+ i_w + 1) += *(grad + grad_index) * (1.0 - top_left_y_w)
+                                                  * (1.0 - top_left_x_w);
+              // calc weight grad of top_left_w, then multiple -1 is the grad of grid_src
+              top_left_y_gw -= *(grad + grad_index) * (top_right_v - bottom_right_v +
+                               (top_left_v - top_right_v - bottom_left_v + bottom_right_v)
+                               * top_left_x_w);
+              top_left_x_gw -= *(grad + grad_index) * (bottom_left_v - bottom_right_v +
+                               (top_left_v - top_right_v - bottom_left_v + bottom_right_v)
+                               * top_left_y_w);
+            }
+            // calc grad of grid
+            *(grad_grid + grid_src_index + o_h * o_w) = top_left_y_gw * (i_h - 1) / 2;
+            *(grad_grid + grid_src_index) = top_left_x_gw * (i_w - 1) / 2;
+          }
+        }
+      }
+    }
+  }
+}  // namespace mshadow
+
+namespace mxnet {
+namespace op {
+template<>
+Operator* CreateOp<cpu>(BilinearSamplingParam param, int dtype) {
+  Operator *op = NULL;
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new BilinearSamplingOp<cpu, DType>(param);
+  })
+  return op;
+}
+
+Operator *BilinearSamplingProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
+                                     std::vector<int> *in_type) const {
+  std::vector<TShape> out_shape, aux_shape;
+  std::vector<int> out_type, aux_type;
+  CHECK(InferType(in_type, &out_type, &aux_type));
+  CHECK(InferShape(in_shape, &out_shape, &aux_shape));
+  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0]);
+}
+
+DMLC_REGISTER_PARAMETER(BilinearSamplingParam);
+
+MXNET_REGISTER_OP_PROPERTY(BilinearSampling, BilinearSamplingProp)
+.add_argument("data", "Symbol", "Input data to the BilinearSamplingOp.")
+.add_argument("grid", "Symbol", "Input grid to the BilinearSamplingOp."
+                                "grid has two channels: x_src, y_src")
+.add_arguments(BilinearSamplingParam::__FIELDS__())
+.describe("Apply bilinear sampling to input feature map.\n    "
+"output[batch, channel, y_dst, x_dst] = G(data[batch, channel, y_src, x_src)\n    "
+"x_dst, y_dst enumerate all spatial locations in output\n    "
+"x_src = grid[batch, 0, y_dst, x_dst]\n    "
+"y_src = grid[batch, 1, y_dst, x_dst]\n    "
+"G() denotes the bilinear interpolation kernel\n"
+"If (x_src, y_src) is beyond the boundaries of input data,"
+"the results of forward and backward are zeros.\n"
+"The shape of output will be (data.shape[0], data.shape[1], grid.shape[2], grid.shape[3])\n"
+"The operator assumes that grid has been nomalized. "
+"If you want to design a CustomOp to manipulate grid, "
+"please refer to GridGeneratorOp.");
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/bilinear_sampling.cu
+++ b/src/operator/bilinear_sampling.cu
@@ -1,0 +1,181 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file bilinear_sampling.cu
+ * \brief
+ * \author Xu Dong
+*/
+
+#include "./bilinear_sampling-inl.h"
+#include <algorithm>
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR == 5
+#include "./cudnn_bilinear_sampling-inl.h"
+#endif  // MXNET_USE_CUDNN && CUDNN_MAJOR
+
+namespace mshadow {
+template<typename DType>
+__device__ bool between(DType value, int lowerBound, int upperBound) {
+  return (value >= lowerBound && value <= upperBound);
+}
+template<typename DType>
+__global__ void BilinearSamplingForwardKernel(const int i_c, const int i_h,
+                                              const int i_w, const DType* data,
+                                              const DType* grid, const int o_n,
+                                              const int o_c, const int o_h,
+                                              const int o_w, DType* out) {
+  for (int index = (blockIdx.x + blockIdx.y * gridDim.x) * blockDim.x + threadIdx.x;
+       index < o_n * o_c * o_h * o_w;
+       index += blockDim.x * gridDim.x * gridDim.y) {
+    // (n, c, h, w) is the element in out
+    int w = index % o_w;
+    int h = (index / o_w) % o_h;
+    int c = (index / o_w / o_h) % o_c;
+    int n = index / o_w / o_h / o_c;
+    index_t out_index = n * o_c * o_h * o_w + c * o_h * o_w + h * o_w + w;
+    index_t grid_index = n * o_h * o_w * 2 + h * o_w + w;
+    DType y_real = (*(grid + grid_index + o_h * o_w) + 1) * (i_h - 1) / 2;
+    DType x_real = (*(grid + grid_index) + 1) * (i_w - 1) / 2;
+    // the way in which cudnnSpatialTfSamplerForward deals with boundaries
+    // is different from here
+    if (between(x_real, 0, i_w-1) && between(y_real, 0, i_h-1)) {
+      // within the boundaries
+      index_t top_left_y = static_cast<int>(floor(y_real));
+      index_t top_left_x = static_cast<int>(floor(x_real));
+      DType top_left_y_w = 1.0 - (y_real - top_left_y);
+      DType top_left_x_w = 1.0 - (x_real - top_left_x);
+      index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w + top_left_y * i_w + top_left_x;
+      DType top_left_v = *(data + data_index);
+      DType top_right_v = *(data + data_index + 1);
+      DType bottom_left_v = *(data + data_index + i_w);
+      DType bottom_right_v = *(data + data_index + i_w + 1);
+      *(out+out_index) = top_left_v * top_left_y_w * top_left_x_w +
+                         top_right_v * top_left_y_w * (1.0 - top_left_x_w) +
+                         bottom_left_v * (1.0 - top_left_y_w) * top_left_x_w +
+                         bottom_right_v * (1.0 - top_left_y_w) * (1.0 - top_left_x_w);
+    }  else {
+      // beyond the boundaries
+      *(out+out_index) = 0;
+    }
+  }
+}
+
+template<typename DType>
+__global__ void BilinearSamplingBackwardKernel(const int i_c, const int i_h,
+                                              const int i_w, const DType* grad,
+                                              const DType* data, const int o_n,
+                                              const int o_c, const int o_h,
+                                              const int o_w, DType* g_input,
+                                              const DType* grid_src,
+                                              DType* grad_grid) {
+  for (int index = (blockIdx.x + blockIdx.y * gridDim.x) * blockDim.x + threadIdx.x;
+       index < o_n * o_h * o_w;
+       index += blockDim.x * gridDim.x * gridDim.y) {
+    // (n, c, h, w) is the element in grad
+    int w = index % o_w;
+    int h = (index / o_w) % o_h;
+    int n = index / o_w / o_h;
+    DType top_left_y_gw = 0.0;
+    DType top_left_x_gw = 0.0;
+    index_t grid_src_index = n * o_h * o_w * 2 + h * o_w + w;
+    DType y_real = (*(grid_src + grid_src_index + o_h * o_w) + 1) * (i_h - 1) / 2;
+    DType x_real = (*(grid_src + grid_src_index) + 1) * (i_w - 1) / 2;
+    // the way in which cudnnSpatialTfSamplerBackward deals with boundaries
+    // is different from here
+    if (between(x_real, 0, i_w-1) && between(y_real, 0, i_h-1)) {
+      // within the boundaries
+      index_t top_left_y = static_cast<int>(floor(y_real));
+      index_t top_left_x = static_cast<int>(floor(x_real));
+      DType top_left_y_w = 1.0 - (y_real - top_left_y);
+      DType top_left_x_w = 1.0 - (x_real - top_left_x);
+      for (index_t c = 0; c < o_c; ++c) {
+        index_t grad_index = n * o_c * o_h * o_w + c * o_h * o_w + h * o_w + w;
+        index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w + top_left_y * i_w + top_left_x;
+        // calc 4 vertex value in input data
+        DType top_left_v = *(data + data_index);
+        DType top_right_v = *(data + data_index + 1);
+        DType bottom_left_v = *(data + data_index + i_w);
+        DType bottom_right_v = *(data + data_index + i_w + 1);
+        // calc input grad
+        *(g_input + data_index) += *(grad + grad_index) * top_left_y_w * top_left_x_w;
+        *(g_input + data_index + 1) += *(grad + grad_index) * top_left_y_w * (1.0 - top_left_x_w);
+        *(g_input + data_index+ i_w) += *(grad + grad_index) * (1.0 - top_left_y_w) * top_left_x_w;
+        *(g_input + data_index+ i_w + 1) += *(grad + grad_index) * (1.0 - top_left_y_w) *
+                                            (1.0 - top_left_x_w);
+        // calc weight grad of top_left_w, then multiple -1 is the grad of grid_src
+        top_left_y_gw -= *(grad + grad_index) * (top_right_v - bottom_right_v +
+                         (top_left_v - top_right_v -
+                         bottom_left_v + bottom_right_v) * top_left_x_w);
+        top_left_x_gw -= *(grad + grad_index) * (bottom_left_v - bottom_right_v + (top_left_v -
+                         top_right_v - bottom_left_v + bottom_right_v) * top_left_y_w);
+      }
+      // calc grid_src grad
+      *(grad_grid + grid_src_index + o_h * o_w) = top_left_y_gw * (i_h - 1) / 2;
+      *(grad_grid + grid_src_index) = top_left_x_gw * (i_w - 1) / 2;
+    }
+  }
+}
+
+template<typename DType>
+inline void BilinearSamplingForward(const Tensor<gpu, 4, DType> &output,
+                                    const Tensor<gpu, 4, DType> &input,
+                                    const Tensor<gpu, 4, DType> &grid_src) {
+    DType *out = output.dptr_;
+    const DType *data = input.dptr_;
+    const DType *grid = grid_src.dptr_;
+    int o_n = output.size(0), o_c = output.size(1), o_h = output.size(2), o_w = output.size(3);
+    int i_c = input.size(1), i_h = input.size(2), i_w = input.size(3);
+    using namespace cuda;
+    const int max_block = (output.shape_.Size() + kMaxThreadsPerBlock - 1) / kMaxThreadsPerBlock;
+    dim3 num_blocks(kMaxGridNum, (max_block + kMaxGridNum - 1) / kMaxGridNum);
+    dim3 threads_per_block(kMaxThreadsPerBlock);
+    CheckLaunchParam(num_blocks, threads_per_block, "bilinear sampling forward");
+    cudaStream_t stream = Stream<gpu>::GetStream(output.stream_);
+    BilinearSamplingForwardKernel<DType> << <num_blocks, threads_per_block, 0, stream >> >(
+      i_c, i_h, i_w, data, grid, o_n, o_c, o_h, o_w, out);
+}
+
+template<typename DType>
+inline void BilinearSamplingBackward(const Tensor<gpu, 4, DType> &input_grad,
+                                     const Tensor<gpu, 4, DType> &ggrid,
+                                     const Tensor<gpu, 4, DType> &output_grad,
+                                     const Tensor<gpu, 4, DType> &input_data,
+                                     const Tensor<gpu, 4, DType> &grid) {
+  DType *g_input = input_grad.dptr_;
+  DType *grad_grid = ggrid.dptr_;
+  const DType *grid_src = grid.dptr_;
+  const DType *grad = output_grad.dptr_;
+  const DType *data = input_data.dptr_;
+  int o_n = output_grad.size(0), o_c = output_grad.size(1),
+      o_h = output_grad.size(2), o_w = output_grad.size(3);
+  int i_c = input_data.size(1), i_h = input_data.size(2), i_w = input_data.size(3);
+  using namespace cuda;
+  const int max_block = (output_grad.shape_.Size() / o_c + kMaxThreadsPerBlock - 1)
+                        / kMaxThreadsPerBlock;
+  dim3 num_blocks(kMaxGridNum, (max_block + kMaxGridNum - 1) / kMaxGridNum);
+  dim3 threads_per_block(kMaxThreadsPerBlock);
+  CheckLaunchParam(num_blocks, threads_per_block, "bilinear sampling backward");
+  cudaStream_t stream = Stream<gpu>::GetStream(input_grad.stream_);
+  BilinearSamplingBackwardKernel<DType> << <num_blocks, threads_per_block, 0, stream >> >(
+    i_c, i_h, i_w, grad, data, o_n, o_c, o_h, o_w, g_input, grid_src, grad_grid);
+}
+
+}  // namespace mshadow
+
+namespace mxnet {
+namespace op {
+template<>
+Operator* CreateOp<gpu>(BilinearSamplingParam param, int dtype) {
+  Operator *op = NULL;
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR == 5
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new CuDNNBilinearSamplingOp<DType>(param);
+  })
+#else
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new BilinearSamplingOp<gpu, DType>(param);
+  })
+#endif  // MXNET_USE_CUDNN && CUDNN_MAJOR
+  return op;
+}
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/cudnn_bilinear_sampling-inl.h
+++ b/src/operator/cudnn_bilinear_sampling-inl.h
@@ -1,0 +1,165 @@
+/*!
+ * Copyright (c) 2016 by Contributors
+ * \file cudnn_bilinear_sampling-inl.h
+ * \brief
+ * \author Xu Dong
+*/
+#ifndef MXNET_OPERATOR_CUDNN_BILINEAR_SAMPLING_INL_H_
+#define MXNET_OPERATOR_CUDNN_BILINEAR_SAMPLING_INL_H_
+
+#include <algorithm>
+#include <vector>
+#include "./bilinear_sampling-inl.h"
+namespace mxnet {
+namespace op {
+#if defined(__CUDACC__) && MXNET_USE_CUDNN == 1 && CUDNN_MAJOR == 5
+template<typename DType>
+class CuDNNBilinearSamplingOp : public Operator {
+ public:
+  explicit CuDNNBilinearSamplingOp(BilinearSamplingParam param) {
+    this->param_ = param;
+    init_cudnn_ = false;
+    dtype_ = mshadow::DataType<DType>::kCudnnFlag;
+    sampler_ = CUDNN_SAMPLER_BILINEAR;
+  }
+
+  ~CuDNNBilinearSamplingOp() {
+    if (init_cudnn_) {
+      CHECK_EQ(cudnnDestroySpatialTransformerDescriptor(st_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnDestroyTensorDescriptor(in_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnDestroyTensorDescriptor(out_desc_), CUDNN_STATUS_SUCCESS);
+    }
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    CHECK_EQ(in_data.size(), 2);
+    CHECK_EQ(out_data.size(), 2);
+    Stream<gpu> *s = ctx.get_stream<gpu>();
+
+    Tensor<gpu, 4, DType> data = in_data[bs::kData].get<gpu, 4, DType>(s);
+    Tensor<gpu, 4, DType> grid = in_data[bs::kGrid].get<gpu, 4, DType>(s);
+    Tensor<gpu, 4, DType> grid_tmp = out_data[bs::kTmp].get<gpu, 4, DType>(s);
+    Tensor<gpu, 4, DType> out = out_data[bs::kOut].get<gpu, 4, DType>(s);
+    // grid_tmp : (batch, h, w, 2)
+    grid_tmp = transpose(grid, Shape4(0, 2, 3, 1));
+    if (!init_cudnn_) {
+     Init(s, in_data, out_data);
+    }
+    CHECK_EQ(data.CheckContiguous(), true);
+    CHECK_EQ(out.CheckContiguous(), true);
+    CHECK_EQ(grid_tmp.CheckContiguous(), true);
+    typename DataType<DType>::ScaleType alpha = 1.0f;
+    typename DataType<DType>::ScaleType beta = 0.0f;
+    CHECK_EQ(cudnnSpatialTfSamplerForward(s->dnn_handle_,
+                                          st_desc_,
+                                          &alpha,
+                                          in_desc_,
+                                          data.dptr_,
+                                          grid_tmp.dptr_,
+                                          &beta,
+                                          out_desc_,
+                                          out.dptr_/*output*/), CUDNN_STATUS_SUCCESS);
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    CHECK_EQ(in_data.size(), 2);
+    CHECK_EQ(out_data.size(), 2);
+    CHECK_EQ(out_grad.size(), 1);
+    Stream<gpu> *s = ctx.get_stream<gpu>();
+    Tensor<gpu, 4, DType> data = in_data[bs::kData].get<gpu, 4, DType>(s);
+    Tensor<gpu, 4, DType> grid_tmp = out_data[bs::kTmp].get<gpu, 4, DType>(s);
+    Tensor<gpu, 4, DType> gdata = in_grad[bs::kData].get<gpu, 4, DType>(s);
+    Tensor<gpu, 4, DType> ggrid = in_grad[bs::kGrid].get<gpu, 4, DType>(s);
+    Tensor<gpu, 4, DType> grad = out_grad[bs::kOut].get<gpu, 4, DType>(s);
+
+    typename DataType<DType>::ScaleType alpha = 1.0f;
+    typename DataType<DType>::ScaleType beta = 0.0f;
+    typename DataType<DType>::ScaleType alpha_dgrid = 1.0f;
+    typename DataType<DType>::ScaleType beta_dgrid = 0.0f;
+    CHECK_EQ(cudnnSpatialTfSamplerBackward(s->dnn_handle_,
+                                           st_desc_,
+                                           &alpha,
+                                           in_desc_,
+                                           data.dptr_,
+                                           &beta,
+                                           in_desc_/*reuse in_desc_*/,
+                                           gdata.dptr_/*output*/,
+                                           &alpha_dgrid,
+                                           out_desc_/*reuse out_desc_*/,
+                                           grad.dptr_,
+                                           grid_tmp.dptr_,
+                                           &beta_dgrid,
+                                           grid_tmp.dptr_/*output, reuse grid*/),
+                                           CUDNN_STATUS_SUCCESS);
+    ggrid = transpose(grid_tmp, Shape4(0, 3, 1, 2));
+  }
+
+ private:
+  inline void Init(mshadow::Stream<gpu> *s,
+                   const std::vector<TBlob> &in_data,
+                   const std::vector<TBlob> &out_data) {
+    using namespace mshadow;
+    #if CUDNN_MAJOR == 5
+    format_ = CUDNN_TENSOR_NCHW;
+    #endif
+    CHECK_EQ(in_data.size(), 2);
+    CHECK_EQ(out_data.size(), 2);
+    if (!init_cudnn_) {
+      init_cudnn_ = true;
+      Tensor<gpu, 4, DType> data = in_data[bs::kData].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> out = out_data[bs::kOut].get<gpu, 4, DType>(s);
+      CHECK_EQ(cudnnCreateSpatialTransformerDescriptor(&st_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnSetTensor4dDescriptor(in_desc_,
+                                          format_,
+                                          dtype_,
+                                          data.size(0),
+                                          data.size(1),
+                                          data.size(2),
+                                          data.size(3)), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnSetTensor4dDescriptor(out_desc_,
+                                          format_,
+                                          dtype_,
+                                          out.size(0),
+                                          out.size(1),
+                                          out.size(2),
+                                          out.size(3)), CUDNN_STATUS_SUCCESS);
+      int dim[] = {static_cast<int>(out.size(0)), static_cast<int>(out.size(1)),
+                   static_cast<int>(out.size(2)), static_cast<int>(out.size(3))};
+      CHECK_EQ(cudnnSetSpatialTransformerNdDescriptor(st_desc_,
+                                                      sampler_,
+                                                      dtype_,
+                                                      4,
+                                                      dim) , CUDNN_STATUS_SUCCESS);
+    }
+  }
+
+  bool init_cudnn_;
+  cudnnDataType_t dtype_;
+  cudnnSpatialTransformerDescriptor_t st_desc_;
+  cudnnTensorDescriptor_t in_desc_;
+  cudnnTensorDescriptor_t out_desc_;
+  cudnnSamplerType_t sampler_;
+  #if CUDNN_MAJOR == 5
+  cudnnTensorFormat_t format_;
+  #endif
+  BilinearSamplingParam param_;
+};
+#endif  // __CUDACC__ && CUDNN
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_CUDNN_BILINEAR_SAMPLING_INL_H_

--- a/src/operator/grid_generator-inl.h
+++ b/src/operator/grid_generator-inl.h
@@ -1,0 +1,314 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file grid_generator-inl.h
+ * \brief 
+ * The operator generate sampling grid
+ * \author Xu Dong
+*/
+#ifndef MXNET_OPERATOR_GRID_GENERATOR_INL_H_
+#define MXNET_OPERATOR_GRID_GENERATOR_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <vector>
+#include <map>
+#include <utility>
+#include <string>
+#include "./operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+namespace grid {
+enum GridGeneratorOpInputs {kData};
+enum GridGeneratorOpOutputs {kOut, kGridDst, kTmp};
+enum GridGeneratorOpResource {kTempSpace};
+enum GridGeneratorTransformType {kAffine, kWarp};
+}
+
+struct GridGeneratorParam : public dmlc::Parameter<GridGeneratorParam> {
+  int transform_type;
+  TShape target_shape;
+  DMLC_DECLARE_PARAMETER(GridGeneratorParam) {
+    int shape[] = {0, 0};
+    DMLC_DECLARE_FIELD(transform_type)
+    .add_enum("affine", grid::kAffine)
+    .add_enum("warp", grid::kWarp)
+    .describe("transformation type\n    "
+              "if transformation type is affine, data is affine matrix : (batch, 6)\n    "
+              "if transformation type is warp, data is optical flow : (batch, 2, h, w)");
+    DMLC_DECLARE_FIELD(target_shape).set_default(TShape(shape, shape + 2))
+    .describe("if transformation type is affine, the operator need a target_shape : (H, W)\n    "
+              "if transofrmation type is warp, the operator will ignore target_shape");
+  }
+};
+
+template<typename xpu, typename DType>
+class GridGeneratorOp : public Operator {
+ public:
+  explicit GridGeneratorOp(GridGeneratorParam p) {
+    this->param_ = p;
+  }
+
+  virtual void Forward(const OpContext &ctx,
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 3);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    switch (param_.transform_type) {
+      case grid::kAffine: {
+        // if transform_type is affine, data is affine matrix, input shape : (batch, 2, 3)
+        Tensor<xpu, 4, DType> out = out_data[grid::kOut].get<xpu, 4, DType>(s);
+        Tensor<xpu, 2, DType> grid_dst = out_data[grid::kGridDst].get<xpu, 2, DType>(s);
+        Shape<3> data_shape = Shape3(out.size(0), 2, 3);
+        Tensor<xpu, 3, DType> data = in_data[grid::kData]
+          .get_with_shape<xpu, 3, DType>(data_shape, s);
+        Tensor<cpu, 2, DType> workspace =
+              ctx.requested[grid::kTempSpace].get_host_space_typed<2, DType>(
+              grid_dst.shape_);
+        Tensor<xpu, 3, DType> tmp = out_data[grid::kTmp].get<xpu, 3, DType>(s);
+        for (index_t i = 1; i <= workspace.size(1); i++) {
+          // grid dst coordinate is (x, y, 1)
+          workspace[0][i-1] = -1.0 + (i-1) % param_.target_shape[1] * 2.0 /
+                              (param_.target_shape[1] - 1);
+          workspace[1][i-1] = -1.0 + (i-1) / param_.target_shape[1] * 2.0 /
+                              (param_.target_shape[0] - 1);
+          workspace[2][i-1] = 1.0;
+        }
+        // create a sampling grid, tmp : (batch, 2, H x W)
+        Copy(grid_dst, workspace, grid_dst.stream_);
+        for (index_t batch = 0; batch < data.size(0); batch++) {
+              tmp[batch] = dot(data[batch], grid_dst);
+        }
+        // out : (batch, 2, H, W)
+        out = reshape(tmp, out.shape_);
+        break;
+      }
+      // Warping transformation
+      case grid::kWarp: {
+        // if transform_type is warp, data is optical flow, input shape : (batch, 2, height, width)
+        // grid_src = grid_dst + optical flow
+        Tensor<xpu, 4, DType> data = in_data[grid::kData].get<xpu, 4, DType>(s);
+        Tensor<xpu, 4, DType> out = out_data[grid::kOut].get<xpu, 4, DType>(s);
+        // grid_dst : (2, H, W) similar to the results of numpy.meshgrid
+        Tensor<xpu, 3, DType> grid_dst = out_data[grid::kGridDst].get<xpu, 3, DType>(s);
+        Tensor<xpu, 1, DType> tmp = out_data[grid::kTmp].get<xpu, 1, DType>(s);
+        Tensor<xpu, 1, DType> workspace =
+              ctx.requested[grid::kTempSpace]
+                .get_space_typed<xpu, 1, DType>(Shape1(data.size(3)), s);
+        workspace = range<DType>(0, data.size(3));
+        grid_dst[0] = repmat(workspace, data.size(2));
+        tmp = range<DType>(0, data.size(2), 1, data.size(3));
+        grid_dst[1] = reshape(tmp, Shape2(data.size(2), data.size(3)));
+        for (index_t batch = 0; batch < data.size(0); batch++) {
+          // bilinear sampling op assume that grid has been nomalized
+          out[batch][0] = (data[batch][0] + grid_dst[0]) /
+            scalar<DType>((data.size(3) - 1) / 2.0) - scalar<DType>(1);
+          out[batch][1] = (data[batch][1] + grid_dst[1]) /
+            scalar<DType>((data.size(2) - 1) / 2.0) - scalar<DType>(1);
+        }
+        break;
+      }
+    }
+  }
+
+  virtual void Backward(const OpContext &ctx,
+                        const std::vector<TBlob> &out_grad,
+                        const std::vector<TBlob> &in_data,
+                        const std::vector<TBlob> &out_data,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<TBlob> &in_grad,
+                        const std::vector<TBlob> &aux_args) {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    CHECK_EQ(in_data.size(), 1);
+    CHECK_EQ(out_data.size(), 3);
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    switch (param_.transform_type) {
+      case grid::kAffine: {
+        Tensor<xpu, 4, DType> grad = out_grad[grid::kOut].get<xpu, 4, DType>(s);
+        Tensor<xpu, 2, DType> grid_dst = out_data[grid::kGridDst].get<xpu, 2, DType>(s);
+        Shape<3> data_shape = Shape3(grad.size(0), 2, 3);
+        Tensor<xpu, 3, DType> gdata = in_grad[grid::kData]
+        .get_with_shape<xpu, 3, DType>(data_shape, s);
+        Tensor<xpu, 3, DType> tmp = out_data[grid::kTmp].get<xpu, 3, DType>(s);
+        tmp = reshape(grad, tmp.shape_);
+        for (index_t batch = 0; batch < gdata.size(0); batch++) {
+            // tmp : (2, H X W)  grid_dst.T : (H x W, 3)
+            gdata[batch] = dot(tmp[batch], grid_dst.T());
+        }
+        break;
+      }
+      case grid::kWarp: {
+        Tensor<xpu, 4, DType> grad = out_grad[grid::kOut].get<xpu, 4, DType>(s);
+        Tensor<xpu, 4, DType> gdata = in_grad[grid::kData].get<xpu, 4, DType>(s);
+        for (index_t batch = 0; batch < gdata.size(0); batch++) {
+            gdata[batch][0] = grad[batch][0] / scalar<DType>((gdata.size(3)-1) / 2.0);
+            gdata[batch][1] = grad[batch][1] / scalar<DType>((gdata.size(2)-1) / 2.0);
+        }
+        break;
+      }
+    }
+  }
+
+ private:
+  GridGeneratorParam param_;
+};  // class GridGeneratorOp
+
+template<typename xpu>
+Operator* CreateOp(GridGeneratorParam param, int dtype);
+
+#if DMLC_USE_CXX11
+class GridGeneratorProp : public OperatorProperty {
+ public:
+  int NumVisibleOutputs() const override {
+    return 1;
+  }
+
+  int NumOutputs() const override {
+    return 3;
+  }
+
+  std::vector<std::string> ListArguments() const override {
+    return {"data"};
+  }
+
+  std::vector<std::string> ListOutputs() const override {
+    return {"output", "grid_dst", "tmp"};
+  }
+
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
+    param_.Init(kwargs);
+  }
+
+  std::map<std::string, std::string> GetParams() const override {
+    return param_.__DICT__();
+  }
+
+  bool InferShape(std::vector<TShape> *in_shape,
+                  std::vector<TShape> *out_shape,
+                  std::vector<TShape> *aux_shape) const override {
+    using namespace mshadow;
+    CHECK_EQ(in_shape->size(), 1) << "Input:[data]";
+    const TShape &lshape = (*in_shape)[grid::kData];
+    if (lshape.ndim() ==  0) return false;
+    out_shape->clear();
+    switch (param_.transform_type) {
+      case grid::kAffine: {
+        CHECK_EQ(lshape.ndim(), 2) \
+          << "if transform_type is affine, data is affine matrix"
+          "affine matrix should be 2D in batch-num_hidden";
+        CHECK_EQ(lshape[1], 6) << "incorrect data shape[1], should be 6";
+        CHECK_GT(param_.target_shape[0], 0) \
+            << "incorrect target_shape: " << param_.target_shape[0];
+        CHECK_GT(param_.target_shape[1], 0) \
+            << "incorrect target_shape: " << param_.target_shape[1];
+        out_shape->push_back(Shape4(lshape[0], 2, param_.target_shape[0], param_.target_shape[1]));
+        out_shape->push_back(Shape2(3, param_.target_shape[0] * param_.target_shape[1]));
+        out_shape->push_back(Shape3(lshape[0], 2, param_.target_shape[0] * param_.target_shape[1]));
+        break;
+      }
+      case grid::kWarp: {
+        CHECK_EQ(lshape.ndim(), 4) \
+          << "if transform_type is warp, data is optical flow"
+             "optical flow should be 4D in batch-num_hidden-y-x";
+        CHECK_EQ(lshape[1], 2) << "incorrect data shape[1], should be 2";
+        out_shape->push_back(lshape);
+        out_shape->push_back(Shape3(2, lshape[2], lshape[3]));
+        out_shape->push_back(Shape1(lshape[2]*lshape[3]));
+        break;
+      }
+    }
+    return true;
+  }
+
+  bool InferType(std::vector<int> *in_type,
+                   std::vector<int> *out_type,
+                   std::vector<int> *aux_type) const override {
+      int dtype = -1;
+      for (size_t i = 0; i < in_type->size(); ++i) {
+        if (dtype == -1) {
+          dtype = in_type->at(i);
+        } else {
+          CHECK(in_type->at(i) == dtype ||
+                in_type->at(i) == -1) <<
+                "Non-uniform data type in GridGenerator";
+        }
+      }
+      if (dtype == -1) {
+        LOG(FATAL) << "Not enough information to infer type in GridGenerator.";
+        return false;
+      }
+      size_t nin = this->ListArguments().size();
+      in_type->clear();
+      for (size_t i = 0; i < nin; ++i) in_type->push_back(dtype);
+      size_t naux = this->ListAuxiliaryStates().size();
+      aux_type->clear();
+      for (size_t i = 0; i < naux; ++i) aux_type->push_back(dtype);
+      size_t nout = this->ListOutputs().size();
+      out_type->clear();
+      for (size_t i = 0; i < nout; ++i) out_type->push_back(dtype);
+      return true;
+    }
+
+  OperatorProperty* Copy() const override {
+    auto ptr = new GridGeneratorProp();
+    ptr->param_ = param_;
+    return ptr;
+  }
+
+  std::string TypeString() const override {
+    return "GridGenerator";
+  }
+
+  std::vector<int> DeclareBackwardDependency(
+    const std::vector<int> &out_grad,
+    const std::vector<int> &in_data,
+    const std::vector<int> &out_data) const override {
+    switch (param_.transform_type) {
+      case grid::kAffine: {
+        return {out_grad[grid::kOut],
+                out_data[grid::kGridDst],
+                out_data[grid::kTmp]};
+      }
+      case grid::kWarp: {
+        return {out_grad[grid::kOut]};
+      }
+    }
+    return {};
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+      const std::vector<TShape> &in_shape) const override {
+    switch (param_.transform_type) {
+      case grid::kAffine: {
+        return {ResourceRequest::kTempSpace};
+      }
+      case grid::kWarp: {
+        return {ResourceRequest::kTempSpace};
+      }
+    }
+    return {};
+  }
+
+  Operator* CreateOperator(Context ctx) const override {
+    LOG(FATAL) << "Not Implemented.";
+    return NULL;
+  }
+
+  Operator* CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
+                             std::vector<int> *in_type) const override;
+
+ private:
+  GridGeneratorParam param_;
+};  // class GridGeneratorProp
+#endif  // DMLC_USE_CXX11
+}  // namespace op
+}  // namespace mxnet
+#endif  // MXNET_OPERATOR_GRID_GENERATOR_INL_H_

--- a/src/operator/grid_generator.cc
+++ b/src/operator/grid_generator.cc
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file grid_generator.cc
+ * \brief
+ * \author Xu Dong
+*/
+
+#include "./grid_generator-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator* CreateOp<cpu>(GridGeneratorParam param, int dtype) {
+  Operator *op = NULL;
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new GridGeneratorOp<cpu, DType>(param);
+  })
+  return op;
+}
+
+Operator *GridGeneratorProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,
+                                     std::vector<int> *in_type) const {
+  std::vector<TShape> out_shape, aux_shape;
+  std::vector<int> out_type, aux_type;
+  CHECK(InferType(in_type, &out_type, &aux_type));
+  CHECK(InferShape(in_shape, &out_shape, &aux_shape));
+  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0]);
+}
+
+DMLC_REGISTER_PARAMETER(GridGeneratorParam);
+
+MXNET_REGISTER_OP_PROPERTY(GridGenerator, GridGeneratorProp)
+.add_argument("data", "Symbol", "Input data to the GridGeneratorOp.")
+.describe("if transformation type is affine, data is affine matrix : (batch, 6)")
+.describe("if transformation type is warp, data is optical flow : (batch, 2, h, w)")
+.add_arguments(GridGeneratorParam::__FIELDS__())
+.describe("generate sampling grid for bilinear sampling.");
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/grid_generator.cu
+++ b/src/operator/grid_generator.cu
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file grid_generator.cu
+ * \brief
+ * \author Xu Dong
+*/
+
+#include "./grid_generator-inl.h"
+
+namespace mxnet {
+namespace op {
+template<>
+Operator* CreateOp<gpu>(GridGeneratorParam param, int dtype) {
+  Operator *op = NULL;
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    op = new GridGeneratorOp<gpu, DType>(param);
+  })
+  return op;
+}
+}  // namespace op
+}  // namespace mxnet


### PR DESCRIPTION
WarpOp is very similar to remap in OpenCV, but have slight differences. It will remap feature map via bilinear interpolation, according to optical flow.

If you want to know the mathematical details of WarpOp, please refer to [Supplementary Material for
"FlowNet 2.0: Evolution of Optical Flow Estimation with Deep Networks"](http://lmb.informatik.uni-freiburg.de/Publications/2016/IMKDB16/FlowNet_2_0_Supplemental__arXiv.pdf)