### PR TITLE
added fix for nonsquare stride during backprop

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -267,7 +267,9 @@ class ConvolutionOp : public Operator {
                               param_.kernel[0],
                               param_.kernel[1],
                               param_.stride[0],
-                              param_.dilate[0]));
+                              param_.stride[1],
+                              param_.dilate[0],
+                              param_.dilate[1]));
       } else {
         Shape<4> pshape = data.Slice(i, i + step).shape_;
         pshape[2] += 2 * param_.pad[0];
@@ -278,7 +280,9 @@ class ConvolutionOp : public Operator {
                                    param_.kernel[0],
                                    param_.kernel[1],
                                    param_.stride[0],
-                                   param_.dilate[0]),
+                                   param_.stride[1],
+                                   param_.dilate[0],
+                                   param_.dilate[1]),
                     gdata[i][0].shape_));
       }
     }


### PR DESCRIPTION
The fix was added for patch2col but not for col2patch.