### PR TITLE
[WIP] Broadcast reduce op refactor (Help needed)

### DIFF
--- a/src/operator/tensor/broadcast_reduce_kernel.h
+++ b/src/operator/tensor/broadcast_reduce_kernel.h
@@ -1,0 +1,228 @@
+/*!
+ *  Copyright (c) 2015 by Contributors
+ * \file broadcast_reduce_kernel.h
+ * \brief Function defintion of elementwise unary operators
+ */
+#ifndef MXNET_OPERATOR_TENSOR_BROADCAST_REDUCE_KERNEL_OP_H_
+#define MXNET_OPERATOR_TENSOR_BROADCAST_REDUCE_KERNEL_OP_H_
+
+#include <mxnet/operator_util.h>
+#include <algorithm>
+#include <vector>
+#include <string>
+#include <utility>
+#include "../mshadow_op.h"
+#include "../elemwise_op_common.h"
+#include "./elemwise_binary_op.h"
+#include "../operator_common.h"
+
+namespace mxnet {
+namespace op {
+namespace broadcast {
+using namespace mshadow;
+const int MAX_DIM = 5;
+using CShape = Shape<MAX_DIM>;
+
+MSHADOW_XINLINE CShape unravel(const int idx, const int ndim, const CShape& shape) {
+  CShape ret;
+  for (int i = ndim-1, j = idx; i >=0; --i) {
+    ret[i] = j % shape[i];
+    j /= shape[i];
+  }
+  return ret;
+}
+
+MSHADOW_XINLINE int ravel(const int ndim, const CShape& coord, const CShape& shape) {
+  int ret = 0;
+  for (int i = 0; i < ndim; ++i) {
+    ret = ret * shape[i] + (shape[i] > 1) * coord[i];
+  }
+  return ret;
+}
+
+MSHADOW_XINLINE int diff(const int ndim, const CShape& small, const CShape& big, CShape &dims, CShape &stride) {
+  int mdim = 0;
+  for (int i = 0; i < ndim; ++i)
+    mdim += small[i] != big[i];
+  for (int i = ndim-1, j = mdim, s = 1; i >= 0; --i) {
+    if (small[i] != big[i]) {
+      --j;
+      stride[j] = s;
+      dims[j] = big[i];
+    }
+    s *= big[i];
+  }
+  return mdim;
+}
+
+MSHADOW_XINLINE int dot(const int ndim, const CShape& coord, const CShape& stride) {
+  int ret = 0;
+  for (int i = 0; i < ndim; ++i) 
+    ret += coord[i] * stride[i];
+  return ret;
+}
+
+template<typename DType>
+MSHADOW_XINLINE void assign(DType& dst, const bool addto, const DType src) {
+  if (addto) {
+    dst += src;
+  } else {
+    dst = src;
+  }
+}
+
+template<typename DType, typename OP>
+MSHADOW_XINLINE void binary_broadcast_assign(const int idx, const int ndim, const bool addto,
+                                             const DType* lhs, const DType* rhs, DType* out,
+                                             const CShape& lshape, const CShape& rshape,
+                                             const CShape& oshape) {
+  const CShape coord = unravel(idx, ndim, oshape);
+  const int j = ravel(ndim, coord, lshape);
+  const int k = ravel(ndim, coord, rshape);
+  assign(out[idx], addto, OP::Map(lhs[j], rhs[k]));
+}
+
+template<typename Reducer, typename DType, typename OP>
+MSHADOW_XINLINE void seq_reduce_assign(const int idx, const int M, const int ndim, const int mdim, const bool addto,
+                                       const DType *big, DType *small, const CShape& bshape, const CShape& sshape,
+                                       const CShape& rshape, const CShape& rstride) {
+  CShape coord = unravel(idx, ndim, sshape);
+  int j = ravel(ndim, coord, bshape);
+  DType val;
+  Reducer::SetInitValue(val);
+  for (int k = 0; k < M; ++k) {
+    coord = unravel(k, mdim, rshape);
+    Reducer::Reduce(val, OP::Map(big[j + dot(mdim, coord, rstride)]));
+  }
+  assign(small[idx], addto, val);
+}
+
+#ifdef __CUDACC__
+
+template<typename DType>
+using CTensor = Tensor<gpu, MAX_DIM, DType>;
+
+template<typename DType, typename OP>
+__global__ void binary_broadcast_kernel(const int N, const int ndim, const bool addto, const DType *lhs,
+                                        const DType *rhs, DType *out, const CShape lshape,
+                                        const CShape rshape, const CShape oshape) {
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < N; idx += blockDim.x * gridDim.x) {
+    binary_broadcast_assign<DType, OP>(idx, ndim, addto, lhs, rhs, out, lshape, rshape, oshape);
+  }
+}
+
+template<typename DType, typename OP>
+void BinaryBroadcastComputeImpl(Stream<gpu> *s, int ndim, const OpReqType req,
+                                const CTensor<DType>& lhs, const CTensor<DType>& rhs, CTensor<DType> out) {
+  using namespace mshadow::cuda;
+  if (req == kNullOp) return;
+  cudaStream_t stream = Stream<gpu>::GetStream(s);
+  int N = out.shape_.Size();
+  int ngrid = std::min(kMaxGridNum, (N + kBaseThreadNum - 1) / kBaseThreadNum);
+  binary_broadcast_kernel<DType, OP><<<ngrid, kBaseThreadNum, 0, stream>>>(
+    N, ndim, req == kAddTo, lhs.dptr_, rhs.dptr_, out.dptr_, lhs.shape_, rhs.shape_, out.shape_);
+}
+
+template<typename Reducer, typename DType, typename OP>
+__global__ void seq_reduce_kernel(const int N, const int M, const int ndim, const int mdim, const bool addto,
+                                  const DType *big, DType *small, const CShape bshape, const CShape sshape,
+                                  const CShape rshape, const CShape rstride) {
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < N; idx += blockDim.x * gridDim.x) {
+    seq_reduce_assign<Reducer, DType, OP>(idx, M, ndim, mdim, addto, big, small, bshape, sshape, rshape, rstride);
+  }
+}
+
+template<typename Reducer, typename DType, typename OP, int x_bits>
+__global__ void par_reduce_kernel(const int N, const int M, const int ndim, const int mdim, const bool addto,
+                                  const DType *big, DType *small, const CShape bshape, const CShape sshape,
+                                  const CShape rshape, const CShape rstride) {
+  __shared__ DType buf[1<<x_bits];
+  for (int idx = blockIdx.x; idx < N; idx += gridDim.x) {
+    CShape coord = unravel(idx, ndim, sshape);
+    int j = ravel(ndim, coord, bshape);
+
+    Reducer::SetInitValue(buf[threadIdx.x]);
+    for (int k = threadIdx.x; k < M; k += blockDim.x) {
+      coord = unravel(k, mdim, rshape);
+      Reducer::Reduce(buf[threadIdx.x], OP::Map(big[j + dot(mdim, coord, rstride)]));
+    }
+    __syncthreads();
+    cuda::Reduce1D<Reducer, x_bits>(buf);
+    if (threadIdx.x == 0) {
+      assign(small[idx], addto, buf[0]);
+    }
+  }
+}
+
+template<typename Reducer, typename DType, typename OP>
+void Reduce(Stream<gpu> *s, int ndim, CTensor<DType> small, const OpReqType req,
+            const CTensor<DType>& big) {
+  using namespace mshadow::cuda;
+  if (req == kNullOp) return;
+  cudaStream_t stream = Stream<gpu>::GetStream(s);
+  CShape rshape, rstride;
+  int mdim = diff(ndim, small.shape_, big.shape_, rshape, rstride);
+  int N = small.shape_.Size(), M = rshape.Size();
+  if (false) {
+    int ngrid = std::min(kMaxGridNum, (N + kBaseThreadNum - 1) / kBaseThreadNum);
+    seq_reduce_kernel<Reducer, DType, OP><<<ngrid, kBaseThreadNum, 0, stream>>>(
+      N, M, ndim, mdim, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
+      rshape, rstride);
+  } else {
+    LOG(INFO) << N << " " << M;
+    par_reduce_kernel<Reducer, DType, OP, 10><<<N, 1024, 0, stream>>>(
+      N, M, ndim, mdim, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
+      rshape, rstride);
+  }
+}
+
+#else
+
+template<typename DType>
+using CTensor = Tensor<cpu, MAX_DIM, DType>;
+
+template<typename DType, typename OP>
+void binary_broadcast_compute(const int N, const int ndim, const bool addto, const DType *lhs,
+                              const DType *rhs, DType *out, const CShape lshape,
+                              const CShape rshape, const CShape oshape) {
+  for (int idx = 0; idx < N; ++idx) {
+    binary_broadcast_assign<DType, OP>(idx, ndim, addto, lhs, rhs, out, lshape, rshape, oshape);
+  }
+}
+
+template<typename DType, typename OP>
+void BinaryBroadcastComputeImpl(Stream<cpu> *s, int ndim, const OpReqType req,
+                                const CTensor<DType>& lhs, const CTensor<DType>& rhs, CTensor<DType> out) {
+  if (req == kNullOp) return;
+  int N = out.shape_.Size();
+  binary_broadcast_compute<DType, OP>(N, ndim, req == kAddTo, lhs.dptr_, rhs.dptr_,
+                           out.dptr_, lhs.shape_, rhs.shape_, out.shape_);
+}
+
+template<typename Reducer, typename DType, typename OP>
+void seq_reduce_compute(const int N, const int M, const int ndim, const int mdim, const bool addto,
+                        const DType *big, DType *small, const CShape bshape, const CShape sshape,
+                        const CShape rshape, const CShape rstride) {
+  for (int idx = 0; idx < N; ++idx) {
+    seq_reduce_assign<Reducer, DType, OP>(idx, M, ndim, mdim, addto, big, small, bshape, sshape, rshape, rstride);
+  }
+}
+
+template<typename Reducer, typename DType, typename OP>
+void Reduce(Stream<cpu> *s, int ndim, CTensor<DType> small, const OpReqType req,
+            const CTensor<DType>& big) {
+  if (req == kNullOp) return;
+  CShape rshape, rstride;
+  int mdim = diff(ndim, small.shape_, big.shape_, rshape, rstride);
+  int N = small.shape_.Size(), M = rshape.Size();
+  seq_reduce_compute<Reducer, DType, OP>(
+    N, M, ndim, mdim, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
+    rshape, rstride);
+}
+
+#endif
+}  // broadcast
+}  // op
+}  // mxnet
+
+#endif  // MXNET_OPERATOR_TENSOR_BROADCAST_REDUCE_KERNEL_OP_H_

