### PR TITLE
Amalgamation JNI bug for Java/Android prediction

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -123,3 +123,4 @@ List of Contributors
 * [Xu Dong](https://github.com/dsqx71)
 * [Chihiro Komaki](https://github.com/ckomaki)
 * [Piyush Singh](https://github.com/Piyush3dB)
+* [Freddy Chua](https://github.com/freddycct)

--- a/amalgamation/Makefile
+++ b/amalgamation/Makefile
@@ -66,7 +66,7 @@ mxnet_predict-all.o: mxnet_predict-all.cc
 libmxnet_predict.a: mxnet_predict-all.o
 	ar rcs libmxnet_predict.a $+
 
-jni_libmxnet_predict.o: mxnet_predict-all.cc
+jni_libmxnet_predict.o: mxnet_predict-all.cc jni/predictor.cc 
 	${CXX} ${CFLAGS} -fPIC -o $@ -c jni/predictor.cc
 
 jni_libmxnet_predict.so: jni_libmxnet_predict.o

--- a/amalgamation/jni/predictor.cc
+++ b/amalgamation/jni/predictor.cc
@@ -19,14 +19,17 @@ JNIEXPORT jlong JNICALL Java_org_dmlc_mxnet_Predictor_createPredictor
 		track.emplace_back(js, s);
     }
 
-	std::vector<mx_uint> index{0};
+	std::vector<mx_uint> index;
 	std::vector<mx_uint> shapes;
+    mx_uint prev = 0;
+    index.emplace_back(prev);
     for (int i=0; i<env->GetArrayLength(jshapes); i++) {
         jintArray jshape = (jintArray) env->GetObjectArrayElement(jshapes, i);
 		jsize shape_len = env->GetArrayLength(jshape);
 		jint *shape = env->GetIntArrayElements(jshape, 0);
 
-		index.emplace_back(shape_len);
+        prev += shape_len;
+		index.emplace_back(prev);
 		for (int j=0; j<shape_len; ++j) shapes.emplace_back((mx_uint)shape[j]);
 		env->ReleaseIntArrayElements(jshape, shape, 0);
     }


### PR DESCRIPTION
This bug results in a wrong index array that could cause a severe memory fault when multiple inputs are given to the createPredictor.

If the program does not crash due to wrong indexing of the arrays in C++, then the program will throw exception due to shape inference errors.
