### PR TITLE
Fix operator arguments

### DIFF
--- a/include/mxnet/tensor_blob.h
+++ b/include/mxnet/tensor_blob.h
@@ -283,6 +283,7 @@ class TBlob {
 namespace dmlc {
 // Add a few patches to support TShape in dmlc/parameter.
 DMLC_DECLARE_TYPE_NAME(mxnet::TShape, "Shape(tuple)");
+DMLC_DECLARE_TYPE_NAME(nnvm::Tuple<int>, "Shape(tuple)");
 
 namespace parameter {
 

--- a/src/operator/activation.cc
+++ b/src/operator/activation.cc
@@ -77,6 +77,7 @@ scalar of the input tensor):
 
 See `LeakyReLU` for other activations with parameters.
 )")
+.add_argument("data", "Symbol", "Input data to activation function.")
 .add_arguments(ActivationParam::__FIELDS__());
 
 }  // namespace op


### PR DESCRIPTION
1. argument "data" for `Activation` is missing
2. ~Old operators use `Symbol` but new operators change to `NDArray`~
3. `nnvm::Tuple<int>` lacks a type name
4. ~Pad use an argument typed with `double`, I'm not sure if it's intended.~