### PR TITLE
[Scala] Add default name to NDArrayIter data and labels

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
@@ -25,7 +25,8 @@ import scala.collection.immutable.ListMap
  */
 class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = IndexedSeq.empty,
                   private val dataBatchSize: Int = 1, shuffle: Boolean = false,
-                  lastBatchHandle: String = "pad") extends DataIter {
+                  lastBatchHandle: String = "pad",
+                  dataName: String = "data", labelName: String = "label") extends DataIter {
   private val logger = LoggerFactory.getLogger(classOf[NDArrayIter])
 
 
@@ -60,8 +61,8 @@ class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = Index
   }
 
 
-  val initData: IndexedSeq[(String, NDArray)] = IO.initData(_dataList, false, "data")
-  val initLabel: IndexedSeq[(String, NDArray)] = IO.initData(_labelList, true, "label")
+  val initData: IndexedSeq[(String, NDArray)] = IO.initData(_dataList, false, dataName)
+  val initLabel: IndexedSeq[(String, NDArray)] = IO.initData(_labelList, true, labelName)
   val numData = _dataList(0).shape(0)
   val numSource = initData.size
   var cursor = -dataBatchSize


### PR DESCRIPTION
Add dataName and labelName as parameter to the NDArrayIter constructor.
Fix #4755 