### PR TITLE
Fix to alamgamation so that JS build target works using latest emscripten.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -122,3 +122,4 @@ List of Contributors
 * [Yu Du](https://github.com/Answeror)
 * [Xu Dong](https://github.com/dsqx71)
 * [Chihiro Komaki](https://github.com/ckomaki)
+* [Piyush Singh](https://github.com/Piyush3dB)

--- a/amalgamation/Makefile
+++ b/amalgamation/Makefile
@@ -1,6 +1,9 @@
 export MXNET_ROOT=`pwd`/..
-# Change this to path of openblas
-export OPENBLAS_ROOT=/usr/local/opt/openblas
+
+# Change this to path or specify in make command
+ifndef OPENBLAS_ROOT
+    export OPENBLAS_ROOT=/usr/local/opt/openblas
+endif
 
 # Whether use minimum build without blas and SSE, this will make the library super slow
 ifndef MIN
@@ -14,6 +17,11 @@ ifndef ANDROID
     export ANDROID=0
 else
     DEFS+=-DMSHADOW_USE_SSE=0
+endif
+
+# Use locally installed emscripten if not specified
+ifndef EMCC
+    EMCC=emcc
 endif
 
 
@@ -73,7 +81,7 @@ else
 endif
 
 libmxnet_predict.js: mxnet_predict-all.cc
-	emcc -std=c++11 -O2 $(DEFS) -DMSHADOW_USE_SSE=0 -D__MXNET_JS__  -o $@ $+ \
+	${EMCC} -std=c++11 -O2 $(DEFS) -DMSHADOW_USE_SSE=0 -D__MXNET_JS__  -o $@ $+ \
 	-s EXPORTED_FUNCTIONS="['_MXPredCreate', '_MXPredGetOutputShape', '_MXPredSetInput', '_MXPredForward', '_MXPredPartialForward', '_MXPredGetOutput', '_MXPredFree', '_MXNDListCreate', '_MXNDListGet', '_MXNDListFree']" \
 	-s ALLOW_MEMORY_GROWTH=1
 
@@ -84,4 +92,4 @@ ${MXNET_ROOT}/lib/libmxnet_predict.so:  mxnet_predict-all.o
 	ls -alh $@
 
 clean:
-	rm -f *.d *.o *.so *.a mxnet_predict-all.cc nnvm.cc
+	rm -f *.d *.o *.so *.a *.js *.js.mem mxnet_predict-all.cc nnvm.cc

--- a/amalgamation/Makefile
+++ b/amalgamation/Makefile
@@ -82,9 +82,17 @@ endif
 
 libmxnet_predict.js: mxnet_predict-all.cc
 	${EMCC} -std=c++11 -O2 $(DEFS) -DMSHADOW_USE_SSE=0 -D__MXNET_JS__  -o $@ $+ \
-	-s EXPORTED_FUNCTIONS="['_MXPredCreate', '_MXPredGetOutputShape', '_MXPredSetInput', '_MXPredForward', '_MXPredPartialForward', '_MXPredGetOutput', '_MXPredFree', '_MXNDListCreate', '_MXNDListGet', '_MXNDListFree']" \
+	-s EXPORTED_FUNCTIONS="['_MXPredCreate', \
+	                        '_MXPredGetOutputShape', \
+	                        '_MXPredSetInput', \
+	                        '_MXPredForward', \
+	                        '_MXPredPartialForward', \
+	                        '_MXPredGetOutput', \
+	                        '_MXPredFree', \
+	                        '_MXNDListCreate', \
+	                        '_MXNDListGet', \
+	                        '_MXNDListFree']" \
 	-s ALLOW_MEMORY_GROWTH=1
-
 
 ${MXNET_ROOT}/lib/libmxnet_predict.so:  mxnet_predict-all.o
 	@mkdir -p ${MXNET_ROOT}/lib

--- a/amalgamation/README.md
+++ b/amalgamation/README.md
@@ -45,10 +45,15 @@ You can use generated library in [Leliana WhatsThis Android app](https://github.
 
 Javascript
 ---------------
-JS version works without OpenBLAS. You need [emscripten](http://kripken.github.io/emscripten-site/) to build it.
-Type ```make MIN=1 libmxnet_predict.js```
+JS version uses [emscripten](http://kripken.github.io/emscripten-site/) to cross-compile the amalgamation source file into a Javascript library that can be integrated into client side applications.  If you already have emanscripten installed then 
 
-You can use generated library in [mxnet.js](https://github.com/dmlc/mxnet.js)
+```make clean libmxnet_predict.js MIN=1```
+
+otherwise you can use [emscripten docker image](https://hub.docker.com/r/apiaryio/emcc/) to compile in the following way
+
+```make clean libmxnet_predict.js MIN=1 EMCC="docker run -v ${PWD}:/src apiaryio/emcc emcc"```
+
+An example WebApp that uses the generated JS library can be found at [mxnet.js](https://github.com/dmlc/mxnet.js)
 
 iOS
 ---------------

--- a/amalgamation/amalgamation.py
+++ b/amalgamation/amalgamation.py
@@ -8,7 +8,7 @@ blacklist = [
     'kvstore_dist.h', 'mach/clock.h', 'mach/mach.h',
     'malloc.h', 'mkl.h', 'mkl_cblas.h', 'mkl_vsl.h', 'mkl_vsl_functions.h',
     'nvml.h', 'opencv2/opencv.hpp', 'sys/stat.h', 'sys/types.h', 'cuda.h', 'cuda_fp16.h',
-    'omp.h', 'execinfo.h', 'packet/sse-inl.h'
+    'omp.h', 'execinfo.h', 'packet/sse-inl.h', 'emmintrin.h'
     ]
 
 minimum = int(sys.argv[6]) if len(sys.argv) > 5 else 0
@@ -122,7 +122,6 @@ f = open(sys.argv[5], 'wb')
 
 if minimum != 0:
     sysheaders.remove('cblas.h')
-    sysheaders.remove('emmintrin.h')
     print >>f, "#define MSHADOW_STAND_ALONE 1"
     print >>f, "#define MSHADOW_USE_SSE 0"
     print >>f, "#define MSHADOW_USE_CBLAS 0"


### PR DESCRIPTION
This PR resolves issue #4909.
1. Improvements to amalgamation makefile to allow specification of `emcc` executable in command line.  This enables usage of the official 'emcc' docker image.
2. Improvements to amalgamation python script so that unwanted header files are removed when run in minimum mode.  This gets rid of error seen in issue #4909.
3. Updated amalgamation build instructions for JS target and added information on how to use 'emcc' docker image.