### PR TITLE
Fixing missing XML R package and installation issue for R on Ubuntu

### DIFF
--- a/docs/get_started/ubuntu_setup.md
+++ b/docs/get_started/ubuntu_setup.md
@@ -64,6 +64,17 @@ You can view the installation script we just used to install MXNet for Python [h
 
 ### Install MXNet for R
 
+MXNet requires R-version to be 3.2.0 and above. If you are running earlier version of R, run below commands to update your R version, before running the installation script.
+
+```bash
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+    sudo add-apt-repository ppa:marutter/rdev
+
+    sudo apt-get update
+    sudo apt-get upgrade
+    sudo apt-get install r-base r-base-dev
+```
+
 To install MXNet for R:
 
 ```bash

--- a/setup-utils/install-mxnet-ubuntu-r.sh
+++ b/setup-utils/install-mxnet-ubuntu-r.sh
@@ -2,7 +2,7 @@
 ######################################################################
 # This script installs MXNet for R along with all required dependencies on a Ubuntu Machine.
 # We recommend to install Microsoft RServer together with Intel MKL library for optimal performance
-# More information can be found here: 
+# More information can be found here:
 # https://blogs.technet.microsoft.com/machinelearning/2016/09/15/building-deep-neural-networks-in-the-cloud-with-azure-gpu-vms-mxnet-and-microsoft-r-server/
 # Tested on Ubuntu 14.04+ distro.
 ######################################################################
@@ -29,16 +29,18 @@ fi
 # libcurl4-openssl-dev and libssl-dev are needed for devtools.
 sudo apt-get -y install libcurl4-openssl-dev libssl-dev
 
+# Needed for R XML
+sudo apt-get install libxml2-dev
+
 sudo Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')"
 cd R-package
 sudo Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cran.rstudio.com')); install_deps(dependencies = TRUE)"
 cd ..
 
 echo "Compiling R package. This can take few minutes..."
-make rpkg
+sudo make rpkg
 
 echo "Installing R package..."
 sudo R CMD INSTALL mxnet_current_r.tar.gz
 
 echo "Done! MXNet for R installation is complete. Go ahead and explore MXNet with R :-)"
-


### PR DESCRIPTION
* Installation script for MXNet with R on Ubuntu was failing due to missing XML related package. Updated script to include this package.
* Minimum R version to run installation script is 3.2.0. Updated installation guide to cover this aspect and give commands to users to upgrade R.