### PR TITLE
Fix bug in CPU memory allocation

### DIFF
--- a/src/resource.cc
+++ b/src/resource.cc
@@ -53,7 +53,7 @@ struct SpaceAllocator {
 
   inline void* GetHostSpace(size_t size) {
     if (host_handle.size >= size) return host_handle.dptr;
-    if (handle.size != 0) {
+    if (host_handle.size != 0) {
       Storage::Get()->DirectFree(host_handle);
     }
     host_handle = Storage::Get()->Alloc(size, Context());


### PR DESCRIPTION
This bug will cause "Cannot Free space to a device you have not allocated"
when normalization parameter of SoftmaxOutput is "valid".