### PR TITLE
enable transpose flags for batch_dot

### DIFF
--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -251,9 +251,10 @@ NNVM_REGISTER_OP(_backward_dot)
 
 NNVM_REGISTER_OP(batch_dot)
 .MXNET_DESCRIBE("Calculate batched dot product of two matrices."
-                " (batch, M, K) batch_dot (batch, K, N) --> (batch, M, N)")
+                " (batch, M, K) X (batch, K, N) --> (batch, M, N).")
 .set_num_inputs(2)
 .set_num_outputs(1)
+.set_attr_parser(ParamParser<DotParam>)
 .set_attr<nnvm::FListInputNames>("FListInputNames",
   [](const NodeAttrs& attrs) {
     return std::vector<std::string>{"lhs", "rhs"};
@@ -267,11 +268,13 @@ NNVM_REGISTER_OP(batch_dot)
 .set_attr<FCompute>("FCompute<cpu>", BatchDotForward_<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_batch_dot"})
 .add_argument("lhs", "NDArray", "Left input")
-.add_argument("rhs", "NDArray", "Right input");
+.add_argument("rhs", "NDArray", "Right input")
+.add_arguments(DotParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_batch_dot)
 .set_num_inputs(3)
 .set_num_outputs(2)
+.set_attr_parser(ParamParser<DotParam>)
 .set_attr<FResourceRequest>("FResourceRequest",
   [](const NodeAttrs& attrs) {
     return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};


### PR DESCRIPTION
Like dot, we can avoid the unnecessary transpose by setting the flags in batch_dot. It could simplify the code + accelerate the speed.