### PR TITLE
fix bug in slice_channel op

### DIFF
--- a/src/operator/slice_channel-inl.h
+++ b/src/operator/slice_channel-inl.h
@@ -140,7 +140,9 @@ class SliceChannelProp : public OperatorProperty {
   std::vector<std::string> ListOutputs() const override {
     std::vector<std::string> ret;
     for (int i = 0; i < param_.num_outputs; ++i) {
-      ret.push_back(std::string("output") + static_cast<char>('0' + i));
+      std::ostringstream os;
+      os << "output" << i;
+      ret.push_back(os.str());
     }
     return ret;
   }


### PR DESCRIPTION
this PR fixes a bug in the `ListOutputs` function of the `slice_channel` op.

Before this fix this function will not produce digits after `output`, but letters and later non printable characters, if the number of outputs is larger than 10.
