### PR TITLE
fix #4584

### DIFF
--- a/src/operator/tensor/broadcast_reduce_op_index.cc
+++ b/src/operator/tensor/broadcast_reduce_op_index.cc
@@ -12,7 +12,7 @@ MXNET_OPERATOR_REGISTER_REDUCE_AXIS(argmax)
 .set_attr<FCompute>("FCompute<cpu>", SearchAxisCompute<cpu, mshadow::red::maximum>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    return MakeGradNode("_zeros", n, {}, {});
+    return MakeGradNode("_zeros", n, {}, {{}});
 });
 
 MXNET_OPERATOR_REGISTER_REDUCE_AXIS(argmin)
@@ -20,7 +20,7 @@ MXNET_OPERATOR_REGISTER_REDUCE_AXIS(argmin)
 .set_attr<FCompute>("FCompute<cpu>", SearchAxisCompute<cpu, mshadow::red::minimum>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    return MakeGradNode("_zeros", n, {}, {});
+    return MakeGradNode("_zeros", n, {}, {{}});
 });
 
 // Legacy support

--- a/src/operator/tensor/elemwise_unary_op.cc
+++ b/src/operator/tensor/elemwise_unary_op.cc
@@ -32,7 +32,7 @@ MXNET_OPERATOR_REGISTER_UNARY(BlockGrad)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
     // pass back zero gradient
-    return MakeGradNode("_zeros", n, {}, {});
+    return MakeGradNode("_zeros", n, {}, {{}});
 });
 
 // identity output as first input, but attributes are constrainted to be like rhs

--- a/src/operator/tensor/ordering_op.cc
+++ b/src/operator/tensor/ordering_op.cc
@@ -34,7 +34,7 @@ NNVM_REGISTER_OP(topk)
       }
       return MakeGradNode("_backward_topk", n, heads, n->attrs.dict);
     } else {
-      return MakeGradNode("_zeros", n, {}, {});
+      return MakeGradNode("_zeros", n, {}, {{}});
     }
   })
 .set_attr<FResourceRequest>("FResourceRequest",
@@ -95,7 +95,7 @@ NNVM_REGISTER_OP(argsort)
 .set_attr<FCompute>("FCompute<cpu>", ArgSort<cpu>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    return MakeGradNode("_zeros", n, {}, {});
+    return MakeGradNode("_zeros", n, {}, {{}});
   })
 .set_attr<FResourceRequest>("FResourceRequest",
   [](const NodeAttrs& attrs) {


### PR DESCRIPTION
When I build the project using g++ 4.9.2, I get
`error: converting to ‘std::unordered_map<std::basic_string<char>, std::basic_string<char> >’ from initializer list would use explicit constructor`
As in c++11, the definition of the default constructor of unordered_map is explicit.
http://stackoverflow.com/questions/26947704/implicit-conversion-failure-from-initializer-list