### PR TITLE
Fixing double cloning issue in osx install script. 

### DIFF
--- a/docs/get_started/amazonlinux_setup.md
+++ b/docs/get_started/amazonlinux_setup.md
@@ -122,9 +122,34 @@ Executing these commands creates a library called ```libmxnet.so```
 &nbsp;
 
 We have installed MXNet core library. Next, we will install MXNet interface package for the programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
 - [R](#install-the-mxnet-package-for-r)
 - [Julia](#install-the-mxnet-package-for-julia)
 - [Scala](#install-the-mxnet-package-for-scala)
+
+### Install the MXNet Package for Python
+Next, we install Python interface for MXNet. Assuming you are in `~/mxnet` directory, run below commands.
+
+```bash
+	# Install MXNet Python package
+	cd python
+	sudo python setup.py install
+```
+
+Check if MXNet is properly installed.
+
+```bash
+	# You can change mx.cpu to mx.gpu
+	python
+	>>> import mxnet as mx
+	>>> a = mx.nd.ones((2, 3), mx.cpu())
+	>>> print ((a * 2).asnumpy())
+	[[ 2.  2.  2.]
+	 [ 2.  2.  2.]]
+```
+If you don't get an import error, then MXNet is ready for python.
+
+Note: You can update mxnet for python by repeating this step after re-building `libmxnet.so`.
 
 ### Install the MXNet Package for R
 Run the following commands to install the MXNet dependencies and build the MXNet R package.

--- a/docs/get_started/osx_setup.md
+++ b/docs/get_started/osx_setup.md
@@ -126,10 +126,34 @@ If building with ```GPU``` support, add the following configuration to config.mk
 &nbsp;
 
 We have installed MXNet core library. Next, we will install MXNet interface package for the programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
 - [R](#install-the-mxnet-package-for-r)
 - [Julia](#install-the-mxnet-package-for-julia)
 - [Scala](#install-the-mxnet-package-for-scala)
 
+### Install the MXNet Package for Python
+Next, we install Python interface for MXNet. Assuming you are in `~/mxnet` directory, run below commands.
+
+```bash
+	# Install MXNet Python package
+	cd python
+	sudo python setup.py install
+```
+
+Check if MXNet is properly installed.
+
+```bash
+	# You can change mx.cpu to mx.gpu
+	python
+	>>> import mxnet as mx
+	>>> a = mx.nd.ones((2, 3), mx.cpu())
+	>>> print ((a * 2).asnumpy())
+	[[ 2.  2.  2.]
+	 [ 2.  2.  2.]]
+```
+If you don't get an import error, then MXNet is ready for python.
+
+Note: You can update mxnet for python by repeating this step after re-building `libmxnet.so`.
 
 ### Install the MXNet Package for R
 You have 2 options:

--- a/docs/get_started/setup.md
+++ b/docs/get_started/setup.md
@@ -4,13 +4,13 @@ You can run MXNet on Amazon Linux, Ubuntu/Debian, OS X, and Windows operating sy
 
 Step by step instructions for setting up MXNet:
 
-- [MXNet with Docker](http://mxnet.io/get_started/docker_setup.html)
-- [Installing MXNet on the Cloud (AWS AMI)](http://mxnet.io/get_started/cloud_setup.html)
+- [Installing MXNet on OS X (Mac)](http://mxnet.io/get_started/osx_setup.html)
 - [Installing MXNet on Ubuntu](http://mxnet.io/get_started/ubuntu_setup.html)
+- [Installing MXNet on Windows](http://mxnet.io/get_started/windows_setup.html)
 - [Installing MXNet on Amazon Linux](http://mxnet.io/get_started/amazonlinux_setup.html)
 - [Installing MXNet on CentOS](http://mxnet.io/get_started/centos_setup.html)
-- [Installing MXNet on OS X (Mac)](http://mxnet.io/get_started/osx_setup.html)
-- [Installing MXNet on Windows](http://mxnet.io/get_started/windows_setup.html)
+- [MXNet with Docker](http://mxnet.io/get_started/docker_setup.html)
+- [Installing MXNet on the Cloud (AWS AMI)](http://mxnet.io/get_started/cloud_setup.html)
 - [Installing MXNet on Raspberry Pi (Raspbian)](http://mxnet.io/get_started/raspbian_setup.html)
 
 This topic also covers the following:

--- a/docs/get_started/ubuntu_setup.md
+++ b/docs/get_started/ubuntu_setup.md
@@ -148,9 +148,34 @@ Next, we install ```graphviz``` library that we use for visualizing network grap
 &nbsp;
 
 We have installed MXNet core library. Next, we will install MXNet interface package for programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
 - [R](#install-the-mxnet-package-for-r)
 - [Julia](#install-the-mxnet-package-for-julia)
 - [Scala](#install-the-mxnet-package-for-scala)
+
+### Install the MXNet Package for Python
+Next, we install Python interface for MXNet. Assuming you are in `~/mxnet` directory, run below commands.
+
+```bash
+	# Install MXNet Python package
+	cd python
+	sudo python setup.py install
+```
+
+Check if MXNet is properly installed.
+
+```bash
+	# You can change mx.cpu to mx.gpu
+	python
+	>>> import mxnet as mx
+	>>> a = mx.nd.ones((2, 3), mx.cpu())
+	>>> print ((a * 2).asnumpy())
+	[[ 2.  2.  2.]
+	 [ 2.  2.  2.]]
+```
+If you don't get an import error, then MXNet is ready for python.
+
+Note: You can update mxnet for python by repeating this step after re-building `libmxnet.so`.
 
 ### Install the MXNet Package for R
 

--- a/setup-utils/install-mxnet-osx-python.sh
+++ b/setup-utils/install-mxnet-osx-python.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 #
-# This scripts installs the dependencies, downloads MXNet source 
-# and compiles it. 
+# This scripts installs the dependencies and compiles
+# MXNet source.
 #
 # The script also installs the MXNet package for Python.
 #
 
 #set -ex
 
-export MXNET_HOME=`pwd`/mxnet
+export MXNET_HOME="$HOME/mxnet"
 export MXNET_LOG=${MXNET_HOME}/buildMXNet_mac.log
 # Insert the Homebrew directory at the top of your PATH environment variable
 export PATH=/usr/local/bin:/usr/local/sbin:$PATH
@@ -16,7 +16,7 @@ LINE="########################################################################"
 
 echo $LINE
 echo " "
-echo "This script installs MXNet on MacOS." 
+echo "This script installs MXNet on MacOS."
 echo "It has been tested to work successfully on MacOS El Capitan and Sierra"
 echo "and is expected to work fine on other versions as well."
 echo " "
@@ -60,8 +60,8 @@ runme brew_pkg_install pkg-config
 runme brew_pkg_install python
 brew install homebrew/science/openblas
 runme brew_pkg_install opencv
-# Needed for /usr/local/lib/graphviz to be created 
-runme brew_pkg_install graphviz  
+# Needed for /usr/local/lib/graphviz to be created
+runme brew_pkg_install graphviz
 runme brew_pkg_install numpy
 
 runme brew tap homebrew/science
@@ -71,17 +71,9 @@ runme pip install jupyter
 runme pip install cython
 
 #
-# Fetch MXNet source and compile it
+# Compile MXNet. It assumes you have checked out MXNet source to ~/mxnet
 #
-if [ -f ${MXNET_HOME} ]; then
-	ls -al ${MXNET_HOME}
-	echo " "
-	echo "ERROR: ${MXNET_HOME} directory already present"
-	echo "To correct the problem, please rename the directory or remove it."
-	echo " "
-fi
 
-runme git clone --recursive https://github.com/dmlc/mxnet
 cd ${MXNET_HOME}
 runme cp make/osx.mk ./config.mk
 runme echo "USE_BLAS = openblas" >> ./config.mk


### PR DESCRIPTION
1. There was a bug in osx install script. MXNet source was cloned 2 times. Fixing it.
2. There was no manual python package install guide for Python in Ubuntu/OSx/Amazon Linux. Adding it.