### PR TITLE
Importing for all collobarators log on mxnet home page to mxnet repo

### DIFF
--- a/docs/_static/mxnet-theme/index.html
+++ b/docs/_static/mxnet-theme/index.html
@@ -62,7 +62,7 @@
         MXNet and sponsoring its major developers (alphabetical order).
       </p>
       <div class="col-lg-4 col-sm-6">
-        <img height="60px" src="https://upload.wikimedia.org/wikipedia/commons/1/1d/AmazonWebservices_Logo.svg">
+        <img height="60px" src="https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo/aws-logo.svg">
       </div>
 
       <div class="col-lg-4 col-sm-6">
@@ -86,11 +86,11 @@
       </div>
 
       <div class="col-lg-4 col-sm-6 clear smallClear">
-        <img height="70px" src="https://upload.wikimedia.org/wikipedia/en/2/21/Nvidia_logo.svg">
+        <img height="70px" src="https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo/nvidia-logo.png">
       </div>
 
       <div class="col-lg-4 col-sm-6">
-        <img height="45px" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/MIT_logo.svg/200px-MIT_logo.svg.png">
+        <img height="45px" src="https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo/mit-logo.png">
       </div>
      
       <div class="col-lg-4 col-sm-6 smallClear">
@@ -106,15 +106,15 @@
       </div>
 
       <div class="col-lg-4 col-sm-6">
-        <img height="45px" src="http://www.toolkit.ualberta.ca/Toolkit%20Downloads/~/media/identity/Toolkit/Logos/UA/UA-COLOUR-180px.png">
+        <img height="45px" src="https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo/university-alberta-logo.png">
       </div>
         
       <div class="col-lg-4 col-sm-6 clear smallClear">
-        <img height="45px" src="http://students.washington.edu/habitat/images/UW_NewLogo.jpg">
+        <img height="45px" src="https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo/university-washington-logo.jpg">
       </div>
 
       <div class="col-lg-4 col-sm-6">
-        <img height="45px" src="http://company.wolfram.com/data/press-center/uploads/2016/08/wolfram-corporate-logo-horizontal-lg.png">
+        <img height="45px" src="https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo/wolfram-logo.png">
       </div>
     </div>
   </div>


### PR DESCRIPTION
* Importing all logos used on mxnet home page to dmlc.
* We had a broken NVIDIA logo as it referenced wikipedia (which was removed)
* This is important security-wise because we were referring to open wiki links.

Note: This should be merged only after uploading attached logo images to https://github.com/dmlc/dmlc.github.io/tree/master/img/logo 