### PR TITLE
[RFC] Operator priority based on pushed order

### DIFF
--- a/include/mxnet/engine.h
+++ b/include/mxnet/engine.h
@@ -84,6 +84,8 @@ class MXNET_API Engine {
   typedef engine::VarHandle VarHandle;
   /*! \brief Operator pointer */
   typedef engine::OprHandle OprHandle;
+  /*! \brief Value for not specified priority. */
+  static constexpr int kNoPriority = 0;
   /*!
    * \brief Notify the engine about a shutdown,
    *  This can help engine to print less messages into display.
@@ -130,7 +132,7 @@ class MXNET_API Engine {
    * \param priority Priority of the action, as hint to the engine.
    * \param profiling The variable indicate whether to profile this operator.
    */
-  virtual void Push(OprHandle op, Context exec_ctx, int priority = 0, bool profiling = false) = 0;
+  virtual void Push(OprHandle op, Context exec_ctx, int priority = kNoPriority, bool profiling = false) = 0;
   /*!
    * \brief Push an asynchronous operation to the engine.
    * \param exec_fun Execution function, this function takes a parameter
@@ -148,7 +150,7 @@ class MXNET_API Engine {
                          std::vector<VarHandle> const& const_vars,
                          std::vector<VarHandle> const& mutable_vars,
                          FnProperty prop = FnProperty::kNormal,
-                         int priority = 0,
+                         int priority = kNoPriority,
                          const char* opr_name = nullptr) = 0;
   /*!
    * \brief Schedule the deletion of a variable.
@@ -205,7 +207,7 @@ class MXNET_API Engine {
                        std::vector<VarHandle> const& const_vars,
                        std::vector<VarHandle> const& mutable_vars,
                        FnProperty prop = FnProperty::kNormal,
-                       int priority = 0,
+                       int priority = kNoPriority,
                        const char* opr_name = nullptr) {
     this->PushAsync([exec_fn](RunContext ctx, CallbackOnComplete on_complete) {
         exec_fn(ctx);

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -195,9 +195,10 @@ int MXImperativeInvoke(AtomicSymbolCreator creator,
     } else if (ctx.dev_mask() == gpu::kDevMask && fgpu.count(op)) {
       fn = fgpu[op];
     }
+    const auto& opname = op->name;
     if (fn) {
       Engine::Get()->PushAsync(
-        [ctx, attrs, fn, ndinputs, ndoutputs, requested](
+        [ctx, attrs, fn, ndinputs, ndoutputs, requested, opname](
             RunContext rctx,
             engine::CallbackOnComplete on_complete) {
           std::vector<TBlob> input_blobs, output_blobs;
@@ -212,6 +213,7 @@ int MXImperativeInvoke(AtomicSymbolCreator creator,
                           engine::CallbackOnComplete(),
                           requested};
           std::vector<OpReqType> req(output_blobs.size(), kWriteTo);
+          std::cout << ">>>" << opname << std::endl;
           fn(attrs, opctx, input_blobs, req, output_blobs);
           if (ctx.dev_mask() == gpu::kDevMask) {
             rctx.get_stream<gpu>()->Wait();

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -213,7 +213,6 @@ int MXImperativeInvoke(AtomicSymbolCreator creator,
                           engine::CallbackOnComplete(),
                           requested};
           std::vector<OpReqType> req(output_blobs.size(), kWriteTo);
-          std::cout << ">>>" << opname << std::endl;
           fn(attrs, opctx, input_blobs, req, output_blobs);
           if (ctx.dev_mask() == gpu::kDevMask) {
             rctx.get_stream<gpu>()->Wait();

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -59,7 +59,10 @@ class NaiveEngine final : public Engine {
     NaiveOpr *opr = op->Cast<NaiveOpr>();
     delete opr;
   }
-  void Push(OprHandle op, Context exec_ctx, int priority = 0, bool profiling = false) override {
+  void Push(OprHandle op,
+            Context exec_ctx,
+            int priority = Engine::kNoPriority,
+            bool profiling = false) override {
     NaiveOpr *opr = op->Cast<NaiveOpr>();
     this->PushAsync(opr->fn,
                     exec_ctx,
@@ -74,7 +77,7 @@ class NaiveEngine final : public Engine {
                  std::vector<VarHandle> const& const_vars,
                  std::vector<VarHandle> const& mutable_vars,
                  FnProperty prop = FnProperty::kNormal,
-                 int priority = 0,
+                 int priority = Engine::kNoPriority,
                  const char* opr_name = nullptr) override {
     CallbackOnComplete callback = CreateCallback(
         NaiveEngine::OnComplete, nullptr);

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -325,6 +325,7 @@ class ThreadedEngine : public Engine {
         if (debug_info) {
           LOG(INFO) << "ExecuteOprFn ";
         }
+        LOG(INFO) << "Run: " << opr_block;
         threaded_opr->fn(run_ctx, callback);
         if (debug_info) {
           LOG(INFO) << "Fin ExecuteOprFn ";

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -166,13 +166,16 @@ class ThreadedVar final : public Var,
   int num_pending_reads_{0};
   /*!
    * \brief Points to the last VersionedVarBlock in the queue.
-   *  head_ always points to a empty VersionedVarBlock.
+   *  head_ always points to an empty VersionedVarBlock.
    *  So when we want to append an operation to the queue:
    *    1) update head_->trigger to be new op
    *    2) update head_->next to be a new VersionedVarBlock
    *    3) move head to head->next.
    */
   VersionedVarBlock* head_{nullptr};
+
+  bool is_last_write_{false};
+  int latest_priority_{0};
   /*!
    * \brief The pointer to next write to perform.
    *  This pointer will only be updated when the write completes.
@@ -237,24 +240,42 @@ struct ThreadedOpr final : public Opr,
  */
 class ThreadedEngine : public Engine {
  public:
+  /*!\brief Priority range (1 ~ kWorkerPriority) for worker thread. */
+  static constexpr int kWorkerPriority = 100000;
+
   // implementing all the functions from Engine.
   ThreadedVar* NewVariable() override;
+
   ThreadedOpr* NewOperator(AsyncFn fn,
                            std::vector<VarHandle> const& const_vars,
                            std::vector<VarHandle> const& mutable_vars,
                            FnProperty prop = FnProperty::kNormal,
                            const char* opr_name = nullptr) override;
+
   void DeleteOperator(OprHandle op) override;
-  void Push(OprHandle op, Context exec_ctx, int priority = 0, bool profiling = false) override;
+
+  // Push an operator to the engine. If priority is not specified, the operator
+  // will be assigned a decreasing priority based on their push order. This makes
+  // earlier operator pushed higher priority, so the engine will try follow
+  // the programming order if all operators pushed could be executed in parallel.
+  void Push(OprHandle op,
+            Context exec_ctx,
+            int priority = Engine::kNoPriority,
+            bool profiling = false) override;
+
   void PushAsync(AsyncFn exec_fun, Context exec_ctx,
                  std::vector<VarHandle> const& const_vars,
                  std::vector<VarHandle> const& mutable_vars,
                  FnProperty prop = FnProperty::kNormal,
-                 int priority = 0,
+                 int priority = Engine::kNoPriority,
                  const char* opr_name = nullptr) override;
+
   void DeleteVariable(SyncFn delete_fn, Context exec_ctx, VarHandle var) override;
+
   void WaitForVar(VarHandle var) override;
+
   void WaitForAll() override;
+
   void NotifyShutdown() override {
     shutdown_phase_.store(true);
   }
@@ -325,7 +346,6 @@ class ThreadedEngine : public Engine {
         if (debug_info) {
           LOG(INFO) << "ExecuteOprFn ";
         }
-        LOG(INFO) << "Run: " << opr_block;
         threaded_opr->fn(run_ctx, callback);
         if (debug_info) {
           LOG(INFO) << "Fin ExecuteOprFn ";
@@ -395,6 +415,11 @@ class ThreadedEngine : public Engine {
   std::shared_ptr<common::ObjectPool<OprBlock> >          objpool_blk_ref_;
   std::shared_ptr<common::ObjectPool<VersionedVarBlock> > objpool_varblk_ref_;
   std::shared_ptr<common::ObjectPool<ThreadedVar> >       objpool_var_ref_;
+
+  /*! \brief Priority counter used to assign to pushed operators. */
+  std::mutex priority_m_;
+  int priority_counter_{ThreadedEngine::kWorkerPriority};
+
   /*!
    * \brief Disallow copy construction and assignment.
    */

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -26,10 +26,11 @@ namespace engine {
 class ThreadedEnginePerDevice : public ThreadedEngine {
  public:
   static auto constexpr kFIFO = dmlc::ConcurrentQueueType::kFIFO;
+  static auto constexpr kFILO = dmlc::ConcurrentQueueType::kFILO;
   static auto constexpr kPriority = dmlc::ConcurrentQueueType::kPriority;
   static auto constexpr kCopyQueue = kPriority;
   static auto constexpr kPriorityQueue = kPriority;
-  static auto constexpr kWorkerQueue = kFIFO;
+  static auto constexpr kWorkerQueue = kFILO;
 
   ThreadedEnginePerDevice() noexcept(false) {
     gpu_worker_nthreads_ = common::GetNumThreadPerGPU();
@@ -79,6 +80,8 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
             })->task_queue.Push(opr_block, opr_block->priority);
         }
       } else {
+
+        LOG(INFO) << "Push: " << opr_block;
         CHECK_EQ(ctx.dev_mask(), gpu::kDevMask);
         // GPU execution.
         FnProperty prop = opr_block->opr->prop;
@@ -159,6 +162,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     OprBlock* opr_block;
     auto* task_queue = &(block->task_queue);
     while (task_queue->Pop(&opr_block)) {
+      LOG(INFO) << "Pop: " << opr_block;
       this->ExecuteOprBlock(run_ctx, opr_block);
     }
     // Catch exception for CUDA driver shutdown

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -26,11 +26,10 @@ namespace engine {
 class ThreadedEnginePerDevice : public ThreadedEngine {
  public:
   static auto constexpr kFIFO = dmlc::ConcurrentQueueType::kFIFO;
-  static auto constexpr kFILO = dmlc::ConcurrentQueueType::kFILO;
   static auto constexpr kPriority = dmlc::ConcurrentQueueType::kPriority;
   static auto constexpr kCopyQueue = kPriority;
   static auto constexpr kPriorityQueue = kPriority;
-  static auto constexpr kWorkerQueue = kFILO;
+  static auto constexpr kWorkerQueue = kPriority;
 
   ThreadedEnginePerDevice() noexcept(false) {
     gpu_worker_nthreads_ = common::GetNumThreadPerGPU();
@@ -80,8 +79,6 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
             })->task_queue.Push(opr_block, opr_block->priority);
         }
       } else {
-
-        LOG(INFO) << "Push: " << opr_block;
         CHECK_EQ(ctx.dev_mask(), gpu::kDevMask);
         // GPU execution.
         FnProperty prop = opr_block->opr->prop;
@@ -162,7 +159,6 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     OprBlock* opr_block;
     auto* task_queue = &(block->task_queue);
     while (task_queue->Pop(&opr_block)) {
-      LOG(INFO) << "Pop: " << opr_block;
       this->ExecuteOprBlock(run_ctx, opr_block);
     }
     // Catch exception for CUDA driver shutdown


### PR DESCRIPTION
***DO NOT MERGE***

@piiswrong @tqchen @mli 

This branch is for engine refactor. Here is the change needed to fix the memory consumption problem mentioned in #4294 . This is the current solution (though not ideal). More details and thinkings on this problem are in the document I sent to you.

Basic idea:
* Assign a decreasing priority to operators based on their pushed order.
* In such way, if pushed operators could be paralleled, their execution order will be close to the sequential order as much as possible.

For following example:
```python
x = mx.nd.zeros((128, 4096), ctx=mx.gpu(0))
dy = mx.nd.zeros((128, 4096), ctx=mx.gpu(0))
dw = mx.nd.zeros((4096, 4096), ctx=mx.gpu(0))

for i in range(10000):
   dw += mx.nd.dot(x.T, dy)

dw.wait_to_read()
```

Previous engine will raise OOM error. This change will use <500 MB memory.

I want to let MinPy use this version of MXNet in the future to make everything more stable. Please have a look.

Thanks.