### PR TITLE
Revise .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ cmake_install.cmake
 dmlc-core
 ps-lite
 nnvm
+!src/nnvm
 lib
 
 # Visual Studio Code


### PR DESCRIPTION
I find that the current .gitignore will also ignore the `src/nnvm`. This should fix the problem.