### PR TITLE
fix when image_encode failed in im2rec.py

### DIFF
--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -103,6 +103,7 @@ def image_encode(args, i, item, q_out):
         except Exception, e:
             traceback.print_exc()
             print('pack_img error:', item[1], e)
+            q_out.put((i, None, item))
         return
 
     try:
@@ -110,9 +111,11 @@ def image_encode(args, i, item, q_out):
     except:
         traceback.print_exc()
         print('imread error trying to load file: %s ' % fullpath)
+        q_out.put((i, None, item))
         return
     if img is None:
         print('imread read blank (None) image for file: %s' % fullpath)
+        q_out.put((i, None, item))
         return
     if args.center_crop:
         if img.shape[0] > img.shape[1]:
@@ -134,6 +137,7 @@ def image_encode(args, i, item, q_out):
     except Exception, e:
         traceback.print_exc()
         print('pack_img error on file: %s' % fullpath, e)
+        q_out.put((i, None, item))
         return
 
 def read_worker(args, q_in, q_out):
@@ -164,7 +168,8 @@ def write_worker(q_out, fname, working_dir):
         while count in buf:
             s, item = buf[count]
             del buf[count]
-            record.write_idx(item[0], s)
+            if s is not None:
+                record.write_idx(item[0], s)
 
             if count % 1000 == 0:
                 cur_time = time.time()


### PR DESCRIPTION
When use multiprocessing to pack images, if some images are missing, the `count` won't increase due to the missing index.