### PR TITLE
Add snapcraft packaging

### DIFF
--- a/snap.python
+++ b/snap.python
@@ -1,0 +1,5 @@
+export MXNET_HOME=$SNAP
+export LD_LIBRARY_PATH=${SNAP}/lib:${SNAP}/usr/lib:$LD_LIBRARY_PATH 
+export PYTHONPATH=$MXNET_HOME:${SNAP}/lib/python2.7/site-packages/:${SNAP}/usr/lib/python2.7/dist-packages/:$PYTHONPATH 
+
+exec ${SNAP}/usr/bin/python $@

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,50 @@
+name: mxnet
+version: '0.9.3'
+summary: MXNet is a deep learning framework designed for efficiency and flexibility.
+description: |
+  MXNet is a deep learning framework designed for both efficiency and 
+  flexibility. It allows you to mix the flavours of symbolic programming and 
+  imperative programming to maximize efficiency and productivity. In its core, 
+  a dynamic dependency scheduler that automatically parallelizes both symbolic 
+  and imperative operations on the fly. A graph optimization layer on top of 
+  that makes symbolic execution fast and memory efficient. The library is 
+  portable and lightweight, and it scales to multiple GPUs and multiple machines.
+
+grade: stable
+confinement: strict
+
+parts:
+  mxnet:
+    source: .
+    plugin: make
+    build-packages:
+      - build-essential
+      - libatlas-base-dev
+      - libopencv-dev
+    stage-packages:
+      - libatlas3-base
+      - libopencv-calib3d2.4v5
+      - libopencv-core2.4v5
+      - libopencv-highgui2.4v5
+      - libopencv-imgproc2.4v5
+      - libopencv-ml2.4v5
+      - libopencv-objdetect2.4v5
+    prepare: |
+      cp make/config.mk .
+    build: |
+      make
+    install: |
+      cp -r bin $SNAPCRAFT_PART_INSTALL/
+      cp -r lib $SNAPCRAFT_PART_INSTALL/
+    
+  mxnet-ubuntu-python:
+    plugin: python
+    python-version: python2
+    source: ./python
+    stage-packages:
+      - python-numpy
+    python-packages:
+      - graphviz
+      - Jupyter
+    after: [mxnet]
+

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,10 @@ description: |
 grade: stable
 confinement: strict
 
+apps:
+  python:
+    command: snap.python
+
 parts:
   mxnet:
     source: .
@@ -47,4 +51,12 @@ parts:
       - graphviz
       - Jupyter
     after: [mxnet]
+    
+  python-wrapper:
+    plugin: dump
+    source: .
+    stage:
+      - snap.python
+    prime:
+      - snap.python
 


### PR DESCRIPTION
Adds snapcraft build configuration and command to run an in-snap Python 2 runtime. This allows MXNet to be used either by calling "/snap/bin/mxnet.python" or by adding the following to your environment and using your system's python:

LD_LIBRARY_PATH=/snap/mxnet/current/lib:/snap/mxnet/current/usr/lib:$LD_LIBRARY_PATH 
PYTHONPATH=/snap/mxnet/current/lib/python2.7/site-packages/:/snap/mxnet/current/usr/lib/python2.7/dist-packages/:$PYTHONPATH

The snap can be build with "snapcraft snap" on Ubuntu 16.04 or later. Use "snapcraft cleanbuild" to build it in an LXC container instead.