### PR TITLE
Run tests in Docker as current user

### DIFF
--- a/tests/jenkins/run_as_user.sh
+++ b/tests/jenkins/run_as_user.sh
@@ -17,4 +17,5 @@ HOME_DIR=/home/${USER_NAME}
 groupadd -f -g ${GROUP_ID} ${GROUP_NAME}
 useradd -m -u ${USER_ID} -g ${GROUP_NAME} ${USER_NAME}
 chown -R ${USER_NAME}:${GROUP_NAME} ${HOME_DIR}
+chown -R ${USER_NAME}:${GROUP_NAME} /usr/local/lib/
 su -m ${USER_NAME} -c "export HOME=${HOME_DIR}; ${SCRIPT}"

--- a/tests/jenkins/run_as_user.sh
+++ b/tests/jenkins/run_as_user.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ ! $1 || ! $2 || ! $3 || ! $4 || ! $5 ]];
+then
+    echo "USAGE: " $(basename $"0") "USER_ID USER_NAME GROUP_ID GROUP_NAME SCRIPT"
+    exit 1
+fi
+
+USER_ID=$1
+USER_NAME=$2
+GROUP_ID=$3
+GROUP_NAME=$4
+SCRIPT=$5
+
+HOME_DIR=/home/${USER_NAME}
+
+groupadd -f -g ${GROUP_ID} ${GROUP_NAME}
+useradd -m -u ${USER_ID} -g ${GROUP_NAME} ${USER_NAME}
+chown -R ${USER_NAME}:${GROUP_NAME} ${HOME_DIR}
+su -m ${USER_NAME} -c "export HOME=${HOME_DIR}; ${SCRIPT}"


### PR DESCRIPTION
Slave environments are running out of disk space due to artifacts owned by "root", which is the default user in Docker containers. This runs tests as the current user in the host.