### PR TITLE
Added epsilon to `CrossEntropy` loss to avoid divison by zero errors.

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -288,6 +288,7 @@ class CrossEntropy(EvalMetric):
 
     def update(self, labels, preds):
         check_label_shapes(labels, preds)
+        eps = 1e-8
 
         for label, pred in zip(labels, preds):
             label = label.asnumpy()
@@ -297,7 +298,7 @@ class CrossEntropy(EvalMetric):
             assert label.shape[0] == pred.shape[0]
 
             prob = pred[numpy.arange(label.shape[0]), numpy.int64(label)]
-            self.sum_metric += (-numpy.log(prob)).sum()
+            self.sum_metric += (-numpy.log(prob + eps)).sum()
             self.num_inst += label.shape[0]
 
 class Torch(EvalMetric):

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -283,12 +283,12 @@ class RMSE(EvalMetric):
 
 class CrossEntropy(EvalMetric):
     """Calculate Cross Entropy loss"""
-    def __init__(self):
+    def __init__(self, eps = 1e-8):
         super(CrossEntropy, self).__init__('cross-entropy')
+        self.eps = eps
 
     def update(self, labels, preds):
         check_label_shapes(labels, preds)
-        eps = 1e-8
 
         for label, pred in zip(labels, preds):
             label = label.asnumpy()
@@ -298,7 +298,7 @@ class CrossEntropy(EvalMetric):
             assert label.shape[0] == pred.shape[0]
 
             prob = pred[numpy.arange(label.shape[0]), numpy.int64(label)]
-            self.sum_metric += (-numpy.log(prob + eps)).sum()
+            self.sum_metric += (-numpy.log(prob + self.eps)).sum()
             self.num_inst += label.shape[0]
 
 class Torch(EvalMetric):

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -283,7 +283,7 @@ class RMSE(EvalMetric):
 
 class CrossEntropy(EvalMetric):
     """Calculate Cross Entropy loss"""
-    def __init__(self, eps = 1e-8):
+    def __init__(self, eps=1e-8):
         super(CrossEntropy, self).__init__('cross-entropy')
         self.eps = eps
 


### PR DESCRIPTION
When using the `CrossEntropy` loss the `prob` (i.e., probabilities) variable can potentially have zeros in the array. When this happens, taking the log results in a division by zero error, similar to the one seen below:

<pre>/home/adrian/.virtualenvs/dlbook/local/lib/python2.7/site-packages/mxnet/metric.py:298: RuntimeWarning: divide by zero encountered in log
  self.sum_metric += (-numpy.log(prob)).sum()</pre>

By adding a small epsilon to `prob` we can avoid this division by zero error.