### PR TITLE
[scala-package] remove confusing warning logging

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
@@ -76,7 +76,6 @@ object Base {
       System.loadLibrary(libname)
     } catch {
       case e: UnsatisfiedLinkError =>
-        logger.warn("Failed to load from native path. Exception:", e)
         val os = System.getProperty("os.name")
         // ref: http://lopica.sourceforge.net/os.html
         if (os.startsWith("Linux")) {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Base.scala
@@ -49,8 +49,7 @@ object Base {
           "Copying native library from the archive. " +
           "Consider installing the library somewhere in the path " +
           "(for Windows: PATH, for Linux: LD_LIBRARY_PATH), " +
-          "or specifying by Java cmd option -Djava.library.path=[lib path]." +
-          "Exception:", e)
+          "or specifying by Java cmd option -Djava.library.path=[lib path].")
         NativeLibraryLoader.loadLibrary("mxnet-scala")
     }
   } catch {


### PR DESCRIPTION
remove confusing warning log 

this line and exception info is actually unnecessary considering that the loader will continue working and throw an exception after all attempts fail eventually