### PR TITLE
Add where op

### DIFF
--- a/include/mxnet/operator.h
+++ b/include/mxnet/operator.h
@@ -36,37 +36,6 @@ enum OpReqType {
   kAddTo
 };
 
-/*! \brief operator request type switch */
-#define MXNET_OP_REQ_TYPE_SWITCH(req, ReqType, ...) \
-  switch (req) {                                    \
-  case kNullOp:                                     \
-    {                                               \
-      const int ReqType = kNullOp;                  \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case kWriteTo:                                    \
-    {                                               \
-      const int ReqType = kWriteTo;                 \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case kWriteInplace:                               \
-    {                                               \
-      const int ReqType = kWriteInplace;            \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case kAddTo:                                      \
-    {                                               \
-      const int ReqType = kAddTo;                   \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  default:                                          \
-    LOG(FATAL) << "Unknown OpReqType enum " << req; \
-  }
-
 /*!
  * \brief All the possible information needed by Operator.Forward and Backward
  *  This is the superset of RunContext.

--- a/include/mxnet/operator.h
+++ b/include/mxnet/operator.h
@@ -36,6 +36,37 @@ enum OpReqType {
   kAddTo
 };
 
+/*! \brief operator request type switch */
+#define MXNET_OP_REQ_TYPE_SWITCH(req, ReqType, ...) \
+  switch (req) {                                    \
+  case kNullOp:                                     \
+    {                                               \
+      const int ReqType = kNullOp;                  \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case kWriteTo:                                    \
+    {                                               \
+      const int ReqType = kWriteTo;                 \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case kWriteInplace:                               \
+    {                                               \
+      const int ReqType = kWriteInplace;            \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case kAddTo:                                      \
+    {                                               \
+      const int ReqType = kAddTo;                   \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  default:                                          \
+    LOG(FATAL) << "Unknown OpReqType enum " << req; \
+  }
+
 /*!
  * \brief All the possible information needed by Operator.Forward and Backward
  *  This is the superset of RunContext.

--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -58,6 +58,54 @@ struct Kernel<OP, gpu> {
 };
 #endif  // __CUDACC__
 
+/*! \brief operator request type switch */
+#define MXNET_ASSIGN_REQ_SWITCH(req, ReqType, ...)  \
+  switch (req) {                                    \
+  case kNullOp:                                     \
+    break;                                          \
+  case kWriteInplace:                               \
+  case kWriteTo:                                    \
+    {                                               \
+      const int ReqType = kWriteTo;                 \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case kAddTo:                                      \
+    {                                               \
+      const int ReqType = kAddTo;                   \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  default:                                          \
+    break;                                          \
+  }
+
+/*!
+ * \brief assign the val to out according
+ * to request in Kernel::Launch
+ * \param out the data to be assigned
+ * \param req the assignment request
+ * \param val the value to be assigned to out
+ * \tparam OType output type
+ * \tparam VType value type
+ */
+#define KERNEL_ASSIGN(out, req, val)  \
+  {                                   \
+    switch (req) {                    \
+      case kNullOp:                   \
+        break;                        \
+      case kWriteTo:                  \
+      case kWriteInplace:             \
+        (out) = (val);                \
+        break;                        \
+      case kAddTo:                    \
+        (out) += (val);               \
+        break;                        \
+      default:                        \
+        break;                        \
+    }                                 \
+  }
+
 struct clip {
   template<typename DType>
   MSHADOW_XINLINE static void Map(int i, DType* out, const DType* datas,

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file control_flow_op.cc
+ * \brief CPU Implementation of flow control
+ */
+#include "./control_flow_op.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(where)
+.MXNET_DESCRIBE("Given three ndarrays, condition, x, and y, return an ndarray"
+                " with the elements from x or y, depending on the elements"
+                " from condition are true or false. x and y must have the same"
+                " shape. If condition has the same shape as x, each element"
+                " in the output array is from x if the corresponding element"
+                " in the condition is true, and from y if false. If condtion"
+                " does not have the same shape as x, it must be a 1D array"
+                " whose size is the same as x's first dimension size. Each"
+                " row of the output array is from x's row if the corresponding"
+                " element from condition is true, and from y's row if false.")
+.set_num_inputs(3)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+    [](const NodeAttrs& attrs) {
+      return std::vector<std::string>{"condition", "x", "y"};
+    })
+.set_attr<nnvm::FInferShape>("FInferShape", WhereOpShape)
+.set_attr<nnvm::FInferType>("FInferType", WhereOpType)
+.set_attr<FCompute>("FCompute<cpu>", WhereOpForward<cpu>)
+.add_argument("condition", "NDArray", "condition array")
+.add_argument("x", "NDArray", "")
+.add_argument("y", "NDArray", "");
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -28,10 +28,16 @@ NNVM_REGISTER_OP(where)
 .set_attr<nnvm::FInferShape>("FInferShape", WhereOpShape)
 .set_attr<nnvm::FInferType>("FInferType", WhereOpType)
 .set_attr<FCompute>("FCompute<cpu>", WhereOpForward<cpu>)
-.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_where"})
 .add_argument("condition", "NDArray", "condition array")
 .add_argument("x", "NDArray", "")
 .add_argument("y", "NDArray", "");
+
+NNVM_REGISTER_OP(_backward_where)
+.set_num_inputs(1)
+.set_num_outputs(3)
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<FCompute>("FCompute<cpu>", WhereOpBackward<cpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -28,7 +28,6 @@ NNVM_REGISTER_OP(where)
 .set_attr<nnvm::FInferShape>("FInferShape", WhereOpShape)
 .set_attr<nnvm::FInferType>("FInferType", WhereOpType)
 .set_attr<FCompute>("FCompute<cpu>", WhereOpForward<cpu>)
-//.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_where"})
 .set_attr<nnvm::FGradient>("FGradient",
   // Use the following lambda function instead of ElemwiseGradUseIn
   // for best efficiency. grad[condition] = 0; to calculate grad[x] and grad[y]

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -28,6 +28,7 @@ NNVM_REGISTER_OP(where)
 .set_attr<nnvm::FInferShape>("FInferShape", WhereOpShape)
 .set_attr<nnvm::FInferType>("FInferType", WhereOpType)
 .set_attr<FCompute>("FCompute<cpu>", WhereOpForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
 .add_argument("condition", "NDArray", "condition array")
 .add_argument("x", "NDArray", "")
 .add_argument("y", "NDArray", "");

--- a/src/operator/tensor/control_flow_op.cu
+++ b/src/operator/tensor/control_flow_op.cu
@@ -11,5 +11,8 @@ namespace op {
 NNVM_REGISTER_OP(where)
 .set_attr<FCompute>("FCompute<gpu>", WhereOpForward<gpu>);
 
+NNVM_REGISTER_OP(_backward_where)
+.set_attr<FCompute>("FCompute<gpu>", WhereOpBackward<gpu>);
+
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/control_flow_op.cu
+++ b/src/operator/tensor/control_flow_op.cu
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file control_flow_op.cu
+ * \brief
+ */
+#include "./control_flow_op.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(where)
+.set_attr<FCompute>("FCompute<gpu>", WhereOpForward<gpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/tensor/control_flow_op.h
+++ b/src/operator/tensor/control_flow_op.h
@@ -1,0 +1,159 @@
+/*!
+ * Copyright (c) 2017 by Contributors
+ * \file control_flow.h
+ * \brief Function definitions of operators for controlling flow
+ */
+#ifndef MXNET_OPERATOR_TENSOR_CONTROL_FLOW_OP_H_
+#define MXNET_OPERATOR_TENSOR_CONTROL_FLOW_OP_H_
+
+#include <vector>
+#include <mxnet/operator_util.h>
+#include "../mshadow_op.h"
+#include "../mxnet_op.h"
+#include "../operator_common.h"
+#include "../elemwise_op_common.h"
+
+namespace mxnet {
+namespace op {
+
+/*! \brief return elements from x or y depending on condition
+ * This is the primary template for the operator where.
+ * The condition, x, and y have the same shape.
+ * The returned array is formed by elements from x or y
+ * depending on the elements of condition.
+ */
+template<bool same_shape>
+struct where {
+  // DType is the output data type
+  // CType is condition data type
+  template<typename DType, typename CType>
+  MSHADOW_XINLINE static void Map(int i, DType* out, const CType* cond,
+                                  const DType* x, const DType* y) {
+    out[i] = (0 != cond[i]? x[i] : y[i]);
+  }
+};
+
+/*! \brief return elements from x or y depending on condition
+ * This is the specialized template for the operator where.
+ * The condition is a vector whose size is the same as the
+ * x's first dim size.
+ * The returned array is formed by rows from x or y depending on
+ * the condition's elements.
+ */
+template<>
+struct where<false> {
+  // DType is the output data type
+  // CType is the condition data type
+  template<typename DType, typename CType>
+  MSHADOW_XINLINE static void Map(int i, DType* out, const CType* cond,
+                                  const DType* x, const DType* y, int M) {
+    int k = i * M;
+    const DType* a = (cond[i] != 0? x : y);
+    for (int j = 0; j < M; ++j) {
+        out[k] = a[k];
+        ++k;
+    }
+  }
+};
+
+inline bool WhereOpShape(const nnvm::NodeAttrs& attrs,
+                         std::vector<TShape>* in_attrs,
+                         std::vector<TShape>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 3)
+    << "where operator takes 3 arguments (" << in_attrs->size() << " given)";
+  CHECK_EQ(out_attrs->size(), 1);
+
+  // condition shape
+  const TShape& cshape = (*in_attrs)[0];
+  // x shape
+  const TShape& xshape = (*in_attrs)[1];
+  // y shape
+  const TShape& yshape = (*in_attrs)[2];
+
+  CHECK_EQ(xshape, yshape) << "x must have the same shape as y";
+  CHECK_LE(cshape.ndim(), xshape.ndim())
+    << "condition's dimension=" << cshape.ndim()
+    << " cannot be greater than x's dimension=" << xshape.ndim();
+
+  // handle 0-dim arrays
+  if (cshape.ndim() == 0 && xshape.ndim() == 0) {
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape());
+    return true;
+  }
+
+  // condition, x, and y cannot be 0-dim arrays
+  // if the program has reached here
+  CHECK_GT(cshape.ndim(), 0) << "condition array cannot be 0-dim if x is not 0-dim";
+  CHECK_GT(xshape.ndim(), 0) << "x array cannot 0-dim if condition is not 0-dim";
+
+  // condition and x have the same shape
+  if (cshape.ndim() == xshape.ndim()) {
+    CHECK_EQ(cshape, xshape) << "condition and x have the same dimension but different shapes";
+  } else {
+    CHECK_EQ(cshape.ndim(), 1) << "condition must either have the same shape as x or be a vector";
+    CHECK_EQ(cshape[0], xshape[0]) << "condition's first dim size ("
+      << cshape[0] << ") must be equal to x's first dim size (" << xshape[0] << ")";
+  }
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, xshape);
+  return true;
+}
+
+inline bool WhereOpType(const nnvm::NodeAttrs& attrs,
+                        std::vector<int>* in_attrs,
+                        std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 3)
+    << "where operator takes 3 arguments (" << in_attrs->size() << " given)";
+  CHECK_EQ(out_attrs->size(), 1);
+
+  if ((*in_attrs)[0] == -1) {
+    TYPE_ASSIGN_CHECK(*in_attrs, 0, mshadow::kFloat32);
+  }
+  if ((*in_attrs)[1] == -1 && (*in_attrs)[2] == -1) {
+    TYPE_ASSIGN_CHECK(*in_attrs, 1, mshadow::kFloat32);
+    TYPE_ASSIGN_CHECK(*in_attrs, 2, mshadow::kFloat32);
+  } else if ((*in_attrs)[1] == -1) {
+    TYPE_ASSIGN_CHECK(*in_attrs, 1, (*in_attrs)[2]);
+  } else if ((*in_attrs)[2] == -1) {
+    TYPE_ASSIGN_CHECK(*in_attrs, 2, (*in_attrs)[1]);
+  } else {
+    CHECK_EQ((*in_attrs)[1], (*in_attrs)[2]) << "The data types of x and y must be same";
+  }
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, (*in_attrs)[1]);
+  return true;
+}
+
+template<typename xpu>
+void WhereOpForward(const nnvm::NodeAttrs& attrs,
+                    const OpContext& ctx,
+                    const std::vector<TBlob>& inputs,
+                    const std::vector<OpReqType>& req,
+                    const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 3);
+  CHECK_EQ(outputs.size(), 1);
+  using namespace mxnet_op;
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  const TBlob& cond = inputs[0];
+  const TBlob& x = inputs[1];
+  const TBlob& y = inputs[2];
+  const TBlob& out = outputs[0];
+  if (out.Size() == 0) return;
+  MSHADOW_TYPE_SWITCH(out.type_flag_, DType, {
+    if (cond.shape_ == x.shape_) {
+      MSHADOW_TYPE_SWITCH(cond.type_flag_, CType, {
+        Kernel<where<true>, xpu>::Launch(s, out.Size(), out.dptr<DType>(),
+                                         cond.dptr<CType>(), x.dptr<DType>(), y.dptr<DType>());
+      });
+    } else {
+      MSHADOW_TYPE_SWITCH(cond.type_flag_, CType, {
+        Kernel<where<false>, xpu>::Launch(s, cond.Size(), out.dptr<DType>(),
+                                          cond.dptr<CType>(), x.dptr<DType>(), y.dptr<DType>(),
+                                          x.Size()/cond.Size());
+      });
+    }
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_TENSOR_CONTROL_FLOW_OP_H_

--- a/src/operator/tensor/control_flow_op.h
+++ b/src/operator/tensor/control_flow_op.h
@@ -6,8 +6,8 @@
 #ifndef MXNET_OPERATOR_TENSOR_CONTROL_FLOW_OP_H_
 #define MXNET_OPERATOR_TENSOR_CONTROL_FLOW_OP_H_
 
-#include <vector>
 #include <mxnet/operator_util.h>
+#include <vector>
 #include "../mshadow_op.h"
 #include "../mxnet_op.h"
 #include "../operator_common.h"

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -475,7 +475,7 @@ struct batch_take {
     int j = idx[i];
     if (j < 0) j = 0;
     else if (j >= M) j = M-1;
-    ASSIGN_DISPATCH(out[i], req, a[i*M+j]);
+    KERNEL_ASSIGN(out[i], req, a[i*M+j]);
   }
 };
 
@@ -491,7 +491,7 @@ void BatchTakeOpForward(const nnvm::NodeAttrs& attrs,
   using namespace mxnet_op;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
-    MXNET_OP_REQ_TYPE_SWITCH(req[0], req_type, {
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
       Kernel<batch_take<req_type>, xpu>::Launch(s, outputs[0].Size(), outputs[0].dptr<DType>(),
                                                 inputs[0].dptr<DType>(), inputs[1].dptr<int>(),
                                                 inputs[0].Size()/inputs[0].shape_[0]);
@@ -585,7 +585,7 @@ struct one_hot {
     int offset = i * depth;
     int j = indices[i];
     if (j >= 0 && j < depth) {
-      ASSIGN_DISPATCH(out[offset+j], req, on_value);
+      KERNEL_ASSIGN(out[offset+j], req, on_value);
     }
   }
 };
@@ -614,7 +614,7 @@ void OneHotOpForward(const nnvm::NodeAttrs& attrs,
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
     mshadow::Tensor<xpu, 1, DType> out = outputs[0].FlatTo1D<xpu, DType>(s);
     ASSIGN_DISPATCH(out, req[0], static_cast<DType>(off_value));
-    MXNET_OP_REQ_TYPE_SWITCH(req[0], req_type, {
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
       Kernel<one_hot<req_type>, xpu>::Launch(s, inputs[0].Size(), outputs[0].dptr<DType>(),
                                              inputs[0].dptr<int>(), depth,
                                              static_cast<DType>(on_value));

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -467,6 +467,7 @@ inline bool BatchTakeOpType(const nnvm::NodeAttrs& attrs,
 }
 
 /*! \brief take scalar value from 2d data array */
+template<int req>
 struct batch_take {
   template<typename DType>
   MSHADOW_XINLINE static void Map(int i, DType* out, const DType* a,
@@ -474,22 +475,27 @@ struct batch_take {
     int j = idx[i];
     if (j < 0) j = 0;
     else if (j >= M) j = M-1;
-    out[i] = a[i*M+j];
+    ASSIGN_DISPATCH(out[i], req, a[i*M+j]);
   }
 };
 
 template<typename xpu>
 void BatchTakeOpForward(const nnvm::NodeAttrs& attrs,
-                      const OpContext& ctx,
-                      const std::vector<TBlob>& inputs,
-                      const std::vector<OpReqType>& req,
-                      const std::vector<TBlob>& outputs) {
+                        const OpContext& ctx,
+                        const std::vector<TBlob>& inputs,
+                        const std::vector<OpReqType>& req,
+                        const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 2);
+  CHECK_EQ(outputs.size(), 1);
+  CHECK_EQ(req.size(), 1);
   using namespace mxnet_op;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
-    Kernel<batch_take, xpu>::Launch(s, outputs[0].Size(), outputs[0].dptr<DType>(),
-                                    inputs[0].dptr<DType>(), inputs[1].dptr<int>(),
-                                    inputs[0].Size()/inputs[0].shape_[0]);
+    MXNET_OP_REQ_TYPE_SWITCH(req[0], req_type, {
+      Kernel<batch_take<req_type>, xpu>::Launch(s, outputs[0].Size(), outputs[0].dptr<DType>(),
+                                                inputs[0].dptr<DType>(), inputs[1].dptr<int>(),
+                                                inputs[0].Size()/inputs[0].shape_[0]);
+    });
   });
 }
 
@@ -571,14 +577,15 @@ inline bool OneHotOpType(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
+template<int req>
 struct one_hot {
   template<typename DType>
   MSHADOW_XINLINE static void Map(int i, DType* out, const int* indices,
-                                  int depth, DType on_value, DType off_value) {
+                                  int depth, DType on_value) {
     int offset = i * depth;
     int j = indices[i];
     if (j >= 0 && j < depth) {
-      out[offset+j] = on_value;
+      ASSIGN_DISPATCH(out[offset+j], req, on_value);
     }
   }
 };
@@ -591,6 +598,7 @@ void OneHotOpForward(const nnvm::NodeAttrs& attrs,
                      const std::vector<TBlob>& outputs) {
   CHECK_EQ(inputs.size(), 1);
   CHECK_EQ(outputs.size(), 1);
+  CHECK_EQ(req.size(), 1);
   // The following line is needed to guard the situation when
   // an output array is empty on GPU. In that case, out.dptr() = 0x0
   if (outputs[0].Size() == 0) return;
@@ -605,10 +613,12 @@ void OneHotOpForward(const nnvm::NodeAttrs& attrs,
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
     mshadow::Tensor<xpu, 1, DType> out = outputs[0].FlatTo1D<xpu, DType>(s);
-    out = static_cast<DType>(off_value);
-    Kernel<one_hot, xpu>::Launch(s, inputs[0].Size(), outputs[0].dptr<DType>(),
-        inputs[0].dptr<int>(), depth,
-        static_cast<DType>(on_value), static_cast<DType>(off_value));
+    ASSIGN_DISPATCH(out, req[0], static_cast<DType>(off_value));
+    MXNET_OP_REQ_TYPE_SWITCH(req[0], req_type, {
+      Kernel<one_hot<req_type>, xpu>::Launch(s, inputs[0].Size(), outputs[0].dptr<DType>(),
+                                             inputs[0].dptr<int>(), depth,
+                                             static_cast<DType>(on_value));
+    });
   });
 }
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2731,11 +2731,11 @@ def test_where():
         shape = (10, 2, 4, 9)
         np_condition = np.random.randint(0, 2, shape[0])
         np_x = np.random.randint(1, 6, np.prod(shape))\
-            .reshape(shape[0], np.prod(shape)/shape[0])
+            .reshape(shape[0], int(np.prod(shape)/shape[0]))
         np_y = np.random.randint(7, 11, np.prod(shape))\
-            .reshape(shape[0], np.prod(shape)/shape[0])
+            .reshape(shape[0], int(np.prod(shape)/shape[0]))
         np_expected = np.zeros(np.prod(shape))\
-            .reshape(shape[0], np.prod(shape)/shape[0])
+            .reshape(shape[0], int(np.prod(shape)/shape[0]))
         for i in range(0, np_condition.shape[0]):
             if np_condition[i] > 0:
                 for j in range(0, len(np_x[0])):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2705,6 +2705,57 @@ def test_one_hot():
     test_empty_indices()
     test_zero_depth()
 
+
+def test_where():
+    def test_same_shape():
+        shape = (5, 2, 4, 9)
+        np_condition = np.random.randint(0, 2, np.prod(shape))
+        np_x = np.random.randint(1, 6, np.prod(shape))
+        np_y = np.random.randint(7, 11, np.prod(shape))
+        np_expected = np.zeros(np.prod(shape))
+        for i in range(0, np_condition.shape[0]):
+            if np_condition[i] > 0:
+                np_expected[i] = np_x[i]
+            else:
+                np_expected[i] = np_y[i]
+        np_expected = np_expected.reshape(shape)
+
+        condition = mx.nd.array(np_condition.reshape(shape),
+                                ctx=default_context(), dtype=np.int32)
+        x = mx.nd.array(np_x.reshape(shape), ctx=default_context(), dtype=np.int32)
+        y = mx.nd.array(np_y.reshape(shape), ctx=default_context(), dtype=np.int32)
+        mx_output = mx.nd.where(condition, x, y)
+        assert same(np_expected, mx_output.asnumpy())
+
+    def test_condition_vector():
+        shape = (10, 2, 4, 9)
+        np_condition = np.random.randint(0, 2, shape[0])
+        np_x = np.random.randint(1, 6, np.prod(shape))\
+            .reshape(shape[0], np.prod(shape)/shape[0])
+        np_y = np.random.randint(7, 11, np.prod(shape))\
+            .reshape(shape[0], np.prod(shape)/shape[0])
+        np_expected = np.zeros(np.prod(shape))\
+            .reshape(shape[0], np.prod(shape)/shape[0])
+        for i in range(0, np_condition.shape[0]):
+            if np_condition[i] > 0:
+                for j in range(0, len(np_x[0])):
+                    np_expected[i, j] = np_x[i, j]
+            else:
+                for j in range(0, len(np_x[0])):
+                    np_expected[i, j] = np_y[i, j]
+        np_expected = np_expected.reshape(shape)
+
+        condition = mx.nd.array(np_condition,
+                                ctx=default_context(), dtype=np.int32)
+        x = mx.nd.array(np_x.reshape(shape), ctx=default_context(), dtype=np.int32)
+        y = mx.nd.array(np_y.reshape(shape), ctx=default_context(), dtype=np.int32)
+        mx_output = mx.nd.where(condition, x, y)
+        assert same(np_expected, mx_output.asnumpy())
+
+    test_same_shape()
+    test_condition_vector()
+
+
 if __name__ == '__main__':
     test_l2_normalization()
     test_sequence_mask()
@@ -2765,3 +2816,4 @@ if __name__ == '__main__':
     test_repeat()
     test_tile()
     test_one_hot()
+    test_where()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2831,8 +2831,8 @@ def test_where():
                                                 grad_req='write')
         where_exe_write.forward(is_train=True, condition=condition_np, x=x_np, y=y_np)
         where_exe_write.backward(grad_in_mx)
-        assert reldiff(where_exe_write.grad_dict['x'].asnumpy(), x_grad_expected) < 1E-3
-        assert reldiff(where_exe_write.grad_dict['y'].asnumpy(), y_grad_expected) < 1E-3
+        assert_almost_equal(where_exe_write.grad_dict['x'].asnumpy(), x_grad_expected)
+        assert_almost_equal(where_exe_write.grad_dict['y'].asnumpy(), y_grad_expected)
 
         # test req='add'
         x_grad_init = np.random.randint(30, 40, np.prod(shape)).reshape(shape)
@@ -2847,8 +2847,8 @@ def test_where():
         where_exe_add.backward(grad_in_mx)
         x_ograd = where_exe_add.grad_dict['x'].asnumpy()
         y_ograd = where_exe_add.grad_dict['y'].asnumpy()
-        assert reldiff(x_ograd, x_grad_expected+x_grad_init) < 1E-3
-        assert reldiff(y_ograd, y_grad_expected+y_grad_init) < 1E-3
+        assert_almost_equal(x_ograd, x_grad_expected+x_grad_init)
+        assert_almost_equal(y_ograd, y_grad_expected+y_grad_init)
 
     def test_where_backward_condition_vector():
         condition = mx.sym.Variable('condition')
@@ -2933,8 +2933,8 @@ def test_where():
                                                 grad_req='write')
         where_exe_write.forward(is_train=True, condition=condition_np, x=x_np, y=y_np)
         where_exe_write.backward(grad_in_mx)
-        assert reldiff(where_exe_write.grad_dict['x'].asnumpy(), x_grad_expected) < 1E-3
-        assert reldiff(where_exe_write.grad_dict['y'].asnumpy(), y_grad_expected) < 1E-3
+        assert_almost_equal(where_exe_write.grad_dict['x'].asnumpy(), x_grad_expected)
+        assert_almost_equal(where_exe_write.grad_dict['y'].asnumpy(), y_grad_expected)
 
         # test req='add'
         x_grad_init = np.random.randint(30, 40, np.prod(shape)).reshape(shape)
@@ -2949,8 +2949,8 @@ def test_where():
         where_exe_add.backward(grad_in_mx)
         x_ograd = where_exe_add.grad_dict['x'].asnumpy()
         y_ograd = where_exe_add.grad_dict['y'].asnumpy()
-        assert reldiff(x_ograd, x_grad_expected+x_grad_init) < 1E-3
-        assert reldiff(y_ograd, y_grad_expected+y_grad_init) < 1E-3
+        assert_almost_equal(x_ograd, x_grad_expected+x_grad_init)
+        assert_almost_equal(y_ograd, y_grad_expected+y_grad_init)
 
     def test_where_numeric_gradient_same_shape():
         condition = mx.sym.Variable('condition')


### PR DESCRIPTION
This PR implements the operator "where" in mxnet. The operator always takes three arguments: condition, x, and y. x and y must have the same dtype. Two situations are allowed for their shapes:
1. condition, x, and y have the same shape.
2. condition is a vector, x and y have the same shape, and condition's size is same as x's first dim size.