### PR TITLE
Improve profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ mxnet_option(USE_OPENCV  "Build with OpenCV support" ON)
 mxnet_option(USE_OPENMP  "Build with Openmp support" ON)
 mxnet_option(USE_CUDNN   "Build with cudnn support"  ON) # one could set CUDNN_ROOT for search path
 mxnet_option(USE_CUDA    "Build with CUDA support"   ON)
+mxnet_option(USE_PROFILER "Build with Profiler support"   OFF)
 mxnet_option(USE_DIST_KVSTORE    "Build with DIST_KVSTORE support"   OFF)
 mxnet_option(USE_PLUGINS_WARPCTC	"Use WARPCTC Plugins" OFF)
 mxnet_option(USE_MXNET_LIB_NAMING "Use MXNet library naming conventions." ON)
@@ -276,6 +277,10 @@ if(USE_DIST_KVSTORE)
 	target_link_libraries(mxnet pslite)
 	target_link_libraries(mxnet ${pslite_LINKER_LIBS})
 	include_directories(SYSTEM ${pslite_INCLUDE_DIR})
+endif()
+
+if(USE_PROFILER)
+	add_definitions(-DMXNET_USE_PROFILER)
 endif()
 
 # ---[ Linter target

--- a/src/engine/profiler.cc
+++ b/src/engine/profiler.cc
@@ -16,20 +16,27 @@
 namespace mxnet {
 namespace engine {
 
-// TODO(ziheng) more lock free
-
 Profiler* Profiler::instance_ = nullptr;
 std::mutex Profiler::m_;
+const int INITIAL_SIZE = 1024;
 
 Profiler::Profiler()
-    : state_(kNotRunning), enable_output_(false), mode_(kOnlySymbolic), filename_("profile.json") {
+  : state_(kNotRunning), enable_output_(false), filename_("profile.json") {
   this->init_time_ = NowInUsec();
 
   // TODO(ziheng) get device number during execution
-  int kMaxNumCpus = 60, kMaxNumGpus = 16;
-  this->cpu_num_ = kMaxNumCpus, this->gpu_num_ = kMaxNumGpus;
+  int kMaxNumCpus = 64;
+  this->cpu_num_ = kMaxNumCpus;
+
+#if MXNET_USE_CUDA
+  cudaError_t ret = cudaGetDeviceCount((int*)&this->gpu_num_);
+  if (ret != cudaSuccess) {
+    this->gpu_num_ = 0;
+  }
+#endif
 
   this->profile_stat = new DevStat[cpu_num_ + gpu_num_ + 1];
+  this->profile_stat->opr_exec_stats.reserve(INITIAL_SIZE);
   for (unsigned int i = 0; i < cpu_num_; ++i) {
     profile_stat[i].dev_name = "cpu/" + std::to_string(i);
   }
@@ -37,6 +44,12 @@ Profiler::Profiler()
     profile_stat[cpu_num_ + i].dev_name = "gpu/" + std::to_string(i);
   }
   profile_stat[cpu_num_ + gpu_num_].dev_name = "cpu pinned/";
+
+  mode_ = (ProfilerMode)dmlc::GetEnv("MXNET_PROFILER_MODE", (int)kOnlySymbolic);
+  if (dmlc::GetEnv("MXNET_PROFILER_AUTOSTART", 0)) {
+    this->state_ = ProfilerState::kRunning;
+    this->enable_output_ = true;
+  }
 }
 
 Profiler* Profiler::Get() {
@@ -61,12 +74,11 @@ void Profiler::SetConfig(ProfilerMode mode, std::string output_filename) {
   this->filename_ = output_filename;
 }
 
-OprExecStat *Profiler::AddOprStat(int dev_type, int dev_id) {
-  std::lock_guard<std::mutex> lock{Profiler::m_};
-
+OprExecStat *Profiler::AddOprStat(int dev_type, uint32_t dev_id) {
   OprExecStat* opr_stat = new OprExecStat;
   opr_stat->dev_type = dev_type;
   opr_stat->dev_id   = dev_id;
+  opr_stat->opr_name[sizeof(opr_stat->opr_name)-1] = '\0';
 
   int idx;
   switch (dev_type) {
@@ -85,12 +97,14 @@ OprExecStat *Profiler::AddOprStat(int dev_type, int dev_id) {
   }
 
   DevStat& dev_stat = profile_stat[idx];
-  dev_stat.opr_exec_stats.push_back(opr_stat);
-
+  {
+	std::lock_guard<std::mutex> lock{Profiler::m_};
+	dev_stat.opr_exec_stats.push_back(opr_stat);
+  }
   return opr_stat;
 }
 
-void Profiler::EmitPid(std::ostream *os, const std::string& name, int pid) {
+void Profiler::EmitPid(std::ostream *os, const std::string& name, uint32_t pid) {
   (*os) << "        {\n"
         << "            \"ph\": \"M\",\n"
         << "            \"args\": {\n"
@@ -103,7 +117,7 @@ void Profiler::EmitPid(std::ostream *os, const std::string& name, int pid) {
 
 void Profiler::EmitEvent(std::ostream *os, const std::string& name,
                        const std::string& category, const std::string& ph,
-                       uint64_t ts, int pid, int tid) {
+                       uint64_t ts, uint32_t pid, uint32_t tid) {
   (*os) << "        {\n"
         << "            \"name\": \""  << name << "\",\n"
         << "            \"cat\": " << "\"" << category << "\",\n"
@@ -123,24 +137,24 @@ void Profiler::DumpProfile() {
   file << "{" << std::endl;
   file << "    \"traceEvents\": [" << std::endl;
 
-  int dev_num = cpu_num_ + gpu_num_ + 1;
+  uint32_t dev_num = cpu_num_ + gpu_num_ + 1;
 
-  for (int i = 0; i < dev_num; ++i) {
+  for (uint32_t i = 0; i < dev_num; ++i) {
     const DevStat &d = profile_stat[i];
     this->EmitPid(&file, d.dev_name, i);
     file << ",\n";
   }
 
   bool first_flag = true;
-  for (int i = 0; i < dev_num; ++i) {
+  for (uint32_t i = 0; i < dev_num; ++i) {
     const DevStat &d = profile_stat[i];
-    int opr_num = d.opr_exec_stats.size();
+    uint32_t opr_num = d.opr_exec_stats.size();
 
-    for (int j = 0; j < opr_num; ++j) {
+    for (uint32_t j = 0; j < opr_num; ++j) {
       const OprExecStat* opr_stat = d.opr_exec_stats[j];
 
-      int pid = i;
-      int tid = opr_stat->thread_id;
+      uint32_t pid = i;
+      uint32_t tid = opr_stat->thread_id;
 
       if (first_flag) {
         first_flag = false;
@@ -152,7 +166,7 @@ void Profiler::DumpProfile() {
             opr_stat->opr_start_rel_micros, pid, tid);
       file << ",\n";
       this->EmitEvent(&file, opr_stat->opr_name, "category", "E",
-            opr_stat->opr_end_rel_micros,   pid, tid);
+            opr_stat->opr_end_rel_micros, pid, tid);
     }
   }
 

--- a/src/engine/profiler.h
+++ b/src/engine/profiler.h
@@ -19,7 +19,7 @@ namespace engine {
  */
 struct OprExecStat {
   /*! \brief operation name */
-  std::string opr_name;
+  char opr_name[32];
   /*!
    * \brief operation execution start relative timestamp
    *        time unit is microsecond (10^-6 s)
@@ -92,7 +92,7 @@ class Profiler {
   }
   /*! \brief add one operation execution record in
    *   corresponding device statistics */
-  OprExecStat* AddOprStat(int dev_type, int dev_id);
+  OprExecStat* AddOprStat(int dev_type, uint32_t dev_id);
 
  protected:
   /*! \brief make constructor protected. */
@@ -100,11 +100,11 @@ class Profiler {
 
  private:
   /*! \brief generate device information following chrome profile file format */
-  void EmitPid(std::ostream *os, const std::string& name, int pid);
+  void EmitPid(std::ostream *os, const std::string& name, uint32_t pid);
   /*! \brief generate event information following chrome profile file format */
   void EmitEvent(std::ostream *os, const std::string& name,
           const std::string& category, const std::string& ph,
-          uint64_t ts, int pid, int tid);
+          uint64_t ts, uint32_t pid, uint32_t tid);
   /*! \brief Profiler instance */
   static Profiler* instance_;
   /*! \brief internal mutex of the profiler */

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -306,7 +306,7 @@ class ThreadedEngine : public Engine {
       opr_block->opr_stat = Profiler::Get()->AddOprStat(ctx.dev_type, ctx.dev_id);
       uint64_t id = std::hash<std::thread::id>()(std::this_thread::get_id());
       opr_block->opr_stat->thread_id = id;
-      opr_block->opr_stat->opr_name  = std::string(threaded_opr->opr_name);
+      strncpy(opr_block->opr_stat->opr_name, threaded_opr->opr_name, sizeof(opr_block->opr_stat->opr_name) - 1);
       // record operator start timestamp
       SetOprStart(opr_block->opr_stat);
     }


### PR DESCRIPTION
1. Reduce lock scope and avoid do memory allocation inside lock
   when possible. Limit symbol name to 32 chars
2. Add two environment variables to control profiler. This enables
   profiling without change any code.
   MXNET_PROFILER_MODE = [0|1] to select 'all' or 'symbolic'
   MXNET_PROFILER_AUTOSTART = 1 to enable profiler automatically
3. Output pid & tid as unsigned int.
4. Get number of GPUs during runtime
5. Add Profiler support to cmake build and enable it by default