### PR TITLE
[WIP][Scala] Module API Support

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Context.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Context.scala
@@ -76,4 +76,8 @@ class Context(deviceTypeName: String, val deviceId: Int = 0) extends Serializabl
       false
     }
   }
+
+  override def hashCode: Int = {
+    toString.hashCode
+  }
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Context.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Context.scala
@@ -67,4 +67,13 @@ class Context(deviceTypeName: String, val deviceId: Int = 0) extends Serializabl
   override def toString: String = {
     s"$deviceType($deviceId)"
   }
+
+  override def equals(other: Any): Boolean = {
+    if (other != null && other.isInstanceOf[Context]) {
+      val otherInst = other.asInstanceOf[Context]
+      otherInst.deviceId == deviceId && otherInst.deviceTypeid == deviceTypeid
+    } else {
+      false
+    }
+  }
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
@@ -235,3 +235,16 @@ class DataDesc(val name: String,  val shape: Shape,
     s"DataDesc[$name,$shape,$dtype,$layout]"
   }
 }
+object DataDesc {
+  /**
+   * Get the dimension that corresponds to the batch size.
+   * @param layout layout string. For example, "NCHW".
+   * @return An axis indicating the batch_size dimension. When data-parallelism is used,
+   *         the data will be automatically split and concatenate along the batch_size dimension.
+   *         Axis can be -1, which means the whole array will be copied
+   *         for each data-parallelism device.
+   */
+  def getBatchAxis(layout: Option[String]): Int = {
+    layout.map(_.indexOf('N')).getOrElse(0)
+  }
+}

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
@@ -18,6 +18,7 @@
 package ml.dmlc.mxnet
 
 import ml.dmlc.mxnet.Base._
+import ml.dmlc.mxnet.DType.DType
 import ml.dmlc.mxnet.io.{MXDataPack, MXDataIter}
 import org.slf4j.LoggerFactory
 
@@ -227,4 +228,10 @@ abstract class DataPack() extends Iterable[DataBatch] {
   def iterator: DataIter
 }
 
-
+// Named data desc description contains name, shape, type and other extended attributes.
+class DataDesc(val name: String,  val shape: Shape,
+               val dtype: DType = Base.MX_REAL_TYPE, val layout: String = "NCHW") {
+  override def toString(): String = {
+    s"DataDesc[$name,$shape,$dtype,$layout]"
+  }
+}

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
@@ -247,4 +247,8 @@ object DataDesc {
   def getBatchAxis(layout: Option[String]): Int = {
     layout.map(_.indexOf('N')).getOrElse(0)
   }
+
+  implicit def ListMap2Descs(shapes: ListMap[String, Shape]): IndexedSeq[DataDesc] = {
+    shapes.map { case (k, s) => new DataDesc(k, s) }.toIndexedSeq
+  }
 }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
@@ -235,6 +235,7 @@ case class DataDesc(name: String, shape: Shape,
     s"DataDesc[$name,$shape,$dtype,$layout]"
   }
 }
