### PR TITLE
bugfix: Some valid kernel sizes don't pass 3d conv&pooling infer shape checks

### DIFF
--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -445,7 +445,7 @@ class ConvolutionProp : public OperatorProperty {
         << "incorrect stride size: " << param_.stride;
       CHECK_GT(param_.dilate.Size(), 0) \
         << "incorrect dilate size: " << param_.dilate;
-      CHECK(ksize_d < dshape[2] + 2 * param_.pad[0]
+      CHECK(ksize_d <= dshape[2] + 2 * param_.pad[0]
             && ksize_y <= dshape[3] + 2 * param_.pad[1]
             && ksize_x <= dshape[4] + 2 * param_.pad[2])
         << "kernel size exceed input";

--- a/src/operator/pooling-inl.h
+++ b/src/operator/pooling-inl.h
@@ -229,7 +229,7 @@ class PoolingProp : public OperatorProperty {
       out_shape->push_back(oshape);
     } else if (param_.kernel.ndim() == 3) {
       CHECK_EQ(dshape.ndim(), 5) << "Pooling: Input data should be 5D in (batch, channel, d, y, x)";
-      CHECK_LT(param_.kernel[0], dshape[2] + 2 * param_.pad[0]) << "kernel size exceeds input";
+      CHECK_LE(param_.kernel[0], dshape[2] + 2 * param_.pad[0]) << "kernel size exceeds input";
       CHECK_LE(param_.kernel[1], dshape[3] + 2 * param_.pad[1]) << "kernel size exceeds input";
       CHECK_LE(param_.kernel[2], dshape[4] + 2 * param_.pad[2]) << "kernel size exceeds input";
       if (param_.global_pool) {


### PR DESCRIPTION
I think the following kernel sizes should be valid.

```
import mxnet as mx
a = mx.sym.Variable(name='a', shape=(1, 1, 3, 3, 3))
conv = mx.symbol.Convolution(data=a, kernel=[3, 3, 3], no_bias=True,stride=[1, 1, 1], num_filter=5,)
conv.infer_shape()
pool = mx.sym.Pooling(data=a, kernel=[3, 3, 3], stride=[1, 1, 1], pool_type='max')
pool.infer_shape()
```

But I get the following errors
```
mxnet.base.MXNetError: Error in operator convolution0: [17:02:06] src/operator/./convolution-inl.h:450: Check failed: ksize_d < dshape[2] + 2 * param_.pad[0] && ksize_y <= dshape[3] + 2 * param_.pad[1] && ksize_x <= dshape[4] + 2 * param_.pad[2] kernel size exceed input
```

```
mxnet.base.MXNetError: Error in operator pooling1: [17:00:32] src/operator/./pooling-inl.h:232: Check failed: param_.kernel[0] < dshape[2] + 2 * param_.pad[0] (3 vs. 3) kernel size exceeds input
```
