### PR TITLE
Add one hot op

### DIFF
--- a/src/ndarray/ndarray_function-inl.h
+++ b/src/ndarray/ndarray_function-inl.h
@@ -65,6 +65,7 @@ inline void EvalBinary_(const TBlob &lhs, const TBlob &rhs,
 template<typename xpu, typename OP>
 inline void EvalOneHot_(const TBlob &index, const TBlob &rhs,
                         TBlob *ret, RunContext ctx) {
+  LOG(INFO) << "The operator onehot_encode is deprecated; use one_hot instead.";
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   // TODO(eric): support mixed type encoding, i.e. int index and float rhs.

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -115,7 +115,9 @@ NNVM_REGISTER_OP(one_hot)
                 " indicating where to set on_value and depth,"
                 " return an output ndarray of shape (shape(indices), depth)."
                 " The off_value is marked everywhere else that"
-                " are not indicated in indices.")
+                " are not indicated in indices. If a location in the indices"
+                " is negative or greater than or equal to depth, assigning"
+                " on_value to that location will be ignored.")
 .set_num_outputs(1)
 .set_num_inputs(1)
 .set_attr_parser(ParamParser<OneHotParam>)

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -128,6 +128,7 @@ NNVM_REGISTER_OP(one_hot)
 .set_attr<nnvm::FInferShape>("FInferShape", OneHotOpShape)
 .set_attr<nnvm::FInferType>("FInferType", OneHotOpType)
 .set_attr<FCompute>("FCompute<cpu>", OneHotOpForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
 .add_argument("indices", "NDArray", "array of locations where to set on_value")
 .add_arguments(OneHotParam::__FIELDS__());
 

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -10,6 +10,7 @@ namespace mxnet {
 namespace op {
 DMLC_REGISTER_PARAMETER(EmbeddingParam);
 DMLC_REGISTER_PARAMETER(TakeParam);
+DMLC_REGISTER_PARAMETER(OneHotParam);
 
 NNVM_REGISTER_OP(Embedding)
 .MXNET_DESCRIBE("Map integer index to vector representations (embeddings)."
@@ -108,6 +109,25 @@ NNVM_REGISTER_OP(batch_take)
 .set_attr<FCompute>("FCompute<cpu>", BatchTakeOpForward<cpu>)
 .add_argument("a", "NDArray", "Input data array")
 .add_argument("indices", "NDArray", "index array");
+
+NNVM_REGISTER_OP(one_hot)
+.MXNET_DESCRIBE("Given an ndarray indices filled with locations"
+                " indicating where to set on_value and depth,"
+                " return an output ndarray of shape (shape(indices), depth)."
+                " The off_value is marked everywhere else that"
+                " are not indicated in indices.")
+.set_num_outputs(1)
+.set_num_inputs(1)
+.set_attr_parser(ParamParser<OneHotParam>)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"indices"};
+  })
+.set_attr<nnvm::FInferShape>("FInferShape", OneHotOpShape)
+.set_attr<nnvm::FInferType>("FInferType", OneHotOpType)
+.set_attr<FCompute>("FCompute<cpu>", OneHotOpForward<cpu>)
+.add_argument("indices", "NDArray", "array of locations where to set on_value")
+.add_arguments(OneHotParam::__FIELDS__());
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -23,6 +23,9 @@ NNVM_REGISTER_OP(_backward_take)
 NNVM_REGISTER_OP(batch_take)
 .set_attr<FCompute>("FCompute<gpu>", BatchTakeOpForward<gpu>);
 
+NNVM_REGISTER_OP(one_hot)
+.set_attr<FCompute>("FCompute<gpu>", OneHotOpForward<gpu>);
+
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -493,6 +493,138 @@ void BatchTakeOpForward(const nnvm::NodeAttrs& attrs,
   });
 }
 
