### PR TITLE
add profiler to R Interface

### DIFF
--- a/R-package/R/profiler.R
+++ b/R-package/R/profiler.R
@@ -1,0 +1,27 @@
+# profiler setting methods
+# 
+
+#' @export
+MX.PROF.MODE <- list(SYMBOLIC = 0L, ALL = 1L)
+#' @export
+MX.PROF.STATE <- list(STOP = 0L, RUN = 1L)
+
+#' Set up the configuration of profiler.
+#'
+#' @param mode Indicting whether to enable the profiler, can be 'MX.PROF.MODE$SYMBOLIC' or 'MX.PROF.MODE$ALL'. Default is `MX.PROF.MODE$SYMBOLIC`.
+#' @param filename The name of output trace file. Default is 'profile.json'
+#'
+#' @export
+mx.profiler.config <- function(mode = MX.PROF.MODE$SYMBOLIC, filename='profile.json') {
+	mx.internal.profiler.config(mode, filename)
+}
+
+#' Set up the profiler state to record operator.
+#'
+#' @param state  Indicting whether to run the profiler, can be 'MX.PROF.STATE$RUN' or 'MX.PROF.STATE$STOP'. Default is `MX.PROF.STATE$STOP`.
+#' @param filename The name of output trace file. Default is 'profile.json'
+#'
+#' @export
+mx.profiler.state <- function(state = MX.PROF.STATE$STOP) {
+	mx.internal.profiler.state(state)
+}

--- a/R-package/src/mxnet.cc
+++ b/R-package/src/mxnet.cc
@@ -23,11 +23,21 @@ void NotifyShutdown(int seed) {
   MX_CALL(MXNotifyShutdown());
 }
 
+void ProfilerSetConfig(int mode, const std::string &filename) {
+  MX_CALL(MXSetProfilerConfig(mode, filename.c_str()));
+}
+
+void ProfilerSetState(int state) {
+  MX_CALL(MXSetProfilerState(state));
+}
+
 // init rcpp module in base
 void InitRcppModule() {
   using namespace Rcpp;  // NOLINT(*)
   function("mx.internal.set.seed", &SetSeed);
   function("mx.internal.notify.shudown", &NotifyShutdown);
+  function("mx.internal.profiler.config", &ProfilerSetConfig);
+  function("mx.internal.profiler.state", &ProfilerSetState);
 }
 }  // namespace R
 }  // namespace mxnet


### PR DESCRIPTION
This PR adds profiling support to `R` Interface (along the Python lines).

Example:

```R
# set-up and start profiler
mx.profiler.config(mode = MX.PROF.MODE$SYMBOLIC, filename = 'profile.json')
mx.profiler.state(state = MX.PROF.STATE$RUN)

# do calculations
#...

# stop profiler
mx.profiler.state(state = MX.PROF.STATE$STOP)
```