### PR TITLE
Fix JQuery version

### DIFF
--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -56,7 +56,7 @@
       };
     </script>
 
-    {% for name in ['jquery.js', 'underscore.js', 'doctools.js', 'searchtools.js', 'selectlang.js'] %}
+    {% for name in ['jquery-1.11.1.js', 'underscore.js', 'doctools.js', 'searchtools.js', 'selectlang.js'] %}
     <script type="text/javascript" src="{{ pathto('_static/' + name, 1) }}"></script>
     {% endfor %}
 


### PR DESCRIPTION
Sphinx 1.5.1 will update JQuery to 3.1.0, while Bootstrap requires JQuery 1.9.1 to 3.0.0. 
I fixed this issue by using JQuery version 1.11.1, which is the version for current website.