### PR TITLE
Improve profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ mxnet_option(USE_OPENCV  "Build with OpenCV support" ON)
 mxnet_option(USE_OPENMP  "Build with Openmp support" ON)
 mxnet_option(USE_CUDNN   "Build with cudnn support"  ON) # one could set CUDNN_ROOT for search path
 mxnet_option(USE_CUDA    "Build with CUDA support"   ON)
+mxnet_option(USE_PROFILER "Build with Profiler support"   OFF)
 mxnet_option(USE_DIST_KVSTORE    "Build with DIST_KVSTORE support"   OFF)
 mxnet_option(USE_PLUGINS_WARPCTC	"Use WARPCTC Plugins" OFF)
 mxnet_option(USE_MXNET_LIB_NAMING "Use MXNet library naming conventions." ON)
@@ -276,6 +277,10 @@ if(USE_DIST_KVSTORE)
 	target_link_libraries(mxnet pslite)
 	target_link_libraries(mxnet ${pslite_LINKER_LIBS})
 	include_directories(SYSTEM ${pslite_INCLUDE_DIR})
+endif()
+
+if(USE_PROFILER)
+	add_definitions(-DMXNET_USE_PROFILER)
 endif()
 
 # ---[ Linter target

--- a/src/engine/profiler.h
+++ b/src/engine/profiler.h
@@ -19,7 +19,7 @@ namespace engine {
  */
 struct OprExecStat {
   /*! \brief operation name */
-  std::string opr_name;
+  char opr_name[32];
   /*!
    * \brief operation execution start relative timestamp
    *        time unit is microsecond (10^-6 s)
@@ -92,7 +92,7 @@ class Profiler {
   }
   /*! \brief add one operation execution record in
    *   corresponding device statistics */
-  OprExecStat* AddOprStat(int dev_type, int dev_id);
+  OprExecStat* AddOprStat(int dev_type, uint32_t dev_id);
 
  protected:
   /*! \brief make constructor protected. */
@@ -100,11 +100,11 @@ class Profiler {
 
  private:
   /*! \brief generate device information following chrome profile file format */
-  void EmitPid(std::ostream *os, const std::string& name, int pid);
+  void EmitPid(std::ostream *os, const std::string& name, uint32_t pid);
   /*! \brief generate event information following chrome profile file format */
   void EmitEvent(std::ostream *os, const std::string& name,
           const std::string& category, const std::string& ph,
-          uint64_t ts, int pid, int tid);
+          uint64_t ts, uint32_t pid, uint32_t tid);
   /*! \brief Profiler instance */
   static Profiler* instance_;
   /*! \brief internal mutex of the profiler */

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -306,7 +306,9 @@ class ThreadedEngine : public Engine {
       opr_block->opr_stat = Profiler::Get()->AddOprStat(ctx.dev_type, ctx.dev_id);
       uint64_t id = std::hash<std::thread::id>()(std::this_thread::get_id());
       opr_block->opr_stat->thread_id = id;
-      opr_block->opr_stat->opr_name  = std::string(threaded_opr->opr_name);
+      strncpy(opr_block->opr_stat->opr_name,
+        threaded_opr->opr_name,
+        sizeof(opr_block->opr_stat->opr_name) - 1);
       // record operator start timestamp
       SetOprStart(opr_block->opr_stat);
     }


### PR DESCRIPTION
1. Reduce lock scope and avoid do memory allocation inside lock
   when possible. Limit symbol name to 32 chars
2. Add two enviroment variables to control profiler. This enables
   profiling without change any code.
   MXNET_PROFILER_MODE = [0|1] to select 'all' or 'symbolic'
   MXNET_PROFILER_AUTOSTART = 1 to enable profiler automatically
3. Output pid & tid as unsigned int.
4. Get number of GPUs during runtime
5. Add Profiler support to cmake build and disabled by default