+
 object DataDesc {
   /**
    * Get the dimension that corresponds to the batch size.

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/IO.scala
@@ -229,8 +229,8 @@ abstract class DataPack() extends Iterable[DataBatch] {
 }
 
 // Named data desc description contains name, shape, type and other extended attributes.
-class DataDesc(val name: String,  val shape: Shape,
-               val dtype: DType = Base.MX_REAL_TYPE, val layout: String = "NCHW") {
+case class DataDesc(name: String, shape: Shape,
+                    dtype: DType = Base.MX_REAL_TYPE, layout: String = "NCHW") {
   override def toString(): String = {
     s"DataDesc[$name,$shape,$dtype,$layout]"
   }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Model.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Model.scala
@@ -156,11 +156,11 @@ object Model {
   }
 
   // Initialize kvstore
-  private def initializeKVStore(kvStore: KVStore,
-                                paramArrays: IndexedSeq[Array[NDArray]],
-                                argParams: Map[String, NDArray],
-                                paramNames: IndexedSeq[String],
-                                updateOnKVStore: Boolean): Unit = {
+  private[mxnet] def initializeKVStore(kvStore: KVStore,
+                                       paramArrays: IndexedSeq[Array[NDArray]],
+                                       argParams: Map[String, NDArray],
+                                       paramNames: IndexedSeq[String],
+                                       updateOnKVStore: Boolean): Unit = {
     require(paramArrays.length == paramNames.length)
     for (idx <- 0 until paramArrays.length) {
       val paramOnDevs = paramArrays(idx)
@@ -172,9 +172,9 @@ object Model {
   }
 
   // Perform update of param_arrays from grad_arrays on kvstore
-  private def updateParamsOnKVStore(paramArrays: IndexedSeq[Array[NDArray]],
-                                    gradArrays: IndexedSeq[Array[NDArray]],
-                                    kvStore: Option[KVStore]): Unit = {
+  private[mxnet] def updateParamsOnKVStore(paramArrays: IndexedSeq[Array[NDArray]],
+                                           gradArrays: IndexedSeq[Array[NDArray]],
+                                           kvStore: Option[KVStore]): Unit = {
     (paramArrays zip gradArrays).zipWithIndex.foreach { case ((argList, gradList), index) =>
       if (gradList != null) {
         // push gradient, priority is negative index
@@ -186,11 +186,11 @@ object Model {
   }
 
   // Perform update of param_arrays from grad_arrays not on kvstore
-  private def updateParams(paramArrays: IndexedSeq[Array[NDArray]],
-                           gradArrays: IndexedSeq[Array[NDArray]],
-                           updater: MXKVStoreUpdater,
-                           numDevice: Int,
-                           kvStore: Option[KVStore] = None) {
+  private[mxnet] def updateParams(paramArrays: IndexedSeq[Array[NDArray]],
+                                  gradArrays: IndexedSeq[Array[NDArray]],
+                                  updater: MXKVStoreUpdater,
+                                  numDevice: Int,
+                                  kvStore: Option[KVStore] = None) {
     (paramArrays zip gradArrays).zipWithIndex.foreach { case ((argList, gradList), index) =>
       if (gradList != null) {
         kvStore.foreach(kv => {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
@@ -815,6 +815,16 @@ class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
   // Get size of current NDArray.
   def size: Int = shape.product
 
+  /**
+   * Return an `NDArray` that lives in the target context. If the array
+   * is already in that context, `self` is returned. Otherwise, a copy is made.
+   * @param context The target context we want the return value to live in.
+   * @return A copy or `self` as an `NDArray` that lives in the target context.
+   */
+  def asInContext(context: Context): NDArray = {
+    if (this.context == context) this else this.copyTo(context)
+  }
+
   override def equals(o: Any): Boolean = o match {
     case that: NDArray =>
       that != null && that.shape == this.shape && that.toArray.sameElements(this.toArray)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
@@ -305,29 +305,54 @@ object NDArray {
   }
 
   /**
-   * Join a sequence of arrays at the first dimension
-   * TODO: shall we make it native?
-   * @param arrays
+   * Concatenate a list of NDArrays along the specified dimension.
+   * @param arrays Arrays to be concatenate.
+   *               They must have identical shape except the first dimension.
+   *               They also must have the same data type.
+   * @param axis The axis along which to concatenate.
+   * @param alwaysCopy Default `True`. When not `True`,
+   *                   if the arrays only contain one `NDArray`,
+   *                   that element will be returned directly, avoid copying.
+   * @return An `NDArray` that lives on the same context as `arrays[0].context`.
    */
-  def concatenate(arrays: Seq[NDArray], ctx: Context = null): NDArray = {
-    require(arrays != null && arrays.size > 0, "arrays empty")
-    val array0 = arrays.head
-    val shape = array0.shape.drop(1)
-    var axis0 = array0.shape(0)
-    arrays.drop(1).foreach { array =>
-      require(shape == array.shape.drop(1),
-        s"shape mismatch between ${array.shape} and $shape")
-      axis0 += array.shape(0)
-    }
+  def concatenate(arrays: Seq[NDArray], axis: Int = 0, alwaysCopy: Boolean = true): NDArray = {
+    require(arrays.size > 0)
 
-    val output = NDArray.empty(Shape(axis0) ++ shape, ctx)
-    axis0 = 0
-    arrays.foreach { array =>
-      output.slice(axis0, axis0 + array.shape(0)).set(array)
-      axis0 += array.shape(0)
-    }
+    val array0 = arrays(0)
+    if (!alwaysCopy && arrays.size == 1) {
+      array0
+    } else {
+      val shapeRest1 = array0.shape.slice(0, axis)
+      val shapeRest2 = array0.shape.slice(axis + 1, array0.shape.length)
+      val dtype = array0.dtype
 
-    output
+      val shapeAxis =
+        arrays.map(arr => {
+          require(shapeRest1 == arr.shape.slice(0, axis))
+          require(shapeRest2 == arr.shape.slice(axis + 1, arr.shape.length))
+          require(dtype == arr.dtype)
+          arr.shape(axis)
+        }).sum
+      val retShape = shapeRest1 ++ Shape(shapeAxis) ++ shapeRest2
+      val ret = NDArray.empty(retShape, ctx = array0.context, dtype = dtype)
+
+      var idx = 0
+      val begin = Array.fill(retShape.length)(0)
+      val end = retShape.toArray
+      for (arr <- arrays) {
+        if (axis == 0) {
+          ret.slice(idx, idx + arr.shape(0)).set(arr)
+        } else {
+          begin(axis) = idx
+          end(axis) = idx + arr.shape(axis)
+          NDArray._crop_assign(Map("out" -> ret,
+            "begin" -> s"(${begin.mkString(",")})",
+            "end" -> s"(${end.mkString(",")})"))(ret, arr)
+          idx += arr.shape(axis)
+        }
+      }
+      ret
+    }
   }
 
   def concatenate(arrays: NDArray *): NDArray = {
@@ -475,10 +500,7 @@ class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
         if (excepts.contains(addr)) {
           true
         } else {
-          weak.get match {
-            case Some(arr) => arr.dispose()
-            case None =>
-          }
+          weak.get.foreach(_.dispose())
           false
         }
       }
@@ -785,20 +807,6 @@ class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
    * @return the copied NDArray in the same context
    */
   def copy(): NDArray = copyTo(this.context)
-
-  /**
-   * Return an `NDArray` that lives in the target context. If the array
-   * is already in that context, the same object is returned. Otherwise, a copy is made.
-   * @param context The target context we want the return value to live in.
-   * @return A copy or `self` as an `NDArray` that lives in the target context.
-   */
-  def asInContext(context: Context): NDArray = {
-    if (this.context == context) {
-      this
-    } else {
-      this.copyTo(context)
-    }
-  }
 
   /**
    * Get shape of current NDArray.

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
@@ -346,10 +346,10 @@ object NDArray {
           begin(axis) = idx
           end(axis) = idx + arr.shape(axis)
           NDArray._crop_assign(Map("out" -> ret,
-            "begin" -> s"(${begin.mkString(",")})",
-            "end" -> s"(${end.mkString(",")})"))(ret, arr)
-          idx += arr.shape(axis)
+            "begin" -> Shape(begin),
+            "end" -> Shape(end)))(ret, arr)
         }
+        idx += arr.shape(axis)
       }
       ret
     }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
@@ -934,6 +934,7 @@ class NDArrayFuncReturn(private[mxnet] val arr: Array[NDArray]) {
   def copy(): NDArray = head.copy()
   def shape: Shape = head.shape
   def size: Int = head.size
+  def asInContext(context: Context): NDArray = head.asInContext(context)
 }
 
 class NDArrayInternal private[mxnet](private val internal: Array[Byte], private val dtype: DType) {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -103,7 +103,7 @@ abstract class BaseModule {
 
   // A convenient function that calls both `forward` and `backward`.
   def forwardBackward(dataBatch: DataBatch): Unit = {
-    forward(dataBatch, isTrain= Option(true))
+    forward(dataBatch, isTrain = Option(true))
     backward()
   }
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -54,47 +54,47 @@ import scala.collection.mutable.ArrayBuffer
  *  - state information
  *    - `binded`: `bool`, indicating whether the memory buffers needed for computation
  *      has been allocated.
- *    - `for_training`: whether the module is binded for training (if binded).
- *    - `params_initialized`: `bool`, indicating whether the parameters of this modules
+ *    - `forTraining`: whether the module is binded for training (if binded).
+ *    - `paramsInitialized`: `bool`, indicating whether the parameters of this modules
  *      has been initialized.
- *    - `optimizer_initialized`: `bool`, indicating whether an optimizer is defined
+ *    - `optimizerInitialized`: `bool`, indicating whether an optimizer is defined
  *      and initialized.
- *    - `inputs_need_grad`: `bool`, indicating whether gradients with respect to the
+ *    - `inputsNeedGrad`: `bool`, indicating whether gradients with respect to the
  *      input data is needed. Might be useful when implementing composition of modules.
  *
  *  - input/output information
- *    - `data_shapes`: a list of `(name, shape)`. In theory, since the memory is allocated,
+ *    - `dataShapes`: a list of `(name, shape)`. In theory, since the memory is allocated,
  *      we could directly provide the data arrays. But in the case of data parallelization,
  *      the data arrays might not be of the same shape as viewed from the external world.
- *    - `label_shapes`: a list of `(name, shape)`. This might be `[]` if the module does
+ *    - `labelShapes`: a list of `(name, shape)`. This might be `[]` if the module does
  *      not need labels (e.g. it does not contains a loss function at the top), or a module
  *      is not binded for training.
- *    - `output_shapes`: a list of `(name, shape)` for outputs of the module.
+ *    - `outputShapes`: a list of `(name, shape)` for outputs of the module.
  *
  *  - parameters (for modules with parameters)
- *    - `get_params()`: return a tuple `(arg_params, aux_params)`. Each of those
+ *    - `getParams()`: return a tuple `(argParams, auxParams)`. Each of those
  *      is a dictionary of name to `NDArray` mapping. Those `NDArray` always lives on
  *      CPU. The actual parameters used for computing might live on other devices (GPUs),
  *      this function will retrieve (a copy of) the latest parameters. Therefore, modifying
- *    - `set_params(arg_params, aux_params)`: assign parameters to the devices
+ *    - `setParams(argParams, auxParams)`: assign parameters to the devices
  *      doing the computation.
- *    - `init_params(...)`: a more flexible interface to assign or initialize the parameters.
+ *    - `initParams(...)`: a more flexible interface to assign or initialize the parameters.
  *
  *  - setup
  *    - `bind()`: prepare environment for computation.
- *    - `init_optimizer()`: install optimizer for parameter updating.
+ *    - `initOptimizer()`: install optimizer for parameter updating.
  *
  *  - computation
- *    - `forward(data_batch)`: forward operation.
- *    - `backward(out_grads=None)`: backward operation.
+ *    - `forward(dataBatch)`: forward operation.
+ *    - `backward(outGrads=None)`: backward operation.
  *    - `update()`: update parameters according to installed optimizer.
- *    - `get_outputs()`: get outputs of the previous forward operation.
- *    - `get_input_grads()`: get the gradients with respect to the inputs computed
+ *    - `getOutputs()`: get outputs of the previous forward operation.
+ *    - `getInputGrads()`: get the gradients with respect to the inputs computed
  *      in the previous backward operation.
- *    - `update_metric(metric, labels)`: update performance metric for the previous forward
+ *    - `updateMetric(metric, labels)`: update performance metric for the previous forward
  *      computed results.
  *
- *  - other properties (mostly for backward compatability)
+ *  - other properties (mostly for backward compatibility)
  *    - `symbol`: the underlying symbolic graph for this module (if any)
  *      This property is not necessarily constant. For example, for `BucketingModule`,
  *      this property is simply the *current* symbol being used. For other modules,
@@ -132,7 +132,7 @@ abstract class BaseModule {
    * Run prediction on `eval_data` and evaluate the performance according to `eval_metric`.
    * @param evalData : DataIter
    * @param evalMetric : EvalMetric
-   * @param numBatch Number of batches to run. Default is `None`,
+   * @param numBatch Number of batches to run. Default is `Integer.MAX_VALUE`,
    *                 indicating run until the `DataIter` finishes.
    * @param batchEndCallback Could also be a list of functions.
    * @param reset Default `True`,

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -1,0 +1,360 @@
+package ml.dmlc.mxnet.module
+
+import java.io.IOException
+
+import ml.dmlc.mxnet.optimizer.SGD
+
+import scala.collection.immutable.ListMap
+import scala.util.control.Breaks._
+import ml.dmlc.mxnet._
+
+/**
+ * The base class of a modules. A module represents a computation component. The design
+ * purpose of a module is that it abstract a computation "machine", that one can run forward,
+ * backward, update parameters, etc. We aim to make the APIs easy to use, especially in the
+ * case when we need to use imperative API to work with multiple modules (e.g. stochastic
+ * depth network).
+ *
+ * A module has several states:
+ *
+ * - Initial state. Memory is not allocated yet, not ready for computation yet.
+ * - Binded. Shapes for inputs, outputs, and parameters are all known, memory allocated,
+ *   ready for computation.
+ * - Parameter initialized. For modules with parameters, doing computation before initializing
+ *   the parameters might result in undefined outputs.
+ * - Optimizer installed. An optimizer can be installed to a module. After this, the parameters
+ *   of the module can be updated according to the optimizer after gradients are computed
+ *   (forward-backward).
+ *
+ *  In order for a module to interactive with others, a module should be able to report the
+ *  following information in its raw stage (before binded)
+ *
+ *  - `data_names`: list of string indicating the names of required data.
+ *  - `output_names`: list of string indicating the names of required outputs.
+ *
+ *  And also the following richer information after binded:
+ *
+ *  - state information
+ *    - `binded`: `bool`, indicating whether the memory buffers needed for computation
+ *      has been allocated.
+ *    - `for_training`: whether the module is binded for training (if binded).
+ *    - `params_initialized`: `bool`, indicating whether the parameters of this modules
+ *      has been initialized.
+ *    - `optimizer_initialized`: `bool`, indicating whether an optimizer is defined
+ *      and initialized.
+ *    - `inputs_need_grad`: `bool`, indicating whether gradients with respect to the
+ *      input data is needed. Might be useful when implementing composition of modules.
+ *
+ *  - input/output information
+ *    - `data_shapes`: a list of `(name, shape)`. In theory, since the memory is allocated,
+ *      we could directly provide the data arrays. But in the case of data parallelization,
+ *      the data arrays might not be of the same shape as viewed from the external world.
+ *    - `label_shapes`: a list of `(name, shape)`. This might be `[]` if the module does
+ *      not need labels (e.g. it does not contains a loss function at the top), or a module
+ *      is not binded for training.
+ *    - `output_shapes`: a list of `(name, shape)` for outputs of the module.
+ *
+ *  - parameters (for modules with parameters)
+ *    - `get_params()`: return a tuple `(arg_params, aux_params)`. Each of those
+ *      is a dictionary of name to `NDArray` mapping. Those `NDArray` always lives on
+ *      CPU. The actual parameters used for computing might live on other devices (GPUs),
+ *      this function will retrieve (a copy of) the latest parameters. Therefore, modifying
+ *    - `set_params(arg_params, aux_params)`: assign parameters to the devices
+ *      doing the computation.
+ *    - `init_params(...)`: a more flexible interface to assign or initialize the parameters.
+ *
+ *  - setup
+ *    - `bind()`: prepare environment for computation.
+ *    - `init_optimizer()`: install optimizer for parameter updating.
+ *
+ *  - computation
+ *    - `forward(data_batch)`: forward operation.
+ *    - `backward(out_grads=None)`: backward operation.
+ *    - `update()`: update parameters according to installed optimizer.
+ *    - `get_outputs()`: get outputs of the previous forward operation.
+ *    - `get_input_grads()`: get the gradients with respect to the inputs computed
+ *      in the previous backward operation.
+ *    - `update_metric(metric, labels)`: update performance metric for the previous forward
+ *      computed results.
+ *
+ *  - other properties (mostly for backward compatability)
+ *    - `symbol`: the underlying symbolic graph for this module (if any)
+ *      This property is not necessarily constant. For example, for `BucketingModule`,
+ *      this property is simply the *current* symbol being used. For other modules,
+ *      this value might not be well defined.
+ *
+ *  When those intermediate-level API are implemented properly, the following
+ *  high-level API will be automatically available for a module:
+ *
+ *  - `fit`: train the module parameters on a data set
+ *  - `predict`: run prediction on a data set and collect outputs
+ *  - `score`: run prediction on a data set and evaluate performance
+ * @author Yizhi Liu
+ */
+abstract class BaseModule {
+  var binded: Boolean = false
+  var forTraining: Boolean = false
+  var inputsNeedGrad: Boolean = false
+  val paramsInitialized: Boolean = false
+  val optimizerInitialized: Boolean = false
+  val symbol: Symbol = null
+  val layoutMapper = None
+
+  // High Level API
+
+  // A convenient function that calls both `forward` and `backward`.
+  def forwardBackward(dataBatch: DataBatch): Unit = {
+    forward(dataBatch, isTrain= Option(true))
+    backward()
+  }
+
+  /**
+   * Run prediction on `eval_data` and evaluate the performance according to `eval_metric`.
+   * @param evalData : DataIter
+   * @param evalMetric : EvalMetric
+   * @param numBatch Number of batches to run. Default is `None`,
+   *                 indicating run until the `DataIter` finishes.
+   * @param batchEndCallback Could also be a list of functions.
+   * @param reset Default `True`,
+   *              indicating whether we should reset `eval_data` before starting evaluating.
+   * @param epoch Default 0. For compatibility, this will be passed to callbacks (if any).
+   *              During training, this will correspond to the training epoch number.
+   */
+  def score(evalData: DataIter, evalMetric: EvalMetric,
+            numBatch: Int = Integer.MAX_VALUE,
+            batchEndCallback: Option[BatchEndCallback] = None,
+            scoreEndCallback: Option[BatchEndCallback] = None,
+            reset: Boolean = true, epoch: Int = 0): EvalMetric = {
+    require(evalData != null && evalMetric != null)
+    require(binded && paramsInitialized)
+
+    if (reset) {
+      evalData.reset()
+    }
+
+    evalMetric.reset()
+
+    var nBatch = 0
+    while (evalData.hasNext && nBatch < numBatch) {
+      val evalBatch = evalData.next()
+
+      forward(evalBatch, isTrain = Option(false))
+      updateMetric(evalMetric, evalBatch.label)
+
+      batchEndCallback.foreach(callback => {
+        callback.invoke(epoch, nBatch, evalMetric)
+      })
+      nBatch += 1
+    }
+
+    scoreEndCallback.foreach(callback => {
+      callback.invoke(epoch, nBatch, evalMetric)
+    })
+
+    // TODO: eval_metric.get_name_value()
+    evalMetric
+  }
+
+  // Symbol information
+  // A list of names for data required by this module.
+  def dataNames: IndexedSeq[String]
+
+  // A list of names for the outputs of this module.
+  def outputNames: IndexedSeq[String]
+
+  // Input/Output information
+  // A list of (name, shape) pairs specifying the data inputs to this module.
+  def dataShapes: IndexedSeq[(String, Shape)]
+
+  /**
+   * A list of (name, shape) pairs specifying the label inputs to this module.
+   * If this module does not accept labels -- either it is a module without loss
+   * function, or it is not binded for training, then this should return an empty
+   * list `[]`.
+   */
+  def labelShapes: IndexedSeq[(String, Shape)]
+
+  // A list of (name, shape) pairs specifying the outputs of this module.
+  def outputShapes: IndexedSeq[(String, Shape)]
+
+  // Parameters of a module
+  /**
+   * Get parameters, those are potentially copies of the the actual parameters used
+   * to do computation on the device.
+   * @return `(arg_params, aux_params)`, a pair of dictionary of name to value mapping.
+   */
+  def getParams: (Map[String, NDArray], Map[String, NDArray])
+
+  /**
+   * Initialize the parameters and auxiliary states.
+   * @param initializer : Initializer
+   *         Called to initialize parameters if needed.
+   *     arg_params : dict
+   *         If not None, should be a dictionary of existing arg_params. Initialization
+   *         will be copied from that.
+   *     aux_params : dict
+   *         If not None, should be a dictionary of existing aux_params. Initialization
+   *         will be copied from that.
+   *     allow_missing : bool
+   *         If true, params could contain missing values, and the initializer will be
+   *         called to fill those missing params.
+   *     force_init : bool
+   *         If true, will force re-initialize even if already initialized.
+   */
+  def initParams(initializer: Initializer = new Uniform(0.01f),
+                 argParams: Option[Map[String, NDArray]] = None,
+                 auxParams: Option[Map[String, NDArray]] = None,
+                 allowMissing: Boolean = false, forceInit: Boolean = false): Unit
+
+  /**
+   * Assign parameter and aux state values.
+   *     arg_params : dict
+   *         Dictionary of name to value (`NDArray`) mapping.
+   *     aux_params : dict
+   *         Dictionary of name to value (`NDArray`) mapping.
+   *     allow_missing : bool
+   *         If true, params could contain missing values, and the initializer will be
+   *         called to fill those missing params.
+   *     force_init : bool
+   *         If true, will force re-initialize even if already initialized.
+   */
+  def setParams(argParams: Map[String, NDArray],
+                auxParams: Map[String, NDArray],
+                allowMissing: Boolean = false,
+                forceInit: Boolean = true): Unit = {
+    initParams(initializer = null, argParams = Option(argParams), auxParams = Option(auxParams),
+      allowMissing = allowMissing, forceInit = forceInit)
+  }
+
+  /**
+   * Save model parameters to file.
+   * @param fname Path to output param file.
+   *
+   */
+  def saveParams(fname: String): Unit = {
+    val (argParams, auxParams) = getParams
+    val saveDict = (
+      argParams.map { case (k, v) => (k, v.asInContext(Context.cpu())) }
+      ++ auxParams.map { case (k, v) => (k, v.asInContext(Context.cpu())) }
+    )
+    NDArray.save(fname, saveDict)
+  }
+
+  /**
+   * Load model parameters from file.
+   * @param fname Path to input param file.
+   * @throws IOException if param file is invalid
+   */
+  @throws(classOf[IOException])
+  def loadParams(fname: String): Unit = {
+    val saveDict = NDArray.load(fname)
+    val argParams = scala.collection.mutable.HashMap.empty[String, NDArray]
+    val auxParams = scala.collection.mutable.HashMap.empty[String, NDArray]
+    (saveDict._1 zip saveDict._2) foreach { case (key, value) =>
+      key.split(":", 2) match {
+        case Array(argType, name) if argType == "arg " => argParams.put(name, value)
+        case Array(argType, name) if argType == "aux " => auxParams.put(name, value)
+        case _ => throw new IOException("Invalid param file " + fname)
+      }
+    }
+    setParams(argParams.toMap, auxParams.toMap)
+  }
+
+  // Install monitor on all executors
+  def installMonitor(monitor: Monitor): Unit
+
+  // Computations
+  /**
+   * Forward computation.
+   * @param dataBatch Could be anything with similar API implemented.
+   * @param isTrain Default is `None`, which means `isTrain` takes the value of `this.forTraining`.
+   */
+  def forward(dataBatch: DataBatch, isTrain: Option[Boolean] = None): Unit
+
+  /**
+   * Backward computation.
+   * @param outGrads Gradient on the outputs to be propagated back.
+   *                 This parameter is only needed when bind is called
+   *                 on outputs that are not a loss function.
+   */
+  def backward(outGrads: Array[NDArray] = null): Unit
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[out1, out2]`
+   */
+  def getOutputsMerged(): IndexedSeq[NDArray]
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be collected from multiple devices.
+   *         The results will look like `[[out1_dev1, out1_dev2], [out2_dev1, out2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  def getOutputs(): IndexedSeq[IndexedSeq[NDArray]]
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[grad1, grad2]`
+   */
+  def getInputGradsMerged(): IndexedSeq[NDArray]
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be collected from multiple devices.
+   *         The results will look like `[[grad1_dev1, grad1_dev2], [grad2_dev1, grad2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  def getInputGrads(): IndexedSeq[IndexedSeq[NDArray]]
+
+  // Update parameters according to the installed optimizer and the gradients computed
+  // in the previous forward-backward batch.
+  def update(): Unit
+
+  /**
+   * Evaluate and accumulate evaluation metric on outputs of the last forward computation.
+   * @param evalMetric
+   * @param labels Typically `DataBatch.label`.
+   */
+  def updateMetric(evalMetric: EvalMetric, labels: IndexedSeq[NDArray]): Unit
+
+  // module setup
+  /**
+   * Bind the symbols to construct executors.
+   * This is necessary before one can perform computation with the module.
+   * @param dataShapes Typically is `DataIter.provideData`.
+   * @param labelShapes Typically is `DataIter.provideLabel`.
+   * @param forTraining Default is `True`. Whether the executors should be bind for training.
+   * @param inputsNeedGrad  Default is `False`.
+   *                        Whether the gradients to the input data need to be computed.
+   *                        Typically this is not needed.
+   *                        But this might be needed when implementing composition of modules.
+   * @param forceRebind Default is `False`. This function does nothing
+   *                    if the executors are already binded. But with this `True`,
+   *                    the executors will be forced to rebind.
+   * @param sharedModule  Default is `None`. This is used in bucketing. When not `None`,
+   *                      the shared module essentially corresponds to a different bucket
+   *                      -- a module with different symbol but with the same sets of parameters
+   *                      (e.g. unrolled RNNs with different lengths).
+   * @param gradReq Requirement for gradient accumulation (globally).
+   *                Can be 'write', 'add', or 'null' (default to 'write').
+   * @param gradReqs Requirement for gradient accumulation (for each argument)
+   *                 Can be 'write', 'add', or 'null' (default to 'write').
+   */
+  def bind(dataShapes: ListMap[String, Shape], labelShapes: Option[ListMap[String, Shape]] = None,
+           forTraining: Boolean = true, inputsNeedGrad: Boolean = false,
+           forceRebind: Boolean = false, sharedModule: Option[BaseModule] = None,
+           gradReq: String = "write", gradReqs: Map[String, String] = null): Unit
+
+  // Install and initialize optimizers.
+  def initOptimizer(kvstore: String = "local",
+                    optimizer: Optimizer = new SGD(learningRate = 0.01f)): Unit
+}

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -5,7 +5,6 @@ import java.io.IOException
 import ml.dmlc.mxnet.optimizer.SGD
 
 import scala.collection.immutable.ListMap
-import scala.util.control.Breaks._
 import ml.dmlc.mxnet._
 
 /**

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ml.dmlc.mxnet.module
 
 import java.io.IOException

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
@@ -84,6 +84,10 @@ object DataParallelExecutorGroup {
         gradReq: String, argNames: IndexedSeq[String], paramNames: IndexedSeq[String],
         fixedParamNames: Set[String], dataNames: Seq[String], inputsNeedGrad: Boolean)
         : Map[String, String] = {
+      require(argNames != null)
+      require(paramNames != null)
+      require(fixedParamNames != null)
+      require(dataNames != null)
       argNames.map(k => {
         if (paramNames.contains(k)) {
           (k, if (fixedParamNames.contains(k)) "null" else gradReq)
@@ -129,12 +133,12 @@ object DataParallelExecutorGroup {
     }
 
     def setLabelShapes(shapes: IndexedSeq[DataDesc]): Builder = {
-      this.labelShapes = Some(shapes)
+      this.labelShapes = Option(shapes)
       this
     }
 
     def setLabelShapesByName(shapes: IndexedSeq[(String, Shape)]): Builder = {
-      this.labelShapes = Some(shapes).map(shapesInst =>
+      this.labelShapes = Option(shapes).map(shapesInst =>
         shapesInst.map { case (k, s) => new DataDesc(k, s) }
       )
       this
@@ -151,17 +155,17 @@ object DataParallelExecutorGroup {
     }
 
     def setSharedGroup(sharedGroup: DataParallelExecutorGroup): Builder = {
-      this.sharedGroup = Some(sharedGroup)
+      this.sharedGroup = Option(sharedGroup)
       this
     }
 
     def setInputTypes(inputTypes: Map[String, DType]): Builder = {
-      this.inputTypes = Some(inputTypes)
+      this.inputTypes = Option(inputTypes)
       this
     }
 
     def setFixedParamNames(fixedParamNames: Set[String]): Builder = {
-      this.fixedParamNames = Some(fixedParamNames).getOrElse(Set.empty[String])
+      this.fixedParamNames = Option(fixedParamNames).getOrElse(Set.empty[String])
       this
     }
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
@@ -237,8 +237,8 @@ object DataParallelExecutorGroup {
  * @param fixedParamNames Indicate parameters to be fixed during training.
  *                        Parameters in this list will not allocate space for gradient,
  *                        nor do gradient calculation.
- * @param gradReq Requirement for gradient accumulation. Can be 'write', 'add', or 'null'
- *                (default to 'write'). Can be specified globally (str) or for each argument (list, dict).
+ * @param gradReq Requirement for gradient accumulation. Can be 'write', 'add', or 'null',
+ *                be specified for each argument.
  */
 class DataParallelExecutorGroup private[mxnet](
     private val symbol: Symbol,
@@ -616,7 +616,7 @@ class DataParallelExecutorGroup private[mxnet](
           }
           sharedExecInst.auxArrays.map(identity)
       }
-    symbol.bind(ctx = context, args = argArrays.toSeq,argsGrad = gradArrayMap.toMap,
+    symbol.bind(ctx = context, args = argArrays.toSeq, argsGrad = gradArrayMap.toMap,
       gradsReq = gradReqRun, auxStates = auxArrays.toSeq, group2ctx = null,
       sharedExec = sharedExec.orNull)
   }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
@@ -25,7 +25,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-object DataParallelExecutorGroup {
+private object DataParallelExecutorGroup {
   private val logger: Logger = LoggerFactory.getLogger(classOf[DataParallelExecutorGroup])
   // Load a list of arrays into a list of arrays specified by slices
   private def loadGeneralMulti(data: Seq[NDArray],
@@ -96,8 +96,8 @@ object DataParallelExecutorGroup {
     }
   }
 
-  object Builder {
-    private[mxnet] def convertGradReq(
+  private object Builder {
+    private[module] def convertGradReq(
         gradReq: String, argNames: IndexedSeq[String], paramNames: IndexedSeq[String],
         fixedParamNames: Set[String], dataNames: Seq[String], inputsNeedGrad: Boolean)
         : Map[String, String] = {
@@ -116,9 +116,10 @@ object DataParallelExecutorGroup {
       }).toMap
     }
   }
-  class Builder(private val symbol: Symbol,
-                private val contexts: Array[Context],
-                private val paramNames: IndexedSeq[String]) {
+
+  class Builder private[module](private val symbol: Symbol,
+                                private val contexts: Array[Context],
+                                private val paramNames: IndexedSeq[String]) {
 
     private var workLoadList: IndexedSeq[Float] = null
     private var dataShapes: IndexedSeq[DataDesc] = null
@@ -261,13 +262,13 @@ object DataParallelExecutorGroup {
  * @param gradReq Requirement for gradient accumulation. Can be 'write', 'add', or 'null',
  *                be specified for each argument.
  */
-class DataParallelExecutorGroup private[mxnet](
+class DataParallelExecutorGroup private[module](
     private val symbol: Symbol,
     private val contexts: Array[Context],
     private val workLoadList: IndexedSeq[Float],
     private val dataShapes: IndexedSeq[DataDesc],
     private val labelShapes: Option[IndexedSeq[DataDesc]] = None,
-    private[mxnet] val paramNames: IndexedSeq[String],
+    private[module] val paramNames: IndexedSeq[String],
     private val forTraining: Boolean,
     private val inputsNeedGrad: Boolean,
     private val sharedGroup: Option[DataParallelExecutorGroup] = None,
@@ -297,9 +298,9 @@ class DataParallelExecutorGroup private[mxnet](
   private var execs: Array[Executor] = null
   private var dataArrays: Seq[Array[((Int, Int), NDArray)]] = null
   private var labelArrays: Option[Seq[Array[((Int, Int), NDArray)]]] = None
-  private[mxnet] var paramArrays: IndexedSeq[Array[NDArray]] = null
-  private[mxnet] var gradArrays: IndexedSeq[Array[NDArray]] = null
-  private[mxnet] var auxArrays: IndexedSeq[Array[NDArray]] = null
+  private[module] var paramArrays: IndexedSeq[Array[NDArray]] = null
+  private[module] var gradArrays: IndexedSeq[Array[NDArray]] = null
+  private[module] var auxArrays: IndexedSeq[Array[NDArray]] = null
   private var inputGradArrays: IndexedSeq[Array[NDArray]] = null
 
   private val dataLayouts = decideSlices(dataShapes)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
@@ -1,0 +1,671 @@
+package ml.dmlc.mxnet.module
+
+import ml.dmlc.mxnet.DType.DType
+import ml.dmlc.mxnet._
+import ml.dmlc.mxnet.module.DataParallelExecutorGroup.Builder
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+object DataParallelExecutorGroup {
+  private val logger: Logger = LoggerFactory.getLogger(classOf[DataParallelExecutorGroup])
+  // Load a list of arrays into a list of arrays specified by slices
+  private def loadGeneralMulti(data: Seq[NDArray],
+                               targets: Seq[IndexedSeq[((Int, Int), NDArray)]],
+                               majorAxis: Seq[Int]): Unit = {
+    for (((dSrc, dTargets), axis) <- data zip targets zip majorAxis) {
+      for (((sliceIdxStart, sliceIdxStop), dDst) <- dTargets) {
+        if (axis >= 0) {
+          // copy slice
+          val shape = dSrc.shape
+          val begin = Array.fill(shape.length)(0)
+          val end = shape.toArray
+          begin(axis) = sliceIdxStart
+          end(axis) = sliceIdxStop
+          if (dSrc.context == dDst.context) {
+            NDArray.crop(Map(
+              "begin" -> new Shape(begin),
+              "end" -> new Shape(end),
+              "out" -> dDst))(dSrc)
+          } else {
+            // on different device, crop and then do cross device copy
+            val dDstCopy: NDArray = NDArray.crop(Map(
+              "begin" -> new Shape(begin),
+              "end" -> new Shape(end)))(dSrc)
+            dDstCopy.copyTo(dDst)
+          }
+        } else {
+          dSrc.copyTo(dDst)
+        }
+      }
+    }
+  }
+
+  private def loadGeneral(data: Seq[NDArray], targets: Seq[NDArray]): Unit = {
+    for ((dSrc, dTarget) <- data zip targets) {
+      dSrc.copyTo(dTarget)
+    }
+  }
+
+  // Load data into sliced arrays
+  private def loadData(batch: DataBatch,
+                       targets: Seq[IndexedSeq[((Int, Int), NDArray)]],
+                       majorAxis: Seq[Int]): Unit = {
+    loadGeneralMulti(batch.data, targets, majorAxis)
+  }
+
+
+  // Load label into sliced arrays
+  private def loadLabel(batch: DataBatch,
+                        targets: Seq[IndexedSeq[((Int, Int), NDArray)]],
+                        majorAxis: Seq[Int]): Unit = {
+    loadGeneralMulti(batch.label, targets, majorAxis)
+  }
+
+  // Merge outputs that lives on multiple context into one,
+  // so that they look like living on one context.
+  private def mergeMultiContext(outputs: IndexedSeq[IndexedSeq[NDArray]], majorAxis: Seq[Int])
+    : IndexedSeq[NDArray] = {
+    (outputs zip majorAxis).map { case (tensors, axis) =>
+      if (axis >= 0) {
+        NDArray.concatenate(tensors, axis = axis, alwaysCopy = false)
+      } else {
+        // negative axis means the there is no batch_size axis, and all the
+        // results should be the same on each device. We simply take the first one,
+        // without checking they are actually the same
+        tensors(0)
+      }
+    }
+  }
+
+  object Builder {
+    private[mxnet] def convertGradReq(
+        gradReq: String, argNames: IndexedSeq[String], paramNames: IndexedSeq[String],
+        fixedParamNames: Set[String], dataNames: Seq[String], inputsNeedGrad: Boolean)
+        : Map[String, String] = {
+      argNames.map(k => {
+        if (paramNames.contains(k)) {
+          (k, if (fixedParamNames.contains(k)) "null" else gradReq)
+        } else if (dataNames.contains(k)) {
+          (k, if (inputsNeedGrad) gradReq else "null")
+        } else {
+          (k, "null")
+        }
+      }).toMap
+    }
+  }
+  class Builder private[DataParallelExecutorGroup](
+    private val symbol: Symbol,
+    private val contexts: Array[Context],
+    private val paramNames: IndexedSeq[String]) {
+
+    private var workLoadList: Seq[Float] = null
+    private var dataShapes: Seq[DataDesc] = null
+    private var labelShapes: Option[Seq[DataDesc]] = None
+    private var forTraining: Boolean = true
+    private var inputsNeedGrad: Boolean = false
+    private var sharedGroup: Option[DataParallelExecutorGroup] = None
+    private var inputTypes: Option[Map[String, DType]] = None
+    private var fixedParamNames: Set[String] = Set.empty[String]
+    private var gradReqs: Map[String, String] = null
+
+    val argNames = symbol.listArguments()
+
+    def setWorkLoadList(workLoad: Seq[Float]): Builder = {
+      this.workLoadList = workLoad
+      this
+    }
+
+    def setDataShapes(shapes: Seq[DataDesc]): Builder = {
+      require(shapes != null)
+      this.dataShapes = shapes
+      this
+    }
+
+    def setDataShapesByName(shapes: Seq[(String, Shape)]): Builder = {
+      require(shapes != null)
+      this.dataShapes = shapes.map { case (k, s) => new DataDesc(k, s) }
+      this
+    }
+
+    def setLabelShapes(shapes: Seq[DataDesc]): Builder = {
+      this.labelShapes = Some(shapes)
+      this
+    }
+
+    def setLabelShapesByName(shapes: Seq[(String, Shape)]): Builder = {
+      this.labelShapes = Some(shapes).map(shapesInst =>
+        shapesInst.map { case (k, s) => new DataDesc(k, s) }
+      )
+      this
+    }
+
+    def setForTraining(forTraining: Boolean): Builder = {
+      this.forTraining = forTraining
+      this
+    }
+
+    def setInputsNeedGrad(needGrad: Boolean): Builder = {
+      this.inputsNeedGrad = needGrad
+      this
+    }
+
+    def setSharedGroup(sharedGroup: DataParallelExecutorGroup): Builder = {
+      this.sharedGroup = Some(sharedGroup)
+      this
+    }
+
+    def setInputTypes(inputTypes: Map[String, DType]): Builder = {
+      this.inputTypes = Some(inputTypes)
+      this
+    }
+
+    def setFixedParamNames(fixedParamNames: Set[String]): Builder = {
+      this.fixedParamNames = Some(fixedParamNames).getOrElse(Set.empty[String])
+      this
+    }
+
+    def setGradReq(gradReq: Map[String, String]): Builder = {
+      require(dataShapes != null)
+      val gradReqTmp = mutable.HashMap.empty[String, String]
+      val dataNames = dataShapes.map(_.name)
+      for (k <- argNames) {
+        if (paramNames.contains(k)) {
+          gradReqTmp.put(k, if (fixedParamNames.contains(k)) "null" else "write")
+        } else if (dataNames.contains(k)) {
+          gradReqTmp.put(k, if (inputsNeedGrad) "write" else "null")
+        } else {
+          gradReqTmp.put(k, "null")
+          gradReqTmp ++= gradReq
+        }
+      }
+      this.gradReqs = gradReqTmp.toMap
+      this
+    }
+
+    def setGradReq(gradReq: String): Builder = {
+      require(dataShapes != null)
+      val dataNames = dataShapes.map(_.name)
+      this.gradReqs = Builder.convertGradReq(
+        gradReq, argNames, paramNames, fixedParamNames, dataNames, inputsNeedGrad)
+      this
+    }
+
+    def setGradReq(gradReq: Seq[(String, String)]): Builder = {
+      require(gradReq.size == argNames.size)
+      this.gradReqs = gradReq.toMap
+      this
+    }
+
+    def build(): DataParallelExecutorGroup = {
+      new DataParallelExecutorGroup(
+        symbol, contexts, workLoadList, dataShapes, labelShapes, paramNames, forTraining,
+        inputsNeedGrad, sharedGroup, inputTypes, fixedParamNames, this.gradReqs)
+    }
+  }
+}
+
+/**
+ * DataParallelExecutorGroup is a group of executors that lives on a group of devices.
+ * This is a helper class used to implement data parallelism. Each mini-batch will
+ * be split and run on the devices.
+ * @param symbol The common symbolic computation graph for all executors.
+ * @param contexts A list of contexts.
+ * @param workLoadList If not `None`, could be a list of numbers that
+ *                     specify the workload to be assigned to different context.
+ *                     Larger number indicate heavier workload.
+ * @param dataShapes Should be a list of (name, shape) tuples, for the shapes of data.
+ *                   Note the order is important and should be the same as the order that
+ *                   the `DataIter` provide the data.
+ * @param labelShapes Should be a list of (name, shape) tuples, for the shapes of label.
+ *                    Note the order is important and should be the same as the order that
+ *                    the `DataIter` provide the label.
+ * @param paramNames A list of strings, indicating the names of parameters
+ *                   (e.g. weights, filters, etc.) in the computation graph.
+ * @param forTraining Indicate whether the executors should be bind for training.
+ *                    When not doing training, the memory for gradients will not be allocated.
+ * @param inputsNeedGrad Indicate whether the gradients for the input data should be computed.
+ *                       This is currently not used.
+ *                       It will be useful for implementing composition of modules.
+ * @param sharedGroup Default is `None`. This is used in bucketing. When not `None`,
+ *                    it should be a executor group corresponding to a different bucket.
+ *                    In other words, it will correspond to a different symbol but
+ *                    with the same set of parameters (e.g. unrolled RNNs with different lengths).
+ *                    In this case, many memory will be shared.
+ * @param inputTypes Default is `None`. When not `None`,
+ *                   can be used to specify the data type for each of the data/label inputs.
+ * @param fixedParamNames Indicate parameters to be fixed during training.
+ *                        Parameters in this list will not allocate space for gradient,
+ *                        nor do gradient calculation.
+ * @param gradReq Requirement for gradient accumulation. Can be 'write', 'add', or 'null'
+ *                (default to 'write'). Can be specified globally (str) or for each argument (list, dict).
+ */
+class DataParallelExecutorGroup private[mxnet](
+    private val symbol: Symbol,
+    private val contexts: Array[Context],
+    private val workLoadList: Seq[Float],
+    private val dataShapes: Seq[DataDesc],
+    private val labelShapes: Option[Seq[DataDesc]] = None,
+    private val paramNames: IndexedSeq[String],
+    private val forTraining: Boolean,
+    private val inputsNeedGrad: Boolean,
+    private val sharedGroup: Option[DataParallelExecutorGroup] = None,
+    private val inputTypes: Option[Map[String, DType]] = None,
+    private val fixedParamNames: Set[String] = Set.empty[String],
+    private val gradReq: Map[String, String] = null) {
+  require(symbol != null)
+  require(contexts != null)
+  private val argNames = symbol.listArguments()
+  private val auxNames = symbol.listAuxiliaryStates()
+
+  private val gradReqRun =
+    if (!forTraining) {
+      val dataNames = dataShapes.map(_.name)
+      Builder.convertGradReq("null",
+        argNames, paramNames, fixedParamNames, dataNames, inputsNeedGrad)
+    } else {
+      gradReq
+    }
+
+  private val sharedDataArrays: Array[mutable.Map[String, NDArray]] =
+    sharedGroup.map(_.sharedDataArrays).getOrElse(
+    Array.fill(contexts.length)(mutable.Map.empty[String, NDArray]))
+
+  private var batchSize: Int = -1
+  private var slices: Array[(Int, Int)] = null
+  private var execs: IndexedSeq[Executor] = null
+  private var dataArrays: Seq[IndexedSeq[((Int, Int), NDArray)]] = null
+  private var labelArrays: Option[Seq[IndexedSeq[((Int, Int), NDArray)]]] = None
+  private var paramArrays: IndexedSeq[IndexedSeq[NDArray]] = null
+  private var gradArrays: IndexedSeq[IndexedSeq[NDArray]] = null
+  private var auxArrays: IndexedSeq[IndexedSeq[NDArray]] = null
+  private var inputGradArrays: IndexedSeq[IndexedSeq[NDArray]] = null
+
+  private val dataLayouts = decideSlices(dataShapes)
+  private val labelLayouts =
+    // call it to make sure labels has the same batch size as data
+    if (labelShapes != None) decideSlices(labelShapes.get)
+    else null
+
+  private val outputLayouts = symbol.listOutputs().map(name =>
+    DataDesc.getBatchAxis(symbol.get(name).attr("__layout__"))
+  )
+  bindExec(dataShapes, labelShapes, sharedGroup)
+
+  /**
+   * Decide the slices for each context according to the workload.
+   * @param dataShapes list of DataDesc(name, shape) specifying
+   *                   the shapes for the input data or label.
+   */
+  private def decideSlices(dataShapes: Seq[DataDesc]): Seq[Int] = {
+    require(dataShapes.size > 0)
+    val majorAxis = dataShapes.map(data => DataDesc.getBatchAxis(Option(data.layout)))
+
+    for ((dataDesc, axis) <- dataShapes.zip(majorAxis)) {
+      if (axis != -1) {
+        val batchSize = dataDesc.shape(axis)
+        if (this.batchSize != -1) {
+          require(batchSize == this.batchSize,
+            s"all data must have the same batch size: $batchSize," +
+            s"but ${dataDesc.name} has shape ${dataDesc.shape}")
+        } else {
+          this.batchSize = batchSize
+          require(this.workLoadList != null)
+          this.slices = ExecutorManager.splitInputSlice(this.batchSize, this.workLoadList)
+        }
+      }
+    }
+    majorAxis
+  }
+
+  /**
+   * Bind executors on their respective devices.
+   * @param dataShapes DataDesc for input data.
+   * @param labelShapes DataDesc for input labels.
+   * @param sharedGroup
+   */
+  def bindExec(dataShapes: Seq[DataDesc], labelShapes: Option[Seq[DataDesc]],
+               sharedGroup: Option[DataParallelExecutorGroup]): Unit = {
+    execs = (0 until contexts.length).map(i => bindIthExec(i, dataShapes, labelShapes, sharedGroup))
+
+    // convenient data structures
+    dataArrays = dataShapes.map(dataDesc =>
+      this.execs.zipWithIndex.map { case (e, i) => (this.slices(i), e.argDict(dataDesc.name)) }
+    )
+
+    labelArrays = labelShapes.map(shapes =>
+      shapes.map(labelDesc =>
+        this.execs.zipWithIndex.map { case (e, i) => (this.slices(i), e.argDict(labelDesc.name)) }
+      )
+    )
+
+    paramArrays = argNames.zipWithIndex.withFilter {
+      case (name, i) => paramNames.contains(name)
+    }.map { case (name, i) =>
+      execs.map(_.argArrays(i))
+    }
+
+    gradArrays =
+      if (forTraining) {
+        argNames.zipWithIndex.withFilter {
+          case (name, i) => paramNames.contains(name)
+        }.map { case (name, i) =>
+          execs.map(_.gradArrays(i))
+        }
+      } else {
+        null
+      }
+
+    val dataNames = dataShapes.map(_.name)
+    inputGradArrays =
+      if (inputsNeedGrad) {
+        argNames.zipWithIndex.withFilter {
+          case (name, i) => dataNames.contains(name)
+        }.map { case (name, i) =>
+          execs.map(_.gradArrays(i))
+        }
+      } else {
+        null
+      }
+
+    auxArrays = (0 until auxNames.length).map(i => execs.map(_.auxArrays(i)))
+  }
+
+  /**
+   * Assign, i.e. copy parameters to all the executors.
+   * @param argParams A dictionary of name to `NDArray` parameter mapping.
+   * @param auxParams A dictionary of name to `NDArray` auxiliary variable mapping.
+   */
+  def setParams(argParams: Map[String, NDArray], auxParams: Map[String, NDArray]): Unit = {
+    execs.foreach(_.copyParamsFrom(argParams, auxParams))
+  }
+
+  /**
+   * Copy data from each executor to `arg_params` and `aux_params`.
+   * @param argParams target parameter arrays
+   * @param auxParams target aux arrays
+   * Note this function will inplace update the NDArrays in arg_params and aux_params.
+   */
+  def getParams(argParams: Map[String, NDArray], auxParams: Map[String, NDArray]): Unit = {
+    for ((name, block) <- paramNames.zip(paramArrays)) {
+      val weight = (block.map(_.copyTo(Context.cpu())).reduce { case (a, b) =>
+        (a + b).disposeDeps()
+      } / block.size).disposeDeps()
+      val weightNewType = weight.asType(argParams(name).dtype)
+      weightNewType.copyTo(argParams(name))
+      weight.dispose()
+      weightNewType.dispose()
+    }
+    for ((name, block) <- auxNames.zip(auxArrays)) {
+      val weight = (block.map(_.copyTo(Context.cpu())).reduce { case (a, b) =>
+        (a + b).disposeDeps()
+      } / block.size).disposeDeps()
+      val weightNewType = weight.asType(auxParams(name).dtype)
+      weightNewType.copyTo(auxParams(name))
+      weight.dispose()
+      weightNewType.dispose()
+    }
+  }
+
+  /**
+   * Split `dataBatch` according to workload and run forward on each devices.
+   * @param dataBatch
+   * @param isTrain The hint for the backend, indicating whether we are during training phase.
+   *                Default is `None`, then the value `self.for_training` will be used.
+   */
+  def forward(dataBatch: DataBatch, isTrain: Option[Boolean] = None): Unit = {
+    DataParallelExecutorGroup.loadData(dataBatch, dataArrays, dataLayouts)
+    val isTrainOpt = isTrain.getOrElse(this.forTraining)
+    labelArrays.foreach(labels => {
+      require(!isTrainOpt || dataBatch.label != null)
+      if (dataBatch.label != null) {
+        require(labelLayouts != null)
+        DataParallelExecutorGroup.loadLabel(dataBatch, labels, labelLayouts)
+      }
+    })
+    execs.foreach(_.forward(isTrainOpt))
+  }
+
+  // Get the shapes of the outputs.
+  def getOutputShapes: IndexedSeq[(String, Shape)] = {
+    val outputs = execs(0).outputs
+    val shapes = outputs.map(_.shape)
+    (symbol.listOutputs() zip shapes zip outputLayouts) map { case ((key, theShape), axis) =>
+      val shape = theShape.toArray
+      if (axis >= 0) {
+        shape(axis) = batchSize
+      }
+      (key, Shape(shape))
+    }
+  }
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be collected from multiple devices.
+   *         The results will look like `[[out1_dev1, out1_dev2], [out2_dev1, out2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  def getOutputs(): IndexedSeq[IndexedSeq[NDArray]] = {
+    (0 until execs(0).outputs.length).map(i => execs.map(_.outputs(i)))
+  }
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[out1, out2]`
+   */
+  def getOutputsMerged(): IndexedSeq[NDArray] = {
+    DataParallelExecutorGroup.mergeMultiContext(getOutputs(), outputLayouts)
+  }
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be collected from multiple devices.
+   *         The results will look like `[[grad1_dev1, grad1_dev2], [grad2_dev1, grad2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  def getInputGrads(): IndexedSeq[IndexedSeq[NDArray]] = {
+    require(inputsNeedGrad)
+    inputGradArrays
+  }
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[grad1, grad2]`
+   */
+  def getInputGradsMerged(): IndexedSeq[NDArray] = {
+    DataParallelExecutorGroup.mergeMultiContext(getInputGrads(), dataLayouts)
+  }
+
+  /**
+   * Run backward on all devices. A backward should be called after
+   * a call to the forward function. Backward cannot be called unless
+   * `this.for_training` is `True`.
+   * @param outGrads Gradient on the outputs to be propagated back.
+   *                 This parameter is only needed when bind is called
+   *                 on outputs that are not a loss function.
+   */
+  def backward(outGrads: Array[NDArray] = null): Unit = {
+    require(forTraining, "re-bind with forTraining = true to run backward")
+
+    for (((exec, islice), i) <- (execs zip slices).zipWithIndex) {
+      val outGradsSlice =
+        if (outGrads != null) {
+          (outGrads zip outputLayouts).map { case (grad, axis) =>
+            if (axis >= 0) {
+              val ogMySlice: NDArray = NDArray.slice_axis(
+                Map("axis" -> axis, "begin" -> islice._1, "end" -> islice._2))(grad)
+              ogMySlice.asInContext(contexts(i))
+            } else {
+              grad.copyTo(contexts(i))
+            }
+          }
+        } else {
+          Array.empty[NDArray]
+        }
+      exec.backward(outGrads = outGradsSlice)
+    }
+  }
+
+  /**
+   * Accumulate the performance according to `eval_metric` on all devices.
+   * @param evalMetric The metric used for evaluation.
+   * @param labels Typically comes from `label` of a `DataBatch`.
+   */
+  def updateMetric(evalMetric: EvalMetric, labels: IndexedSeq[NDArray]): Unit = {
+    for ((texec, islice) <- this.execs zip this.slices) {
+      val labelsSlice =
+        (labels zip this.labelLayouts) map { case (label, axis) =>
+          if (axis == 0) {
+            label.slice(islice)
+          } else if (axis > 0) {
+            val labelMySlice: NDArray = NDArray.slice_axis(Map(
+              "axis" -> axis, "begin" -> islice._1, "end" -> islice._2))(label)
+              .as_in_context(label.context)
+            labelMySlice
+          } else {
+            label
+          }
+        }
+      evalMetric.update(labelsSlice, texec.outputs)
+    }
+  }
+
+  // Internal utility function to bind the i-th executor.
+  private def bindIthExec(i: Int, dataShapes: Seq[DataDesc],
+                          labelShapes: Option[Seq[DataDesc]],
+                          sharedGroup: Option[DataParallelExecutorGroup]): Executor = {
+    val dataShapesSliced = slicedShape(dataShapes, i, dataLayouts)
+    val labelShapesSliced = labelShapes.map(slicedShape(_, i, labelLayouts))
+    val sharedExec = sharedGroup.map(_.execs(i))
+    val context = contexts(i)
+    val sharedDataArrays = this.sharedDataArrays(i)
+
+    val inputShapes
+      = dataShapesSliced.toMap ++ labelShapesSliced.getOrElse(Map.empty[String, Shape])
+
+    val (argShapes, _, auxShapes) = symbol.inferShape(inputShapes)
+    require(argShapes != null, "shape inference failed")
+
+    val inputTypesGot = inputTypes.getOrElse(inputShapes.map { case (k, v) =>
+      (k, Base.MX_REAL_TYPE)
+    })
+    val (argTypes, _, auxTypes) = symbol.inferType(inputTypesGot)
+    require(argTypes != null, "type inference failed")
+
+    val argArrays = ArrayBuffer.empty[NDArray]
+    val gradArrayMap = if (forTraining) mutable.HashMap.empty[String, NDArray] else null
+
+    // create or borrow arguments and gradients
+    for (j <- 0 until argNames.length) {
+      val name = argNames(j)
+      val argArr =
+        if (paramNames.contains(name)) {
+          // model parameter
+          sharedExec match {
+            case None =>
+              val argArr = NDArray.zeros(argShapes(j), context, dtype = argTypes(j))
+              if (gradReqRun(name) != "null") {
+                val gradArr = NDArray.zeros(argShapes(j), context, dtype = argTypes(j))
+                gradArrayMap.put(name, gradArr)
+              }
+              argArr
+            case Some(sharedExecInst) =>
+              val argArr = sharedExecInst.argDict(name)
+              require(argArr.shape == argShapes(j))
+              require(argArr.dtype == argTypes(j))
+              if (gradReqRun(name) != "null") {
+                gradArrayMap.put(name, sharedExecInst.gradDict(name))
+              }
+              argArr
+          }
+        } else {
+          // data or label
+          val argArr = getOrReshape(name, sharedDataArrays, argShapes(j), argTypes(j), context)
+          // data might also need grad if inputs_need_grad is True
+          if (gradReqRun(name) != "null") {
+            gradArrayMap.put(name,
+              getOrReshape(s"grad of $name", sharedDataArrays, argShapes(j), argTypes(j), context))
+          }
+          argArr
+        }
+      argArrays.append(argArr)
+    }
+
+    // create or borrow aux variables
+    val auxArrays =
+      sharedExec match {
+        case None => (auxShapes zip auxTypes).map { case (s, t) =>
+          NDArray.zeros(s, context, dtype = t)
+        }.toArray
+        case Some(sharedExecInst) =>
+          for ((arr, j) <- sharedExecInst.auxArrays.zipWithIndex) {
+            require(auxShapes(j) == arr.shape)
+            require(auxTypes(j) == arr.dtype)
+          }
+          sharedExecInst.auxArrays.map(identity)
+      }
+    symbol.bind(ctx = context, args = argArrays.toSeq,argsGrad = gradArrayMap.toMap,
+      gradsReq = gradReqRun, auxStates = auxArrays.toSeq, group2ctx = null,
+      sharedExec = sharedExec.orNull)
+  }
+
+  /**
+   * Get the sliced shapes for the i-th executor.
+   * @param shapes : The original (name, shape) pairs.
+   * @param i Which executor we are dealing with.
+   * @param majorAxis
+   */
+  private def slicedShape(shapes: Seq[DataDesc], i: Int, majorAxis: Seq[Int])
+    : Seq[(String, Shape)] = {
+    (shapes zip majorAxis).map { case (DataDesc(k, shape, _ , _), axis) =>
+      val shapeArr = shape.toArray
+      if (axis >= 0) {
+        shapeArr(axis) = slices(i)._2 - slices(i)._1
+      }
+      (k, Shape(shapeArr))
+    }
+  }
+
+  // Install monitor on all executors
+  def installMonitor(monitor: Monitor): Unit = {
+    execs.foreach(monitor.install)
+  }
+
+  // Internal helper to get a memory block or re-use by re-shaping
+  private def getOrReshape(name: String,
+                           sharedDataArrays: mutable.Map[String, NDArray],
+                           argShape: Shape,
+                           argType: DType,
+                           context: Context): NDArray = {
+    if (sharedDataArrays.contains(name)) {
+      val argArr = sharedDataArrays(name)
+      if (argArr.shape.product >= argShape.product) {
+        // nice, we can directly re-use this data blob
+        require(argArr.dtype == argType)
+        argArr.reshape(argShape)
+      } else {
+        DataParallelExecutorGroup.logger.warn(s"bucketing: data \"$name\" has a shape $argShape," +
+          s"which is larger than already allocated shape ${argArr.shape}." +
+          "Need to re-allocate. Consider putting default_bucket_key to be the bucket" +
+          "taking the largest input for better memory sharing.")
+        val argArrNew = NDArray.zeros(argShape, context, dtype = argType)
+        // replace existing shared array because the new one is bigger
+        sharedDataArrays.put(name, argArrNew)
+        argArrNew
+      }
+    } else {
+      val argArrNew = NDArray.zeros(argShape, context, dtype = argType)
+      sharedDataArrays.put(name, argArrNew)
+      argArrNew
+    }
+  }
+}

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/DataParallelExecutorGroup.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ml.dmlc.mxnet.module
 
 import ml.dmlc.mxnet.DType.DType

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory
 /**
  * Module is a basic module that wrap a `Symbol`. It is functionally the same
  * as the `FeedForward` model, except under the module API.
- * @param symbol : Symbol definition.
+ * @param symbolVar : Symbol definition.
  * @param dataNames Input data names.
  * @param labelNames Input label names
  * @param contexts Default is cpu().
@@ -111,11 +111,11 @@ class Module(symbolVar: Symbol,
     }
 
     this.argParams.foreach { case (name, arr) =>
-      impl(name, arr, allowMissing, Some(initializer), argParams)
+      impl(name, arr, allowMissing, Option(initializer), argParams)
     }
 
     this.auxParams.foreach { case (name, arr) =>
-      impl(name, arr, allowMissing, Some(initializer), auxParams)
+      impl(name, arr, allowMissing, Option(initializer), auxParams)
     }
 
     this.paramsInitialized = true
@@ -174,7 +174,7 @@ class Module(symbolVar: Symbol,
   override def bind(dataShapes: IndexedSeq[DataDesc],
                     labelShapes: Option[IndexedSeq[DataDesc]] = None,
                     forTraining: Boolean = true, inputsNeedGrad: Boolean = false,
-                    forceRebind: Boolean = false, sharedModule: Option[BaseModule] = null,
+                    forceRebind: Boolean = false, sharedModule: Option[BaseModule] = None,
                     gradReq: String = "write"): Unit = {
     // force rebinding is typically used when one want to switch from training to prediction phase.
     if (forceRebind) {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
@@ -1,0 +1,251 @@
+package ml.dmlc.mxnet.module
+
+import ml.dmlc.mxnet.DType.DType
+import ml.dmlc.mxnet._
+import org.slf4j.{LoggerFactory, Logger}
+
+import scala.collection.immutable.ListMap
+import scala.collection.mutable
+
+/**
+ * Module is a basic module that wrap a `Symbol`. It is functionally the same
+ * as the `FeedForward` model, except under the module API.
+ * @param symbol : Symbol
+    data_names : list of str
+        Default is `('data')` for a typical model used in image classification.
+    label_names : list of str
+        Default is `('softmax_label')` for a typical model used in image
+        classification.
+    logger : Logger
+        Default is `logging`.
+    context : Context or list of Context
+        Default is `cpu()`.
+    work_load_list : list of number
+        Default `None`, indicating uniform workload.
+    fixed_param_names: list of str
+        Default `None`, indicating no network parameters are fixed.
+ */
+class Module(private val symbol: Symbol, val dataNames: IndexedSeq[String] = IndexedSeq("data"),
+             labelNames: IndexedSeq[String] = IndexedSeq("softmax_label"),
+             context: Array[Context] = Context.cpu(), workLoadList: Option[Seq[Float]] = None,
+             fixedParamNames: Option[Seq[String]] = None) extends BaseModule {
+  private val logger = LoggerFactory.getLogger(classOf[Module])
+  // TODO: module.DataParallelExecutorGroup
+  private var execGroup: DataParallelExecutorGroup = null
+  private var paramsInitialized: Boolean = false
+
+  private val workLoads = workLoadList.getOrElse(context.map(_ => 1f).toSeq)
+  require(workLoads.size == context.length)
+
+  private val labelNameList = if (labelNames == null) IndexedSeq.empty[String] else labelNames
+
+  private val argNames = symbol.listArguments()
+  private val inputNames = dataNames ++ labelNameList
+  private val paramNames = argNames.filterNot(inputNames.toSet)
+  private val auxNames = symbol.listAuxiliaryStates()
+  val outputNames = symbol.listOutputs()
+
+  private var argParams: Map[String, NDArray] = null
+  private var auxParams: Map[String, NDArray] = null
+  private var paramsDirty = false
+
+  private var optimizer: Optimizer = null
+  private var kvstore: KVStore = null
+  private var updateOnKvstore = None
+  private var updater = None
+
+  private var dataShapes: Seq[DataDesc] = null
+  private var labelShapes: Option[Seq[DataDesc]] = None
+
+  // Internal function to reset binded state.
+  private def resetBind(): Unit = {
+    binded = false
+    execGroup = null
+    dataShapes = null
+    labelShapes = null
+  }
+
+  def getDataShapes(): ListMap[String, Shape] = {
+    require(binded)
+    dataShapes
+  }
+
+  def getLabelShapes(): ListMap[String, Shape] = {
+    require(binded)
+    labelShapes
+  }
+
+  def getOutputShapes(): ListMap[String, Shape] = {
+    require(binded)
+    null // TODO
+  }
+
+  /**
+   * Get current parameters.
+   * `(arg_params, aux_params)`, each a dictionary of name to parameters (in
+   * `NDArray`) mapping.
+   */
+  def getParams(): (Map[String, NDArray], Map[String, NDArray]) = {
+    require(binded && paramsInitialized)
+    if (paramsDirty) {
+      // TODO: sync_params_from_devices()
+    }
+    (argParams, auxParams)
+  }
+
+  /**
+   * Initialize the parameters and auxiliary states.
+   * @param initializer Called to initialize parameters if needed.
+   * @param argParams If not None, should be a dictionary of existing arg_params.
+   *                  Initialization will be copied from that.
+   * @param auxParams If not None, should be a dictionary of existing aux_params.
+   *                  Initialization will be copied from that.
+   * @param allowMissing If true, params could contain missing values,
+   *                     and the initializer will be called to fill those missing params.
+   * @param forceInit If true, will force re-initialize even if already initialized.
+   */
+  def initParams(initializer: Initializer = new Uniform(0.01f),
+                 argParams: Map[String, NDArray] = null,
+                 auxParams: Map[String, NDArray] = null,
+                 allowMissing: Boolean = false, forceInit: Boolean = false): Unit = {
+    if (paramsInitialized && !forceInit) {
+      return
+    }
+    require(binded, "call bind before initializing the parameters")
+
+    if (this.argParams == null) {
+      val paramArrays =
+        execGroup.paramArrays.map(nds => NDArray.zeros(nds(0).shape, dtype = nds(0).dtype))
+      this.argParams = this.paramNames.zip(paramArrays).toMap
+    }
+
+    if (this.auxParams == null) {
+      val auxArrays =
+        execGroup.auxArrays.map(nds => NDArray.zeros(nds(0).shape, dtype = nds(0).dtype))
+      this.auxParams = this.auxNames.zip(auxArrays).toMap
+    }
+
+    this.argParams.foreach { case (name, arr) =>
+      _impl(name, arr, allowMissing, Some(initializer), argParams)
+    }
+
+    this.auxParams.foreach { case (name, arr) =>
+      _impl(name, arr, allowMissing, Some(initializer), auxParams)
+    }
+
+    this.paramsInitialized = true
+    this.paramsDirty = false // copy the initialized parameters to devices
+    // TODO: this.execGroup.setParams(self._arg_params, self._aux_params)
+  }
+
+  // Internal helper for parameter initialization
+  private def _impl(name: String, arr: NDArray, allowMissing: Boolean,
+                    initializer: Option[Initializer] = None,
+                    cache: Map[String, NDArray] = null): Unit = {
+    if (cache != null) {
+      if (cache.contains(name)) {
+        val cacheArr = cache(name) // just in case the cached array is just the target itself
+        if (cacheArr != arr) {
+          cacheArr.copyTo(arr)
+        }
+      } else {
+        if (allowMissing) {
+          throw new RuntimeException(s"$name is not presented")
+        }
+        initializer.foreach(inst => inst(name, arr))
+      }
+    } else {
+      initializer.foreach(inst => inst(name, arr))
+    }
+  }
+
+  // Internal function to reset binded state.
+  private def _reset_bind(): Unit = {
+    binded = false
+    execGroup = null
+    dataShapes = null
+    labelShapes = null
+  }
+
+  /**
+   * Bind the symbols to construct executors. This is necessary before one
+   * can perform computation with the module.
+   * @param dataShapes Typically is `dataIter.provideData`.
+   * @param labelShapes Typically is `data_iter.provide_label`.
+   * @param forTraining Default is `true`. Whether the executors should be bind for training.
+   * @param inputsNeedGrad Default is `false`.
+   *                       Whether the gradients to the input data need to be computed.
+   *                       Typically this is not needed.
+   *                       But this might be needed when implementing composition of modules.
+   * @param forceRebind Default is `false`.
+   *                    This function does nothing if the executors are already binded.
+   *                    But with this `true`, the executors will be forced to rebind.
+   * @param sharedModule Default is `None`. This is used in bucketing.
+   *                     When not `None`, the shared module essentially corresponds to
+   *                     a different bucket -- a module with different symbol
+   *                     but with the same sets of parameters
+   *                     (e.g. unrolled RNNs with different lengths).
+   */
+  def bind(dataShapes: Seq[DataDesc], labelShapes: Option[Seq[DataDesc]] = None,
+           forTraining: Boolean = true, inputsNeedGrad: Boolean = false,
+           forceRebind: Boolean = false, sharedModule: Module = null,
+           gradReq: String = "write"): Unit = {
+    // force rebinding is typically used when one want to switch from training to prediction phase.
+    if (forceRebind) {
+      _reset_bind()
+    }
+
+    if (binded) {
+      logger.warn("Already binded, ignoring bind()")
+      return
+    }
+
+    this.forTraining = forTraining
+    this.inputsNeedGrad = inputsNeedGrad
+    this.binded = true
+
+    require(forTraining || !inputsNeedGrad)
+    // this is not True, as some module might not contains a loss function
+    // that consumes the labels
+    // assert label_shapes is not None
+
+    this.dataShapes = dataShapes
+    this.labelShapes = labelShapes
+
+    val sharedGroup =
+      if (sharedModule != null) {
+        require(sharedModule.binded && sharedModule.paramsInitialized)
+        sharedModule.execGroup
+      } else {
+        null
+      }
+
+    val inputTypes = this.dataShapes.map(dataDesc => (dataDesc.name, dataDesc.dtype)).toMap ++
+      labelShapes.map(shapes => shapes.map(dataDesc => (dataDesc.name, dataDesc.dtype)).toMap)
+                 .getOrElse(Map.empty[String, DType])
+
+    /* TODO
+    self._exec_group = DataParallelExecutorGroup(self._symbol, self._context,
+      self._work_load_list, self._data_shapes,
+      self._label_shapes, self._param_names,
+      for_training, inputs_need_grad,
+      shared_group, logger = self.logger,
+      fixed_param_names = self._fixed_param_names,
+      grad_req = grad_req, input_types = input_types)
+    */
+    if (sharedModule != null) {
+      paramsInitialized = true
+      argParams = sharedModule.argParams
+      auxParams = sharedModule.auxParams
+    } else if (paramsInitialized) {
+      // if the parameters are already initialized, we are re-binding
+      // so automatically copy the already initialized params
+      // TODO
+      execGroup.setParams(argParams, auxParams)
+    }
+
+    if (sharedModule != null && sharedModule.optimizerInitialized) {
+      borrowOptimizer(sharedModule)
+    }
+  }
+}

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ml.dmlc.mxnet.module
 
 import ml.dmlc.mxnet.DType.DType

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/Module.scala
@@ -258,9 +258,12 @@ class Module(symbolVar: Symbol,
       logger.warn("optimizer already initialized, ignoring ...")
     } else {
       val (kvstoreInst, updateOnKVStore) = Model.createKVStore(kvstore, contexts.length, argParams)
-      val batchSize = execGroup.getBatchSize *
-        (if (kvstoreInst != None && kvstoreInst.get.`type` == "dist_sync")
-          kvstoreInst.get.numWorkers else 1)
+      val batchSize = execGroup.getBatchSize * (
+        if (kvstoreInst != None && kvstoreInst.get.`type` == "dist_sync") {
+          kvstoreInst.get.numWorkers
+        } else {
+          1
+        })
       if (resetOptimizer) {
         val idx2name =
           if (updateOnKVStore) {

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/NDArraySuite.scala
@@ -283,12 +283,20 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
     assert(argmax.toArray === Array(1f, 0f))
   }
 
-  test("concatenate") {
+  test("concatenate axis-0") {
     val arr1 = NDArray.array(Array(1f, 2f, 4f, 3f, 3f, 3f), shape = Shape(2, 3))
     val arr2 = NDArray.array(Array(8f, 7f, 6f), shape = Shape(1, 3))
     val arr = NDArray.concatenate(arr1, arr2)
     assert(arr.shape === Shape(3, 3))
     assert(arr.toArray === Array(1f, 2f, 4f, 3f, 3f, 3f, 8f, 7f, 6f))
+  }
+
+  test("concatenate axis-1") {
+    val arr1 = NDArray.array(Array(1f, 2f, 3f, 4f), shape = Shape(2, 2))
+    val arr2 = NDArray.array(Array(5f, 6f), shape = Shape(2, 1))
+    val arr = NDArray.concatenate(Array(arr1, arr2), axis = 1)
+    assert(arr.shape === Shape(2, 3))
+    assert(arr.toArray === Array(1f, 2f, 5f, 3f, 4f, 6f))
   }
 
   test("transpose") {

--- a/scala-package/examples/scripts/module/mnist_mlp.sh
+++ b/scala-package/examples/scripts/module/mnist_mlp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+ROOT_DIR=$(cd `dirname $0`/../../..; pwd)
+CLASSPATH=$ROOT_DIR/assembly/osx-x86_64-cpu/target/*:$ROOT_DIR/examples/target/*:$ROOT_DIR/examples/target/classes/lib/*
+
+java -Xmx4G -cp $CLASSPATH \
+	ml.dmlc.mxnet.examples.module.MnistMlp \
+  --data-dir "$ROOT_DIR/core/data/" \
+  --batch-size 10 \
+  --num-epoch 10

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ml.dmlc.mxnet.examples.module
 
 import ml.dmlc.mxnet._

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
@@ -18,7 +18,7 @@
 package ml.dmlc.mxnet.examples.module
 
 import ml.dmlc.mxnet._
-import ml.dmlc.mxnet.module.Module
+import ml.dmlc.mxnet.module.{FitParams, Module}
 import ml.dmlc.mxnet.DataDesc._
 import ml.dmlc.mxnet.optimizer.SGD
 import org.kohsuke.args4j.{Option, CmdLineParser}
@@ -117,7 +117,7 @@ object MnistMlp {
 
   def main(args: Array[String]): Unit = {
     val inst = new MnistMlp
-    val parser: CmdLineParser = new CmdLineParser(inst)
+    val parser = new CmdLineParser(inst)
     try {
       parser.parseArgument(args.toList.asJava)
 

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
@@ -1,0 +1,86 @@
+package ml.dmlc.mxnet.examples.module
+
+import ml.dmlc.mxnet._
+import ml.dmlc.mxnet.module.Module
+import ml.dmlc.mxnet.DataDesc._
+import ml.dmlc.mxnet.optimizer.SGD
+import org.kohsuke.args4j.{Option, CmdLineParser}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+object MnistMlp {
+  private val logger = LoggerFactory.getLogger(classOf[MnistMlp])
+
+  def getSymbol: Symbol = {
+    val data = Symbol.Variable("data")
+    val fc1 = Symbol.FullyConnected(name = "fc1")(data)(Map("num_hidden" -> 128))
+    val act1 = Symbol.Activation(name = "relu1")(fc1)(Map("act_type" -> "relu"))
+    val fc2 = Symbol.FullyConnected(name = "fc2")(act1)(Map("num_hidden" -> 64))
+    val act2 = Symbol.Activation(name = "relu2")(fc2)(Map("act_type" -> "relu"))
+    val fc3 = Symbol.FullyConnected(name = "fc3")(act2)(Map("num_hidden" -> 10))
+    val softmax = Symbol.SoftmaxOutput(name = "softmax")(fc3)()
+    softmax
+  }
+
+  def main(args: Array[String]): Unit = {
+    val inst = new MnistMlp
+    val parser: CmdLineParser = new CmdLineParser(inst)
+    try {
+      parser.parseArgument(args.toList.asJava)
+
+      val train = IO.MNISTIter(Map(
+        "image" -> (inst.dataDir + "train-images-idx3-ubyte"),
+        "label" -> (inst.dataDir + "train-labels-idx1-ubyte"),
+        "label_name" -> "softmax_label",
+        "input_shape" -> "(784,)",
+        "batch_size" -> inst.batchSize.toString,
+        "shuffle" -> "True",
+        "flat" -> "True", "silent" -> "False", "seed" -> "10"))
+      val eval = IO.MNISTIter(Map(
+        "image" -> (inst.dataDir + "t10k-images-idx3-ubyte"),
+        "label" -> (inst.dataDir + "t10k-labels-idx1-ubyte"),
+        "label_name" -> "softmax_label",
+        "input_shape" -> "(784,)",
+        "batch_size" -> inst.batchSize.toString,
+        "flat" -> "True", "silent" -> "False"))
+
+      // Intermediate-level API
+      val mod = new Module(getSymbol)
+      mod.bind(dataShapes = train.provideData, labelShapes = Some(train.provideLabel))
+      mod.initParams()
+      mod.initOptimizer(optimizer = new SGD(learningRate = 0.01f, momentum = 0.9f))
+
+      val metric = new Accuracy()
+
+      for (epoch <- 0 until inst.numEpoch) {
+        while (train.hasNext) {
+          val batch = train.next()
+          mod.forward(batch)
+          mod.updateMetric(metric, batch.label)
+          mod.backward()
+          mod.update()
+        }
+
+        val (name, value) = metric.get
+        logger.info(s"epoch $epoch $name=$value")
+        metric.reset()
+        train.reset()
+      }
+    } catch {
+      case ex: Exception =>
+        logger.error(ex.getMessage, ex)
+        parser.printUsage(System.err)
+        sys.exit(1)
+    }
+  }
+}
+
+class MnistMlp {
+  @Option(name = "--data-dir", usage = "the input data directory")
+  private val dataDir: String = "mnist/"
+  @Option(name = "--batch-size", usage = "the batch size for data iterator")
+  private val batchSize: Int = 2
+  @Option(name = "--num-epoch", usage = "number of training epoches")
+  private val numEpoch: Int = 10
+}

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/MnistMlp.scala
@@ -80,7 +80,7 @@ object MnistMlp {
       val preds = mod.predict(batch)
       val predLabel: Array[Int] = NDArray.argmax_channel(preds(0)).toArray.map(_.toInt)
       val label = batch.label(0).toArray.map(_.toInt)
-      val acc = (predLabel zip label).map { case (py, y) =>
+      val acc = predLabel.zip(label).map { case (py, y) =>
         if (py == y) 1 else 0
       }.sum / predLabel.length.toFloat
       if (iBatch % 20 == 0) {


### PR DESCRIPTION
Here's what I got for `examples/scripts/module/mnist_mlp.sh`:

```
[01:10:54] src/io/iter_mnist.cc:91: MNISTIter: load 60000 images, shuffle=1, shape=(10,784)
[01:10:54] src/io/iter_mnist.cc:91: MNISTIter: load 10000 images, shuffle=1, shape=(10,784)
2017-02-11 01:11:03,389 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 0 accuracy=0.81295
2017-02-11 01:11:11,801 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 1 accuracy=0.96045
2017-02-11 01:11:19,246 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 2 accuracy=0.97318333
2017-02-11 01:11:26,635 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 3 accuracy=0.9789
2017-02-11 01:11:34,581 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 4 accuracy=0.9823
2017-02-11 01:11:42,359 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 5 accuracy=0.98415
2017-02-11 01:11:51,417 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 6 accuracy=0.9867333
2017-02-11 01:11:59,458 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 7 accuracy=0.9877333
2017-02-11 01:12:07,118 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 8 accuracy=0.9887667
2017-02-11 01:12:16,234 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - epoch 9 accuracy=0.9888833
2017-02-11 01:12:23,087 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Train-accuracy=0.13861667
2017-02-11 01:12:23,087 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Time cost=6826
2017-02-11 01:12:23,365 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Validation-accuracy=0.3904
2017-02-11 01:12:29,399 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Train-accuracy=0.74293333
2017-02-11 01:12:29,400 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Time cost=6035
2017-02-11 01:12:29,716 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Validation-accuracy=0.8561
2017-02-11 01:12:37,259 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[2] Train-accuracy=0.89135
2017-02-11 01:12:37,259 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[2] Time cost=7543
2017-02-11 01:12:37,634 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[2] Validation-accuracy=0.9165
2017-02-11 01:12:45,638 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[3] Train-accuracy=0.92903334
2017-02-11 01:12:45,638 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[3] Time cost=8004
2017-02-11 01:12:45,929 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[3] Validation-accuracy=0.9394
2017-02-11 01:12:53,964 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[4] Train-accuracy=0.9471167
2017-02-11 01:12:53,965 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[4] Time cost=8036
2017-02-11 01:12:54,508 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[4] Validation-accuracy=0.9514
2017-02-11 01:13:01,534 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[5] Train-accuracy=0.95783335
2017-02-11 01:13:01,535 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[5] Time cost=7026
2017-02-11 01:13:02,036 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[5] Validation-accuracy=0.9585
2017-02-11 01:13:08,396 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[6] Train-accuracy=0.9645333
2017-02-11 01:13:08,396 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[6] Time cost=6359
2017-02-11 01:13:08,663 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[6] Validation-accuracy=0.9637
2017-02-11 01:13:14,277 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[7] Train-accuracy=0.96955
2017-02-11 01:13:14,277 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[7] Time cost=5614
2017-02-11 01:13:14,523 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[7] Validation-accuracy=0.9666
2017-02-11 01:13:20,128 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[8] Train-accuracy=0.9734667
2017-02-11 01:13:20,128 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[8] Time cost=5605
2017-02-11 01:13:20,376 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[8] Validation-accuracy=0.969
2017-02-11 01:13:26,104 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[9] Train-accuracy=0.9767
2017-02-11 01:13:26,104 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[9] Time cost=5728
2017-02-11 01:13:26,350 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[9] Validation-accuracy=0.9711
2017-02-11 01:13:26,353 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 0 acc: 1.0
2017-02-11 01:13:26,362 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 20 acc: 1.0
2017-02-11 01:13:26,370 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 40 acc: 0.9
2017-02-11 01:13:26,377 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 60 acc: 1.0
2017-02-11 01:13:26,383 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 80 acc: 0.9
2017-02-11 01:13:26,390 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 100 acc: 1.0
2017-02-11 01:13:26,396 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 120 acc: 0.9
2017-02-11 01:13:26,403 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 140 acc: 1.0
2017-02-11 01:13:26,409 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 160 acc: 1.0
2017-02-11 01:13:26,415 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 180 acc: 1.0
2017-02-11 01:13:26,423 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 200 acc: 1.0
2017-02-11 01:13:26,431 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 220 acc: 1.0
2017-02-11 01:13:26,437 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 240 acc: 1.0
2017-02-11 01:13:26,443 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 260 acc: 1.0
2017-02-11 01:13:26,449 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 280 acc: 1.0
2017-02-11 01:13:26,455 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 300 acc: 0.9
2017-02-11 01:13:26,461 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 320 acc: 1.0
2017-02-11 01:13:26,467 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 340 acc: 1.0
2017-02-11 01:13:26,473 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 360 acc: 1.0
2017-02-11 01:13:26,479 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 380 acc: 1.0
2017-02-11 01:13:26,485 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 400 acc: 1.0
2017-02-11 01:13:26,491 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 420 acc: 1.0
2017-02-11 01:13:26,497 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 440 acc: 1.0
2017-02-11 01:13:26,503 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 460 acc: 1.0
2017-02-11 01:13:26,509 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 480 acc: 1.0
2017-02-11 01:13:26,515 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 500 acc: 0.9
2017-02-11 01:13:26,521 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 520 acc: 1.0
2017-02-11 01:13:26,528 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 540 acc: 1.0
2017-02-11 01:13:26,536 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 560 acc: 1.0
2017-02-11 01:13:26,542 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 580 acc: 1.0
2017-02-11 01:13:26,548 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 600 acc: 1.0
2017-02-11 01:13:26,554 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 620 acc: 1.0
2017-02-11 01:13:26,559 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 640 acc: 1.0
2017-02-11 01:13:26,565 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 660 acc: 1.0
2017-02-11 01:13:26,570 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 680 acc: 1.0
2017-02-11 01:13:26,576 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 700 acc: 1.0
2017-02-11 01:13:26,582 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 720 acc: 1.0
2017-02-11 01:13:26,588 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 740 acc: 1.0
2017-02-11 01:13:26,594 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 760 acc: 1.0
2017-02-11 01:13:26,600 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 780 acc: 1.0
2017-02-11 01:13:26,606 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 800 acc: 0.8
2017-02-11 01:13:26,612 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 820 acc: 1.0
2017-02-11 01:13:26,617 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 840 acc: 1.0
2017-02-11 01:13:26,622 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 860 acc: 1.0
2017-02-11 01:13:26,628 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 880 acc: 0.9
2017-02-11 01:13:26,633 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 900 acc: 1.0
2017-02-11 01:13:26,640 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 920 acc: 1.0
2017-02-11 01:13:26,646 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 940 acc: 1.0
2017-02-11 01:13:26,652 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 960 acc: 0.9
2017-02-11 01:13:26,657 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Batch 980 acc: 0.9
2017-02-11 01:13:27,236 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Validation Accuracy: 0.9711
2017-02-11 01:13:27,490 [main] [ml.dmlc.mxnet.examples.module.MnistMlp] [INFO] - Scored accuracy = 0.9711
```