### PR TITLE
fix image_file in example/ssd

### DIFF
--- a/example/ssd/dataset/pascal_voc.py
+++ b/example/ssd/dataset/pascal_voc.py
@@ -130,7 +130,7 @@ class PascalVoc(Imdb):
         full path of annotation file
         """
         label_file = os.path.join(self.data_path, 'Annotations', index + '.xml')
-        assert os.path.exists(label_file), 'Path does not exist: {}'.format(image_file)
+        assert os.path.exists(label_file), 'Path does not exist: {}'.format(label_file)
         return label_file
 
     def _load_image_labels(self):


### PR DESCRIPTION
It seems that in example/sdd https://github.com/dmlc/mxnet/blob/master/example/ssd/dataset/pascal_voc.py#L133, the var `image_file` should be `label_file`. It may be a typo error.