### PR TITLE
disable cython to prevent strange import error

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -72,5 +72,5 @@ setup(name='mxnet',
           'mxnet._cy2', 'mxnet._cy3', 'mxnet.notebook'
           ],
       data_files=[('mxnet', [LIB_PATH[0]])],
-      url='https://github.com/dmlc/mxnet',
-      ext_modules=config_cython())
+      url='https://github.com/dmlc/mxnet')
+      #ext_modules=config_cython())  # causes strange import error for some users.


### PR DESCRIPTION
https://github.com/dmlc/minpy/issues/131#issuecomment-274229165
https://github.com/dmlc/mxnet/issues/4746

strange error. cannot reproduce. but seems to be common for a lot of users. but looks like this will fix it.