### PR TITLE
Enhencement on build

### DIFF
--- a/amalgamation/Makefile
+++ b/amalgamation/Makefile
@@ -5,17 +5,22 @@ export OPENBLAS_ROOT=/usr/local/opt/openblas
 # Whether use minimum build without blas and SSE, this will make the library super slow
 ifndef MIN
 	export MIN=0
+	DEFS=-DMSHADOW_USE_CBLAS=1
+else
+	DEFS=-DMSHADOW_USE_CBLAS=0
 endif
 
 ifndef ANDROID
     export ANDROID=0
+else
+	DEFS+=-DMSHADOW_USE_SSE=0
 endif
 
 
 .PHONY: all clean
 
-
-CFLAGS=-std=c++11 -Wno-unknown-pragmas -Wall
+DEFS+=-DMSHADOW_USE_CUDA=0 -DMSHADOW_USE_MKL=0 -DMSHADOW_RABIT_PS=0 -DMSHADOW_DIST_PS=0 -DMSHADOW_FORCE_STREAM -DMXNET_USE_OPENCV=1 -DMXNET_PREDICT_ONLY=1 -DDISABLE_OPENMP=1
+CFLAGS=-std=c++11 -Wno-unknown-pragmas -Wall $(DEFS)
 ifneq ($(MIN), 1)
 	CFLAGS += -I${OPENBLAS_ROOT} -I${OPENBLAS_ROOT}/include
 	LDFLAGS+= -L${OPENBLAS_ROOT} -L${OPENBLAS_ROOT}/lib -lopenblas
@@ -28,21 +33,19 @@ nnvm.d:
 	./prep_nnvm.sh
 
 dmlc.d: dmlc-minimum0.cc
-	${CXX} ${CFLAGS} -MD -MF $@ \
+	${CXX} ${CFLAGS} -M -MT dmlc-minimum0.o \
 	-I ${MXNET_ROOT}/dmlc-core/include \
-	-D__MIN__=$(MIN) -c $+
-	rm dmlc-minimum0.o
+	-D__MIN__=$(MIN) $+ > dmlc.d
 
 
 mxnet_predict0.d: mxnet_predict0.cc nnvm.d dmlc.d
-	${CXX} ${CFLAGS} -MD -MF $@ \
+	${CXX} ${CFLAGS} -M -MT mxnet_predict0.o \
 	-I ${MXNET_ROOT}/ -I ${MXNET_ROOT}/mshadow/ -I ${MXNET_ROOT}/dmlc-core/include \
 	-I ${MXNET_ROOT}/nnvm/include \
 	-I ${MXNET_ROOT}/include \
-	-D__MIN__=$(MIN) -c mxnet_predict0.cc
+	-D__MIN__=$(MIN) mxnet_predict0.cc > mxnet_predict0.d
 	cat dmlc.d >> mxnet_predict0.d
 	cat nnvm.d >> mxnet_predict0.d
-	rm mxnet_predict0.o
 
 mxnet_predict-all.cc:  mxnet_predict0.d dmlc-minimum0.cc nnvm.cc mxnet_predict0.cc
 	@echo "Generating amalgamation to " $@
@@ -61,7 +64,6 @@ jni_libmxnet_predict.so: jni_libmxnet_predict.o
 	${CXX} ${CFLAGS} -shared -o $@ $(filter %.o %.a, $^) $(LDFLAGS)
 
 ifneq ($(ANDROID), 1)
-        LDFLAGS+= -lrt
         android:
 else
         CFLAGS+=  -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -O3
@@ -70,7 +72,7 @@ else
 endif
 
 libmxnet_predict.js: mxnet_predict-all.cc
-	emcc -std=c++11 -O2 -D__MXNET_JS__  -o $@ $+ \
+	emcc -std=c++11 -O2 $(DEFS) -DMSHADOW_USE_SSE=0 -D__MXNET_JS__  -o $@ $+ \
 	-s EXPORTED_FUNCTIONS="['_MXPredCreate', '_MXPredGetOutputShape', '_MXPredSetInput', '_MXPredForward', '_MXPredPartialForward', '_MXPredGetOutput', '_MXPredFree', '_MXNDListCreate', '_MXNDListGet', '_MXNDListFree']" \
 	-s ALLOW_MEMORY_GROWTH=1
 

--- a/amalgamation/mxnet_predict0.cc
+++ b/amalgamation/mxnet_predict0.cc
@@ -1,29 +1,5 @@
 // mexnet.cc
 
-#define MSHADOW_FORCE_STREAM
-
-#ifndef MSHADOW_USE_CBLAS
-#if (__MIN__ == 1)
-#define MSHADOW_USE_CBLAS   0
-#else
-#define MSHADOW_USE_CBLAS   1
-#endif
-#endif
-
-#define MSHADOW_USE_CUDA    0
-#define MSHADOW_USE_MKL     0
-#define MSHADOW_RABIT_PS    0
-#define MSHADOW_DIST_PS     0
-
-#if defined(__ANDROID__) || defined(__MXNET_JS__)
-#define MSHADOW_USE_SSE         0
-#endif
-
-#define MXNET_USE_OPENCV    0
-#define MXNET_PREDICT_ONLY  1
-#define DISABLE_OPENMP 1
-
-
 #include "src/ndarray/ndarray_function.cc"
 #include "src/ndarray/ndarray.cc"
 

--- a/amalgamation/prep_nnvm.sh
+++ b/amalgamation/prep_nnvm.sh
@@ -3,20 +3,7 @@ cd ../nnvm/amalgamation
 make clean
 make nnvm.d
 cp nnvm.d ../../amalgamation/
-echo '#define MSHADOW_FORCE_STREAM
-
-#ifndef MSHADOW_USE_CBLAS
-#if (__MIN__ == 1)
-#define MSHADOW_USE_CBLAS   0
-#else
-#define MSHADOW_USE_CBLAS   1
-#endif
-#endif
-#define MSHADOW_USE_CUDA    0
-#define MSHADOW_USE_MKL     0
-#define MSHADOW_RABIT_PS    0
-#define MSHADOW_DIST_PS     0
-
+echo '
 #include "mshadow/tensor.h"
 #include "mxnet/base.h"
 #include "dmlc/json.h"


### PR DESCRIPTION
Move macro to build command line to avoid the issues causes by order of macro defined. Also reduce the duplicated logic in two places.
Avoid compile the code when generate .d file to reduce compile significant