### PR TITLE
Update docs/how_to/cloud.md.

### DIFF
--- a/docs/how_to/cloud.md
+++ b/docs/how_to/cloud.md
@@ -119,7 +119,8 @@ directory of the root computer, such as `~/train`, and MXNet is built as `~/mxne
   And then copy the training program:
 
   ```bash
-  cp ~/mxnet/example/image-classification/*.py 
+  cp ~/mxnet/example/image-classification/*.py .
+  cp -r ~/mxnet/example/image-classification/common .
   ```
 
 2. Prepare a host file with all slaves's private IPs. For example, `cat hosts`:

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -284,7 +284,7 @@ class KVStore(object):
 
     @property
     def num_workers(self):
-        """Get the number of worker ndoes
+        """Get the number of worker nodes
 
         Returns
         -------


### PR DESCRIPTION
    Fix a bug in docs/how_to/cloud.md, which may cause “import error, package common not found”. This bug is caused by copying all python scripts without copying common dir.
    Fix a typo in python/mxnet/kvstore.py.