### PR TITLE
bug in scala package: scalar times symbol

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
@@ -1089,7 +1089,7 @@ class SymbolConversions[@specialized(Int, Float, Double) V](val value: V) {
   }
 
   def *(other: Symbol): Symbol = {
-    other + value
+    other * value
   }
 
   def /(other: Symbol): Symbol = {


### PR DESCRIPTION
A bug found in Symbol.scala.