--- a/src/operator/tensor/broadcast_reduce_kernel.h
+++ b/src/operator/tensor/broadcast_reduce_kernel.h
@@ -23,8 +23,9 @@ using namespace mshadow;
 const int MAX_DIM = 5;
 using CShape = Shape<MAX_DIM>;
 
-MSHADOW_XINLINE CShape unravel(const int idx, const int ndim, const CShape& shape) {
-  CShape ret;
+template<int ndim>
+MSHADOW_XINLINE Shape<ndim> unravel(const int idx, const Shape<ndim>& shape) {
+  Shape<ndim> ret;
   for (int i = ndim-1, j = idx; i >=0; --i) {
     ret[i] = j % shape[i];
     j /= shape[i];
@@ -32,7 +33,8 @@ MSHADOW_XINLINE CShape unravel(const int idx, const int ndim, const CShape& shap
   return ret;
 }
 
-MSHADOW_XINLINE int ravel(const int ndim, const CShape& coord, const CShape& shape) {
+template<int ndim>
+MSHADOW_XINLINE int ravel(const Shape<ndim>& coord, const Shape<ndim>& shape) {
   int ret = 0;
   for (int i = 0; i < ndim; ++i) {
     ret = ret * shape[i] + (shape[i] > 1) * coord[i];
@@ -40,10 +42,13 @@ MSHADOW_XINLINE int ravel(const int ndim, const CShape& coord, const CShape& sha
   return ret;
 }
 
-MSHADOW_XINLINE int diff(const int ndim, const CShape& small, const CShape& big, CShape &dims, CShape &stride) {
+template<int ndim>
+MSHADOW_XINLINE int diff(const Shape<ndim>& small, const Shape<ndim>& big, Shape<ndim> &dims, Shape<ndim> &stride) {
   int mdim = 0;
-  for (int i = 0; i < ndim; ++i)
+  for (int i = 0; i < ndim; ++i) {
     mdim += small[i] != big[i];
+    dims[i] = stride[i] = 1;
+  }
   for (int i = ndim-1, j = mdim, s = 1; i >= 0; --i) {
     if (small[i] != big[i]) {
       --j;
@@ -55,7 +60,8 @@ MSHADOW_XINLINE int diff(const int ndim, const CShape& small, const CShape& big,
   return mdim;
 }
 
-MSHADOW_XINLINE int dot(const int ndim, const CShape& coord, const CShape& stride) {
+template<int ndim>
+MSHADOW_XINLINE int dot(const Shape<ndim>& coord, const Shape<ndim>& stride) {
   int ret = 0;
   for (int i = 0; i < ndim; ++i) 
     ret += coord[i] * stride[i];
@@ -72,27 +78,27 @@ MSHADOW_XINLINE void assign(DType& dst, const bool addto, const DType src) {
 }
 
 template<typename DType, typename OP>
-MSHADOW_XINLINE void binary_broadcast_assign(const int idx, const int ndim, const bool addto,
+MSHADOW_XINLINE void binary_broadcast_assign(const int idx, const bool addto,
                                              const DType* lhs, const DType* rhs, DType* out,
                                              const CShape& lshape, const CShape& rshape,
                                              const CShape& oshape) {
-  const CShape coord = unravel(idx, ndim, oshape);
-  const int j = ravel(ndim, coord, lshape);
-  const int k = ravel(ndim, coord, rshape);
+  const CShape coord = unravel(idx, oshape);
+  const int j = ravel(coord, lshape);
+  const int k = ravel(coord, rshape);
   assign(out[idx], addto, OP::Map(lhs[j], rhs[k]));
 }
 
 template<typename Reducer, typename DType, typename OP>
-MSHADOW_XINLINE void seq_reduce_assign(const int idx, const int M, const int ndim, const int mdim, const bool addto,
+MSHADOW_XINLINE void seq_reduce_assign(const int idx, const int M, const bool addto,
                                        const DType *big, DType *small, const CShape& bshape, const CShape& sshape,
                                        const CShape& rshape, const CShape& rstride) {
-  CShape coord = unravel(idx, ndim, sshape);
-  int j = ravel(ndim, coord, bshape);
+  CShape coord = unravel(idx, sshape);
+  int j = ravel(coord, bshape);
   DType val;
   Reducer::SetInitValue(val);
   for (int k = 0; k < M; ++k) {
-    coord = unravel(k, mdim, rshape);
-    Reducer::Reduce(val, OP::Map(big[j + dot(mdim, coord, rstride)]));
+    coord = unravel(k, rshape);
+    Reducer::Reduce(val, OP::Map(big[j + dot(coord, rstride)]));
   }
   assign(small[idx], addto, val);
 }
@@ -103,16 +109,16 @@ template<typename DType>
 using CTensor = Tensor<gpu, MAX_DIM, DType>;
 
 template<typename DType, typename OP>
-__global__ void binary_broadcast_kernel(const int N, const int ndim, const bool addto, const DType *lhs,
+__global__ void binary_broadcast_kernel(const int N, const bool addto, const DType *lhs,
                                         const DType *rhs, DType *out, const CShape lshape,
                                         const CShape rshape, const CShape oshape) {
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < N; idx += blockDim.x * gridDim.x) {
-    binary_broadcast_assign<DType, OP>(idx, ndim, addto, lhs, rhs, out, lshape, rshape, oshape);
+    binary_broadcast_assign<DType, OP>(idx, addto, lhs, rhs, out, lshape, rshape, oshape);
   }
 }
 
 template<typename DType, typename OP>
-void BinaryBroadcastComputeImpl(Stream<gpu> *s, int ndim, const OpReqType req,
+void BinaryBroadcastComputeImpl(Stream<gpu> *s, const OpReqType req,
                                 const CTensor<DType>& lhs, const CTensor<DType>& rhs, CTensor<DType> out) {
   using namespace mshadow::cuda;
   if (req == kNullOp) return;
@@ -120,31 +126,31 @@ void BinaryBroadcastComputeImpl(Stream<gpu> *s, int ndim, const OpReqType req,
   int N = out.shape_.Size();
   int ngrid = std::min(kMaxGridNum, (N + kBaseThreadNum - 1) / kBaseThreadNum);
   binary_broadcast_kernel<DType, OP><<<ngrid, kBaseThreadNum, 0, stream>>>(
-    N, ndim, req == kAddTo, lhs.dptr_, rhs.dptr_, out.dptr_, lhs.shape_, rhs.shape_, out.shape_);
+    N, req == kAddTo, lhs.dptr_, rhs.dptr_, out.dptr_, lhs.shape_, rhs.shape_, out.shape_);
 }
 
 template<typename Reducer, typename DType, typename OP>
-__global__ void seq_reduce_kernel(const int N, const int M, const int ndim, const int mdim, const bool addto,
+__global__ void seq_reduce_kernel(const int N, const int M, const bool addto,
                                   const DType *big, DType *small, const CShape bshape, const CShape sshape,
                                   const CShape rshape, const CShape rstride) {
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < N; idx += blockDim.x * gridDim.x) {
-    seq_reduce_assign<Reducer, DType, OP>(idx, M, ndim, mdim, addto, big, small, bshape, sshape, rshape, rstride);
+    seq_reduce_assign<Reducer, DType, OP>(idx, M, addto, big, small, bshape, sshape, rshape, rstride);
   }
 }
 
 template<typename Reducer, typename DType, typename OP, int x_bits>
-__global__ void par_reduce_kernel(const int N, const int M, const int ndim, const int mdim, const bool addto,
+__global__ void par_reduce_kernel(const int N, const int M, const bool addto,
                                   const DType *big, DType *small, const CShape bshape, const CShape sshape,
                                   const CShape rshape, const CShape rstride) {
   __shared__ DType buf[1<<x_bits];
   for (int idx = blockIdx.x; idx < N; idx += gridDim.x) {
-    CShape coord = unravel(idx, ndim, sshape);
-    int j = ravel(ndim, coord, bshape);
+    CShape coord = unravel(idx, sshape);
+    int j = ravel(coord, bshape);
 
     Reducer::SetInitValue(buf[threadIdx.x]);
     for (int k = threadIdx.x; k < M; k += blockDim.x) {
-      coord = unravel(k, mdim, rshape);
-      Reducer::Reduce(buf[threadIdx.x], OP::Map(big[j + dot(mdim, coord, rstride)]));
+      coord = unravel(k, rshape);
+      Reducer::Reduce(buf[threadIdx.x], OP::Map(big[j + dot(coord, rstride)]));
     }
     __syncthreads();
     cuda::Reduce1D<Reducer, x_bits>(buf);
@@ -155,23 +161,23 @@ __global__ void par_reduce_kernel(const int N, const int M, const int ndim, cons
 }
 
 template<typename Reducer, typename DType, typename OP>
-void Reduce(Stream<gpu> *s, int ndim, CTensor<DType> small, const OpReqType req,
+void Reduce(Stream<gpu> *s, CTensor<DType> small, const OpReqType req,
             const CTensor<DType>& big) {
   using namespace mshadow::cuda;
   if (req == kNullOp) return;
   cudaStream_t stream = Stream<gpu>::GetStream(s);
   CShape rshape, rstride;
-  int mdim = diff(ndim, small.shape_, big.shape_, rshape, rstride);
+  int mdim = diff(small.shape_, big.shape_, rshape, rstride);
   int N = small.shape_.Size(), M = rshape.Size();
-  if (false) {
+  if (N > 32*kBaseThreadNum) {
     int ngrid = std::min(kMaxGridNum, (N + kBaseThreadNum - 1) / kBaseThreadNum);
     seq_reduce_kernel<Reducer, DType, OP><<<ngrid, kBaseThreadNum, 0, stream>>>(
-      N, M, ndim, mdim, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
+      N, M, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
       rshape, rstride);
   } else {
-    LOG(INFO) << N << " " << M;
-    par_reduce_kernel<Reducer, DType, OP, 10><<<N, 1024, 0, stream>>>(
-      N, M, ndim, mdim, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
+    int ngrid = std::min(kMaxGridNum, N);
+    par_reduce_kernel<Reducer, DType, OP, kBaseThreadBits><<<ngrid, kBaseThreadNum, 0, stream>>>(
+      N, M, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
       rshape, rstride);
   }
 }
@@ -182,41 +188,41 @@ template<typename DType>
 using CTensor = Tensor<cpu, MAX_DIM, DType>;
 
 template<typename DType, typename OP>
-void binary_broadcast_compute(const int N, const int ndim, const bool addto, const DType *lhs,
+void binary_broadcast_compute(const int N, const bool addto, const DType *lhs,
                               const DType *rhs, DType *out, const CShape lshape,
                               const CShape rshape, const CShape oshape) {
   for (int idx = 0; idx < N; ++idx) {
-    binary_broadcast_assign<DType, OP>(idx, ndim, addto, lhs, rhs, out, lshape, rshape, oshape);
+    binary_broadcast_assign<DType, OP>(idx, addto, lhs, rhs, out, lshape, rshape, oshape);
   }
 }
 
 template<typename DType, typename OP>
-void BinaryBroadcastComputeImpl(Stream<cpu> *s, int ndim, const OpReqType req,
+void BinaryBroadcastComputeImpl(Stream<cpu> *s, const OpReqType req,
                                 const CTensor<DType>& lhs, const CTensor<DType>& rhs, CTensor<DType> out) {
   if (req == kNullOp) return;
   int N = out.shape_.Size();
-  binary_broadcast_compute<DType, OP>(N, ndim, req == kAddTo, lhs.dptr_, rhs.dptr_,
+  binary_broadcast_compute<DType, OP>(N, req == kAddTo, lhs.dptr_, rhs.dptr_,
                            out.dptr_, lhs.shape_, rhs.shape_, out.shape_);
 }
 
 template<typename Reducer, typename DType, typename OP>
-void seq_reduce_compute(const int N, const int M, const int ndim, const int mdim, const bool addto,
+void seq_reduce_compute(const int N, const int M, const bool addto,
                         const DType *big, DType *small, const CShape bshape, const CShape sshape,
                         const CShape rshape, const CShape rstride) {
   for (int idx = 0; idx < N; ++idx) {
-    seq_reduce_assign<Reducer, DType, OP>(idx, M, ndim, mdim, addto, big, small, bshape, sshape, rshape, rstride);
+    seq_reduce_assign<Reducer, DType, OP>(idx, M, addto, big, small, bshape, sshape, rshape, rstride);
   }
 }
 
 template<typename Reducer, typename DType, typename OP>
-void Reduce(Stream<cpu> *s, int ndim, CTensor<DType> small, const OpReqType req,
+void Reduce(Stream<cpu> *s, CTensor<DType> small, const OpReqType req,
             const CTensor<DType>& big) {
   if (req == kNullOp) return;
   CShape rshape, rstride;
-  int mdim = diff(ndim, small.shape_, big.shape_, rshape, rstride);
+  int mdim = diff(small.shape_, big.shape_, rshape, rstride);
   int N = small.shape_.Size(), M = rshape.Size();
   seq_reduce_compute<Reducer, DType, OP>(
-    N, M, ndim, mdim, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
+    N, M, req == kAddTo, big.dptr_, small.dptr_, big.shape_, small.shape_,
     rshape, rstride);
 }
 

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -113,7 +113,7 @@ void BinaryBroadcastCompute(const nnvm::NodeAttrs& attrs,
       CTensor<DType> lhs = inputs[0].get_with_shape<xpu, MAX_DIM, DType>(new_lshape.get<MAX_DIM>());
       CTensor<DType> rhs = inputs[1].get_with_shape<xpu, MAX_DIM, DType>(new_rshape.get<MAX_DIM>());
       CTensor<DType> out = outputs[0].get_with_shape<xpu, MAX_DIM, DType>(new_oshape.get<MAX_DIM>());
-      BinaryBroadcastComputeImpl<DType, OP>(s, ndim, req[0], lhs, rhs, out);
+      BinaryBroadcastComputeImpl<DType, OP>(s, req[0], lhs, rhs, out);
     });
   }
 }
@@ -188,8 +188,8 @@ void BinaryBroadcastBackwardUseNone(const nnvm::NodeAttrs& attrs,
         outputs[0].get_with_shape<xpu, MAX_DIM, DType>(new_lshape.get<MAX_DIM>(), s);
       CTensor<DType> rgrad =
         outputs[1].get_with_shape<xpu, MAX_DIM, DType>(new_rshape.get<MAX_DIM>(), s);
-      Reduce<red::sum, DType, LOP>(s, ndim, lgrad, req[0], ograd);
-      Reduce<red::sum, DType, ROP>(s, ndim, rgrad, req[1], ograd);
+      Reduce<red::sum, DType, LOP>(s, lgrad, req[0], ograd);
+      Reduce<red::sum, DType, ROP>(s, rgrad, req[1], ograd);
     });
   }
 }

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -15,6 +15,7 @@
 #include "../elemwise_op_common.h"
 #include "./elemwise_binary_op.h"
 #include "../operator_common.h"
+#include "broadcast_reduce_kernel.h"
 
 namespace mxnet {
 namespace op {
@@ -52,11 +53,11 @@ inline bool BinaryBroadcastShape(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
-inline bool BinaryBroadcastShapeCompact(const TShape& lshape, const TShape& rshape,
-                                        const TShape& oshape, TShape *new_lshape,
-                                        TShape *new_rshape, TShape *new_oshape) {
-  if (lshape == rshape) return false;
-  index_t odim = std::max<index_t>(oshape.ndim(), MXNET_SPECIAL_MAX_NDIM);
+inline int BinaryBroadcastShapeCompact(const TShape& lshape, const TShape& rshape,
+                                       const TShape& oshape, TShape *new_lshape,
+                                       TShape *new_rshape, TShape *new_oshape) {
+  if (lshape == rshape) return 0;
+  index_t odim = std::max<index_t>(oshape.ndim(), broadcast::MAX_DIM);
   *new_lshape = TShape(odim);
   *new_rshape = TShape(odim);
   *new_oshape = TShape(odim);
@@ -84,101 +85,15 @@ inline bool BinaryBroadcastShapeCompact(const TShape& lshape, const TShape& rsha
     (*new_oshape)[j] = oprod;
     ++j;
   }
-  if (j <= 2) {
-    new_lshape->assign(&(*new_lshape)[0], &(*new_lshape)[2]);
-    new_rshape->assign(&(*new_rshape)[0], &(*new_rshape)[2]);
-    new_oshape->assign(&(*new_oshape)[0], &(*new_oshape)[2]);
-  } else if (j <= MXNET_SPECIAL_MAX_NDIM) {
-    new_lshape->assign(&(*new_lshape)[0], &(*new_lshape)[MXNET_SPECIAL_MAX_NDIM]);
-    new_rshape->assign(&(*new_rshape)[0], &(*new_rshape)[MXNET_SPECIAL_MAX_NDIM]);
-    new_oshape->assign(&(*new_oshape)[0], &(*new_oshape)[MXNET_SPECIAL_MAX_NDIM]);
+  if (j <= broadcast::MAX_DIM) {
+    new_lshape->assign(&(*new_lshape)[0], &(*new_lshape)[broadcast::MAX_DIM]);
+    new_rshape->assign(&(*new_rshape)[0], &(*new_rshape)[broadcast::MAX_DIM]);
+    new_oshape->assign(&(*new_oshape)[0], &(*new_oshape)[broadcast::MAX_DIM]);
   } else {
     LOG(FATAL) << "Too many broadcast dimensions with operands " << lshape << " " << rshape;
   }
-  return true;
+  return j;
 }
-
-#ifdef __CUDACC__
-
-template<int ndim, typename DType, typename OP, bool addto>
-__global__ void binary_broadcast_kernel(const int N, const DType *lhs,
-                                        const DType *rhs, DType *out,
-                                        const mshadow::Shape<ndim> lshape,
-                                        const mshadow::Shape<ndim> rshape,
-                                        const mshadow::Shape<ndim> oshape) {
-  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < N; idx += blockDim.x * gridDim.x) {
-    int i, j, k;
-    mshadow::Shape<ndim> coord;
-    for (i = ndim-1, j = idx; i >=0; --i) {
-      coord[i] = j % oshape[i];
-      j /= oshape[i];
-    }
-    for (i = 0, j = 0, k = 0; i < ndim; ++i) {
-      j = j * lshape[i] + (lshape[i] > 1) * coord[i];
-      k = k * rshape[i] + (rshape[i] > 1) * coord[i];
-    }
-    if (addto) {
-      out[idx] += OP::Map(lhs[j], rhs[k]);
-    } else {
-      out[idx] = OP::Map(lhs[j], rhs[k]);
-    }
-  }
-}
-
-
-template<typename xpu, int ndim, typename DType, typename OP>
-inline void BinaryBroadcastComputeImpl(const OpContext& ctx,
-                                              const std::vector<TBlob>& inputs,
-                                              const std::vector<OpReqType>& req,
-                                              const std::vector<TBlob>& outputs,
-                                              const TShape& new_lshape,
-                                              const TShape& new_rshape,
-                                              const TShape& new_oshape) {
-  using namespace mshadow;
-  using namespace mshadow::expr;
-  using namespace mshadow::cuda;
-  if (req[0] == kNullOp) return;
-  Stream<xpu> *s = ctx.get_stream<xpu>();
-  mshadow::Shape<ndim> oshape = new_oshape.get<ndim>();
-  mshadow::Shape<ndim> lshape = new_lshape.get<ndim>();
-  mshadow::Shape<ndim> rshape = new_rshape.get<ndim>();
-  Tensor<gpu, ndim, DType> out = outputs[0].get_with_shape<xpu, ndim, DType>(oshape, s);
-  Tensor<gpu, ndim, DType> lhs = inputs[0].get_with_shape<xpu, ndim, DType>(lshape, s);
-  Tensor<gpu, ndim, DType> rhs = inputs[1].get_with_shape<xpu, ndim, DType>(rshape, s);
-  cudaStream_t stream = Stream<xpu>::GetStream(s);
-  int N = oshape.Size();
-  int ngrid = std::min(kMaxGridNum, (N + kBaseThreadNum - 1) / kBaseThreadNum);
-  if (req[0] == kAddTo) {
-    binary_broadcast_kernel<ndim, DType, OP, true><<<ngrid, kBaseThreadNum, 0, stream>>>(
-      N, lhs.dptr_, rhs.dptr_, out.dptr_, lshape, rshape, oshape);
-  } else {
-    binary_broadcast_kernel<ndim, DType, OP, false><<<ngrid, kBaseThreadNum, 0, stream>>>(
-      N, lhs.dptr_, rhs.dptr_, out.dptr_, lshape, rshape, oshape);
-  }
-}
-
-#else
-
-template<typename xpu, int ndim, typename DType, typename OP>
-inline void BinaryBroadcastComputeImpl(const OpContext& ctx,
-                                              const std::vector<TBlob>& inputs,
-                                              const std::vector<OpReqType>& req,
-                                              const std::vector<TBlob>& outputs,
-                                              const TShape& new_lshape,
-                                              const TShape& new_rshape,
-                                              const TShape& new_oshape) {
-  using namespace mshadow;
-  using namespace mshadow::expr;
-  Stream<xpu> *s = ctx.get_stream<xpu>();
-  Tensor<xpu, ndim, DType> out =
-    outputs[0].get_with_shape<xpu, ndim, DType>(new_oshape.get<ndim>(), s);
-  Tensor<xpu, ndim, DType> lhs =
-    inputs[0].get_with_shape<xpu, ndim, DType>(new_lshape.get<ndim>(), s);
-  Tensor<xpu, ndim, DType> rhs =
-    inputs[1].get_with_shape<xpu, ndim, DType>(new_rshape.get<ndim>(), s);
-  ASSIGN_DISPATCH(out, req[0], F<OP>(broadcast_to(lhs, new_oshape), broadcast_to(rhs, new_oshape)));
-}
-#endif
 
 template<typename xpu, typename OP>
 void BinaryBroadcastCompute(const nnvm::NodeAttrs& attrs,
@@ -186,20 +101,19 @@ void BinaryBroadcastCompute(const nnvm::NodeAttrs& attrs,
                             const std::vector<TBlob>& inputs,
                             const std::vector<OpReqType>& req,
                             const std::vector<TBlob>& outputs) {
+  using namespace broadcast;
   TShape new_lshape, new_rshape, new_oshape;
-  bool need_bc = BinaryBroadcastShapeCompact(inputs[0].shape_, inputs[1].shape_, outputs[0].shape_,
-                                             &new_lshape, &new_rshape, &new_oshape);
-  if (!need_bc) {
+  int ndim = BinaryBroadcastShapeCompact(inputs[0].shape_, inputs[1].shape_, outputs[0].shape_,
+                                         &new_lshape, &new_rshape, &new_oshape);
+  if (!ndim) {
     BinaryCompute<xpu, OP>(attrs, ctx, inputs, req, outputs);
   } else {
+    mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
     MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
-      if (new_oshape.ndim() == 2) {
-        BinaryBroadcastComputeImpl<xpu, 2, DType, OP>(
-          ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
-      } else {
-        BinaryBroadcastComputeImpl<xpu, MXNET_SPECIAL_MAX_NDIM, DType, OP>(
-          ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
-      }
+      CTensor<DType> lhs = inputs[0].get_with_shape<xpu, MAX_DIM, DType>(new_lshape.get<MAX_DIM>());
+      CTensor<DType> rhs = inputs[1].get_with_shape<xpu, MAX_DIM, DType>(new_rshape.get<MAX_DIM>());
+      CTensor<DType> out = outputs[0].get_with_shape<xpu, MAX_DIM, DType>(new_oshape.get<MAX_DIM>());
+      BinaryBroadcastComputeImpl<DType, OP>(s, ndim, req[0], lhs, rhs, out);
     });
   }
 }
@@ -252,47 +166,30 @@ void ReduceToAssign(mshadow::Tensor<xpu, 2, DType> out, const OpReqType req, con
   }
 }
 
-template<typename xpu, int ndim, typename DType, typename LOP, typename ROP>
-inline void BinaryBroadcastBackwardUseNoneImpl(const OpContext& ctx,
-                                               const std::vector<TBlob>& inputs,
-                                               const std::vector<OpReqType>& req,
-                                               const std::vector<TBlob>& outputs,
-                                               const TShape& new_lshape,
-                                               const TShape& new_rshape,
-                                               const TShape& new_oshape) {
-  using namespace mshadow;
-  using namespace mshadow::expr;
-  Stream<xpu> *s = ctx.get_stream<xpu>();
-  Tensor<xpu, ndim, DType> ograd =
-    inputs[0].get_with_shape<xpu, ndim, DType>(new_oshape.get<ndim>(), s);
-  Tensor<xpu, ndim, DType> lgrad =
-    outputs[0].get_with_shape<xpu, ndim, DType>(new_lshape.get<ndim>(), s);
-  Tensor<xpu, ndim, DType> rgrad =
-    outputs[1].get_with_shape<xpu, ndim, DType>(new_rshape.get<ndim>(), s);
-  ReduceToAssign<red::sum>(lgrad, req[0], F<LOP>(ograd));
-  ReduceToAssign<red::sum>(rgrad, req[1], F<ROP>(ograd));
-}
-
 template<typename xpu, typename LOP, typename ROP>
 void BinaryBroadcastBackwardUseNone(const nnvm::NodeAttrs& attrs,
                                     const OpContext& ctx,
                                     const std::vector<TBlob>& inputs,
                                     const std::vector<OpReqType>& req,
                                     const std::vector<TBlob>& outputs) {
+  LOG(INFO) << attrs.name;
+  using namespace broadcast;
   TShape new_lshape, new_rshape, new_oshape;
-  bool need_bc = BinaryBroadcastShapeCompact(outputs[0].shape_, outputs[1].shape_, inputs[0].shape_,
+  int ndim = BinaryBroadcastShapeCompact(outputs[0].shape_, outputs[1].shape_, inputs[0].shape_,
                                              &new_lshape, &new_rshape, &new_oshape);
-  if (!need_bc) {
+  if (!ndim) {
     BinaryBackwardUseNone<xpu, LOP, ROP>(attrs, ctx, inputs, req, outputs);
   } else {
     MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
-      if (new_oshape.ndim() == 2) {
-        BinaryBroadcastBackwardUseNoneImpl<xpu, 2, DType, LOP, ROP>(
-          ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
-      } else {
-        BinaryBroadcastBackwardUseNoneImpl<xpu, MXNET_SPECIAL_MAX_NDIM, DType, LOP, ROP>(
-          ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
-      }
+      Stream<xpu> *s = ctx.get_stream<xpu>();
+      CTensor<DType> ograd =
+        inputs[0].get_with_shape<xpu, MAX_DIM, DType>(new_oshape.get<MAX_DIM>(), s);
+      CTensor<DType> lgrad =
+        outputs[0].get_with_shape<xpu, MAX_DIM, DType>(new_lshape.get<MAX_DIM>(), s);
+      CTensor<DType> rgrad =
+        outputs[1].get_with_shape<xpu, MAX_DIM, DType>(new_rshape.get<MAX_DIM>(), s);
+      Reduce<red::sum, DType, LOP>(s, ndim, lgrad, req[0], ograd);
+      Reduce<red::sum, DType, ROP>(s, ndim, rgrad, req[1], ograd);
     });
   }
 }
@@ -341,7 +238,7 @@ void BinaryBroadcastBackwardUseIn(const nnvm::NodeAttrs& attrs,
         BinaryBroadcastBackwardUseInImpl<xpu, 2, DType, LOP, ROP>(
           ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
       } else {
-        BinaryBroadcastBackwardUseInImpl<xpu, MXNET_SPECIAL_MAX_NDIM, DType, LOP, ROP>(
+        BinaryBroadcastBackwardUseInImpl<xpu, broadcast::MAX_DIM, DType, LOP, ROP>(
           ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
       }
     });
@@ -388,7 +285,7 @@ void BinaryBroadcastBackwardUseOut(const nnvm::NodeAttrs& attrs,
         BinaryBroadcastBackwardUseOutImpl<xpu, 2, DType, LOP, ROP>(
           ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
       } else {
-        BinaryBroadcastBackwardUseOutImpl<xpu, MXNET_SPECIAL_MAX_NDIM, DType, LOP, ROP>(
+        BinaryBroadcastBackwardUseOutImpl<xpu, broadcast::MAX_DIM, DType, LOP, ROP>(
           ctx, inputs, req, outputs, new_lshape, new_rshape, new_oshape);
       }
     });


### PR DESCRIPTION
Current broadcast and reduce ops are not efficient and takes a long time to compile. This is an attempt to fix it by using kernels instead of mshadow ops.

I'm having trouble optimizing the kernels. Help from someone with more expertise in cuda will be appriciated.

@ptredak