### PR TITLE
Fix mx.img.resize arguments order in ssd example

### DIFF
--- a/example/ssd/dataset/iterator.py
+++ b/example/ssd/dataset/iterator.py
@@ -173,7 +173,7 @@ class DetIter(mx.io.DataIter):
         else:
             interp_methods = [cv2.INTER_LINEAR]
         interp_method = interp_methods[int(np.random.uniform(0, 1) * len(interp_methods))]
-        data = mx.img.imresize(data, self._data_shape[0], self._data_shape[1], interp_method)
+        data = mx.img.imresize(data, self._data_shape[1], self._data_shape[0], interp_method)
         if self.is_train and self._rand_mirror:
             if np.random.uniform(0, 1) > 0.5:
                 data = mx.nd.flip(data, axis=1)


### PR DESCRIPTION
I found a small bug in "example/ssd"

In success case 
```
mx.img.imresize(data, width, height, interp_method)
```

But in this case
```
mx.img.imresize(data, self._data_shape[0], self._data_shape[1], interp_method)
# maybe self._data_shape[0] is height, self._data_shape[1] is width
```

I fixed it!