### PR TITLE
add access to attributes of R symbols

### DIFF
--- a/R-package/src/symbol.h
+++ b/R-package/src/symbol.h
@@ -45,6 +45,14 @@ class Symbol {
   /*! \return the outputs in the symbol */
   std::vector<std::string> ListOuputs() const;
 
+  /*! \return the attributes of the symbol */
+  Rcpp::List getAttrs() const;
+  /*!
+   * \brief sets the attributes of the symbol
+   * \param attr list of keyword arguments
+   */
+  void setAttrs(Rcpp::List attr);
+
   /*!
    * \brief Save the symbol to file
    * \param fname the file name we need to save to

--- a/R-package/tests/testthat/test_symbol.R
+++ b/R-package/tests/testthat/test_symbol.R
@@ -18,4 +18,17 @@ test_that("basic symbol operation", {
   expect_equal(arguments(composed), c('data', 'fc1_weight', 'fc1_bias', 'fc2_weight', 'fc2_bias', 'fc3_weight', 'fc3_bias', 'fc4_weight', 'fc4_bias'))
 })
 
+test_that("symbol attributes access", {
+  str <- "(1, 1, 1, 1)"
+  x = mx.symbol.Variable('x')
+  x$attributes <- list(`__shape__` = str)
+  
+  expect_equal(x$attributes$`__shape__`, str)
+  
+  y = mx.symbol.Variable('y')
+  y$attributes$`__shape__` <- str
+  
+  expect_equal(y$attributes$`__shape__`, str)
+})
+
 


### PR DESCRIPTION
The `R` package does not offer any access to attributes of a symbol. This PR adds a Rcpp-property 'attributes' and allows getting and setting of the internal attribute values (as it is possible in Python).

Brief usage example can be found in `test_symbol.R`:

```R
test_that("symbol attributes access", {
  str <- "(1, 1, 1, 1)"
  x = mx.symbol.Variable('x')
  x$attributes <- list(`__shape__` = str)
  
  expect_equal(x$attributes$`__shape__`, str)
  
  y = mx.symbol.Variable('y')
  y$attributes$`__shape__` <- str
  
  expect_equal(y$attributes$`__shape__`, str)
})
```