+/*!
+ * \brief The parameters of the one_hot operator.
+ */
+struct OneHotParam : public dmlc::Parameter<OneHotParam> {
+  int depth;
+  double on_value;
+  double off_value;
+  int axis;
+  int dtype;
+  DMLC_DECLARE_PARAMETER(OneHotParam) {
+    DMLC_DECLARE_FIELD(depth)
+      .describe("The dimension size at dim = axis.");
+    DMLC_DECLARE_FIELD(on_value)
+      .set_default(1.0f)
+      .describe("The value assigned to the locations represented by indices.");
+    DMLC_DECLARE_FIELD(off_value)
+      .set_default(0.0f)
+      .describe("The value assigned to the locations not represented by indices.");
+    DMLC_DECLARE_FIELD(axis)
+      .set_default(-1)
+      .describe("The dimension position at which a new dimension will be created."
+                " So far, only axis = -1 is supported, which means a new dimension"
+                " is always appended at the end of the array. Setting it to other"
+                " numbers will cause the program to throw an exception");
+    DMLC_DECLARE_FIELD(dtype)
+      .set_default(mshadow::kFloat32)
+      .add_enum("float32", mshadow::kFloat32)
+      .add_enum("float64", mshadow::kFloat64)
+      .add_enum("float16", mshadow::kFloat16)
+      .add_enum("uint8", mshadow::kUint8)
+      .add_enum("int32", mshadow::kInt32)
+      .describe("DType of the output");
+  }
+};
+
+inline void GetOneHotParams(const OneHotParam& param, int* depth, double* on_value,
+                            double* off_value, int* axis, int* dtype) {
+  *depth = param.depth;
+  CHECK_GE(*depth, 0) << "Dimension size, depth, must be a non-negative integer";
+  *on_value = param.on_value;
+  *off_value = param.off_value;
+  *axis = param.axis;
+  CHECK_EQ(*axis, -1) << "Only support axis = -1 for now";
+  *dtype = param.dtype;
+  CHECK_EQ(*dtype == mshadow::kFloat32
+        || *dtype == mshadow::kFloat64
+        || *dtype == mshadow::kFloat16
+        || *dtype == mshadow::kUint8
+        || *dtype == mshadow::kInt32, true) << "dtype = " << dtype << " is not supported";
+}
+
+inline bool OneHotOpShape(const nnvm::NodeAttrs& attrs,
+                          std::vector<TShape> *in_attrs,
+                          std::vector<TShape> *out_attrs) {
+  const OneHotParam& param = nnvm::get<OneHotParam>(attrs.parsed);
+  CHECK_EQ(in_attrs->size(), 1);
+  CHECK_EQ(out_attrs->size(), 1);
+  // The shape of indices
+  const TShape& ishape = (*in_attrs)[0];
+
+  int depth = 0;
+  double on_value = 1.0;
+  double off_value = 0.0;
+  int axis = -1;
+  int dtype = mshadow::kFloat32;
+  GetOneHotParams(param, &depth, &on_value, &off_value, &axis, &dtype);
+
+  TShape oshape(ishape.ndim() + 1);
+  for (index_t i = 0; i < ishape.ndim(); ++i) {
+    oshape[i] = ishape[i];
+  }
+  oshape[oshape.ndim()-1] = depth;
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
+  return true;
+}
+
+inline bool OneHotOpType(const nnvm::NodeAttrs& attrs,
+                         std::vector<int>* in_attrs,
+                         std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1);
+  CHECK_EQ(out_attrs->size(), 1);
+  int depth = 0;
+  double on_value = 1.0;
+  double off_value = 0.0;
+  int axis = -1;
+  int dtype = mshadow::kFloat32;
+  const OneHotParam& param = nnvm::get<OneHotParam>(attrs.parsed);
+  GetOneHotParams(param, &depth, &on_value, &off_value, &axis, &dtype);
+  TYPE_ASSIGN_CHECK(*in_attrs, 0, mshadow::kInt32);
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, dtype);
+  return true;
+}
+
+struct one_hot {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, DType* out, const int* indices,
+                                  int depth, DType on_value, DType off_value) {
+    int offset = i * depth;
+    for (int j = 0; j < depth; ++j) {
+      out[offset+j] = off_value;
+    }
+    int j = indices[i];
+    if (j >= 0 && j < depth) {
+      out[offset+j] = on_value;
+    }
+  }
+};
+
+template<typename xpu>
+void OneHotOpForward(const nnvm::NodeAttrs& attrs,
+                     const OpContext& ctx,
+                     const std::vector<TBlob>& inputs,
+                     const std::vector<OpReqType>& req,
+                     const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1);
+  CHECK_EQ(outputs.size(), 1);
+  int depth = 0;
+  double on_value = 1.0;
+  double off_value = 0.0;
+  int axis = -1;
+  int dtype = mshadow::kFloat32;
+  const OneHotParam& param = nnvm::get<OneHotParam>(attrs.parsed);
+  GetOneHotParams(param, &depth, &on_value, &off_value, &axis, &dtype);
+  using namespace mxnet_op;
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
+    Kernel<one_hot, xpu>::Launch(s, inputs[0].Size(), outputs[0].dptr<DType>(),
+        inputs[0].dptr<int>(), depth,
+        static_cast<DType>(on_value), static_cast<DType>(off_value));
+  });
+}
+
 }  // namespace op
 }  // namespace mxnet
 #ifdef __CUDACC__

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -612,8 +612,8 @@ void OneHotOpForward(const nnvm::NodeAttrs& attrs,
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
-    mshadow::Tensor<xpu, 2, DType> out = outputs[0].FlatTo2D<xpu, DType>(s);
-    out = scalar<DType>(static_cast<DType>(off_value));
+    mshadow::Tensor<xpu, 1, DType> out = outputs[0].FlatTo1D<xpu, DType>(s);
+    out = static_cast<DType>(off_value);
     Kernel<one_hot, xpu>::Launch(s, inputs[0].Size(), outputs[0].dptr<DType>(),
         inputs[0].dptr<int>(), depth,
         static_cast<DType>(on_value), static_cast<DType>(off_value));

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -537,11 +537,6 @@ inline void GetOneHotParams(const OneHotParam& param, int* depth, double* on_val
   *axis = param.axis;
   CHECK_EQ(*axis, -1) << "Only support axis = -1 for now";
   *dtype = param.dtype;
-  CHECK_EQ(*dtype == mshadow::kFloat32
-        || *dtype == mshadow::kFloat64
-        || *dtype == mshadow::kFloat16
-        || *dtype == mshadow::kUint8
-        || *dtype == mshadow::kInt32, true) << "dtype = " << dtype << " is not supported";
 }
 
 inline bool OneHotOpShape(const nnvm::NodeAttrs& attrs,
@@ -591,9 +586,6 @@ struct one_hot {
   MSHADOW_XINLINE static void Map(int i, DType* out, const int* indices,
                                   int depth, DType on_value, DType off_value) {
     int offset = i * depth;
-    for (int j = 0; j < depth; ++j) {
-      out[offset+j] = off_value;
-    }
     int j = indices[i];
     if (j >= 0 && j < depth) {
       out[offset+j] = on_value;
@@ -617,8 +609,11 @@ void OneHotOpForward(const nnvm::NodeAttrs& attrs,
   const OneHotParam& param = nnvm::get<OneHotParam>(attrs.parsed);
   GetOneHotParams(param, &depth, &on_value, &off_value, &axis, &dtype);
   using namespace mxnet_op;
+  using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
+    mshadow::Tensor<xpu, 1, DType> out = outputs[0].FlatTo1D<xpu, DType>(s);
+    out = scalar<DType>(static_cast<DType>(off_value));
     Kernel<one_hot, xpu>::Launch(s, inputs[0].Size(), outputs[0].dptr<DType>(),
         inputs[0].dptr<int>(), depth,
         static_cast<DType>(on_value), static_cast<DType>(off_value));

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -612,7 +612,7 @@ void OneHotOpForward(const nnvm::NodeAttrs& attrs,
   using namespace mshadow::expr;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
-    mshadow::Tensor<xpu, 1, DType> out = outputs[0].FlatTo1D<xpu, DType>(s);
+    mshadow::Tensor<xpu, 2, DType> out = outputs[0].FlatTo2D<xpu, DType>(s);
     out = scalar<DType>(static_cast<DType>(off_value));
     Kernel<one_hot, xpu>::Launch(s, inputs[0].Size(), outputs[0].dptr<DType>(),
         inputs[0].dptr<int>(), depth,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2490,6 +2490,7 @@ def test_cast():
             assert_almost_equal(exe.outputs[0].asnumpy(), X.astype(srctype).astype(dsttype), threshold=5e-4)
             assert_almost_equal(exe.grad_arrays[0].asnumpy(), X.astype(dsttype).astype(srctype), threshold=5e-4)
 
+
 def test_repeat():
     def test_repeat_forward():
         ndim_max = 6 # max number of dims of the ndarray
@@ -2562,6 +2563,7 @@ def test_repeat():
     test_repeat_backward(axis=0)
     test_repeat_backward(axis=1)
     test_repeat_numeric_gradient()
+
 
 def test_tile():
     def test_normal_case():
@@ -2657,11 +2659,12 @@ def test_tile():
     test_tile_backward()
     test_tile_numeric_gradient()
 
+
 def test_one_hot():
     def test_normal_case():
         ndim_max = 6
         dim_size_max = 20
-        depth = dim_size_max / 2
+        depth = int(dim_size_max / 2)
         on_value = 1
         off_value = 0
         for ndim in range(1, ndim_max+1):
@@ -2672,7 +2675,7 @@ def test_one_hot():
                                         size=np.prod(shape)).reshape(shape)
             mx_one_hot_array = mx.nd.one_hot(
                 mx.nd.array(indices, ctx=default_context(), dtype=np.int32),
-                depth = depth, dtype=np.int32)
+                depth=depth, dtype=np.int32)
             expected_array = np.zeros((np.prod(shape), depth), dtype=np.int32)
             expected_array[:] = off_value
             indices_1d = indices.flatten()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2573,7 +2573,7 @@ def test_tile():
             shape = ()
             for i in range(0, ndim):
                 shape += (np.random.randint(1, size_max+1), )
-            a = np.random.random_integers(0, 100, shape)
+            a = np.random.randint(0, 100, shape)
             a = np.asarray(a, dtype=np.int32)
             if ndim == 0:
                 a = np.array([])
@@ -2657,6 +2657,55 @@ def test_tile():
     test_tile_backward()
     test_tile_numeric_gradient()
 
+def test_one_hot():
+    def test_normal_case():
+        ndim_max = 6
+        dim_size_max = 20
+        depth = dim_size_max / 2
+        on_value = 1
+        off_value = 0
+        for ndim in range(1, ndim_max+1):
+            shape = ()
+            for i in range(1, ndim+1):
+                shape += (np.random.randint(1, dim_size_max+1), )
+            indices = np.random.randint(-dim_size_max, dim_size_max+1,
+                                        size=np.prod(shape)).reshape(shape)
+            mx_one_hot_array = mx.nd.one_hot(mx.nd.array(indices, dtype=np.int32),
+                                             depth = depth, dtype=np.int32)
+            expected_array = np.zeros((np.prod(shape), depth), dtype=np.int32)
+            expected_array[:] = off_value
+            indices_1d = indices.flatten()
+            row = 0
+            for idx in indices_1d:
+                if 0 <= idx < depth:
+                    expected_array[row, idx] = on_value
+                row += 1
+            expected_array = expected_array.reshape(shape + (depth, ))
+            one_hot_array = mx_one_hot_array.asnumpy()
+            assert same(expected_array, one_hot_array)
+
+    def test_empty_indices():
+        shape = (2, 0, 9, 3)
+        indices = np.array([]).reshape(shape)
+        depth = 10
+        mx_one_hot_array = mx.nd.one_hot(mx.nd.array(indices, dtype=np.int32),
+                                         depth=depth, dtype=np.int32).asnumpy()
+        expected_array = np.array([], dtype=np.int32).reshape(shape + (depth, ))
+        assert same(expected_array, mx_one_hot_array)
+
+    def test_zero_depth():
+        shape = (2, 4, 9, 3)
+        indices = np.ones(shape)
+        depth = 0
+        mx_one_hot_array = mx.nd.one_hot(mx.nd.array(indices, dtype=np.int32),
+                                         depth=depth, dtype=np.int32).asnumpy()
+        expected_array = np.array([], dtype=np.int32).reshape(shape + (depth, ))
+        assert same(expected_array, mx_one_hot_array)
+
+    test_normal_case()
+    test_empty_indices()
+    test_zero_depth()
+
 if __name__ == '__main__':
     test_dot()
     test_cast()
@@ -2716,3 +2765,4 @@ if __name__ == '__main__':
     test_binary_logic()
     test_repeat()
     test_tile()
+    test_one_hot()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2670,8 +2670,9 @@ def test_one_hot():
                 shape += (np.random.randint(1, dim_size_max+1), )
             indices = np.random.randint(-dim_size_max, dim_size_max+1,
                                         size=np.prod(shape)).reshape(shape)
-            mx_one_hot_array = mx.nd.one_hot(mx.nd.array(indices, dtype=np.int32),
-                                             depth = depth, dtype=np.int32)
+            mx_one_hot_array = mx.nd.one_hot(
+                mx.nd.array(indices, ctx=default_context(), dtype=np.int32),
+                depth = depth, dtype=np.int32)
             expected_array = np.zeros((np.prod(shape), depth), dtype=np.int32)
             expected_array[:] = off_value
             indices_1d = indices.flatten()
@@ -2688,8 +2689,9 @@ def test_one_hot():
         shape = (2, 0, 9, 3)
         indices = np.array([]).reshape(shape)
         depth = 10
-        mx_one_hot_array = mx.nd.one_hot(mx.nd.array(indices, dtype=np.int32),
-                                         depth=depth, dtype=np.int32).asnumpy()
+        mx_one_hot_array = mx.nd.one_hot(
+            mx.nd.array(indices, ctx=default_context(), dtype=np.int32),
+            depth=depth, dtype=np.int32).asnumpy()
         expected_array = np.array([], dtype=np.int32).reshape(shape + (depth, ))
         assert same(expected_array, mx_one_hot_array)
 
@@ -2697,8 +2699,9 @@ def test_one_hot():
         shape = (2, 4, 9, 3)
         indices = np.ones(shape)
         depth = 0
-        mx_one_hot_array = mx.nd.one_hot(mx.nd.array(indices, dtype=np.int32),
-                                         depth=depth, dtype=np.int32).asnumpy()
+        mx_one_hot_array = mx.nd.one_hot(
+            mx.nd.array(indices, ctx=default_context(), dtype=np.int32),
+            depth=depth, dtype=np.int32).asnumpy()
         expected_array = np.array([], dtype=np.int32).reshape(shape + (depth, ))
         assert same(expected_array, mx_one_hot_array)
 


### PR DESCRIPTION
This PR implements the operator one_hot. The one called onehot_encode in the current code base will be deprecated.