### PR TITLE
Enabled loading of saved NDArray with GPU context in CPU only environ…

### DIFF
--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -637,7 +637,11 @@ bool NDArray::Load(dmlc::Stream *strm) {
   if (ctx.dev_mask() == cpu::kDevMask) {
     *this = std::move(temp); return true;
   } else {
+#if MXNET_USE_CUDA
     *this = temp.Copy(ctx); return true;
+#else
+    *this = std::move(temp); return true;
+#endif
   }
 }
 


### PR DESCRIPTION
To resolve issue 4597 <https://github.com/dmlc/mxnet/issues/4597>

Enabled NDArray loading method to load saved NDArray file with GPU context in a CPU only environment.