### PR TITLE
Fix output_shapes property of BucketingModule

### DIFF
--- a/python/mxnet/module/bucketing_module.py
+++ b/python/mxnet/module/bucketing_module.py
@@ -97,7 +97,7 @@ class BucketingModule(BaseModule):
         A list of `(name, shape)` pairs.
         """
         assert self.binded
-        return self._curr_module.label_shapes
+        return self._curr_module.output_shapes
 
     def get_params(self):
         """Get current parameters.


### PR DESCRIPTION
The output_shapes of the BucketingModule returns label_shapes instead of output_shapes.
One-line PR to fix this typo.