### PR TITLE
Autograd for NDArray

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -516,6 +516,17 @@ MXNET_DLL int MXImperativeInvoke(AtomicSymbolCreator creator,
                                  const char **param_keys,
                                  const char **param_vals);
 
+MXNET_DLL int MXAutogradSetRecording(int recording);
+MXNET_DLL int MXAutogradSetMarkForRecord(mx_uint num_arr,
+                                         NDArrayHandle *arrays,
+                                         int mark);
+MXNET_DLL int MXAutogradComputeGradient(mx_uint num_input,
+                                        NDArrayHandle* input_handles,
+                                        mx_uint num_output,
+                                        NDArrayHandle* output_handles,
+                                        mx_uint* num_grad,
+                                        NDArrayHandle** grad_handles);
+
 //--------------------------------------------
 // Part 3: symbolic configuration generation
 //--------------------------------------------

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -515,16 +515,32 @@ MXNET_DLL int MXImperativeInvoke(AtomicSymbolCreator creator,
                                  int num_params,
                                  const char **param_keys,
                                  const char **param_vals);
-
+/*!
+ * \brief set whether to record operator for autograd
+ * \param recording 1 when turn on recording, 0 when turn off recording
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXAutogradSetRecording(int recording);
-
-MXNET_DLL int MXAutogradComputeGradient(mx_uint num_input,
-                                        NDArrayHandle* input_handles,
-                                        mx_uint num_output,
+/*!
+ * \brief mark NDArrays as variables to compute gradient for autograd
+ * \param num_var number of variable NDArrays
+ * \param var_handles variable NDArrays
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXAutogradMarkVariables(mx_uint num_var,
+                                      NDArrayHandle* var_handles);
+/*!
+ * \brief compute the gradient of outputs w.r.t variabels
+ * \param num_output number of output NDArray
+ * \param output_handles output NDArrays
+ * \param num_grad number of gradient NDArrays
+ * \param grad_handles gradient NDArrays
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXAutogradComputeGradient(mx_uint num_output,
                                         NDArrayHandle* output_handles,
                                         mx_uint* num_grad,
                                         NDArrayHandle** grad_handles);
-
 //--------------------------------------------
 // Part 3: symbolic configuration generation
 //--------------------------------------------

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -517,9 +517,7 @@ MXNET_DLL int MXImperativeInvoke(AtomicSymbolCreator creator,
                                  const char **param_vals);
 
 MXNET_DLL int MXAutogradSetRecording(int recording);
-MXNET_DLL int MXAutogradSetMarkForRecord(mx_uint num_arr,
-                                         NDArrayHandle *arrays,
-                                         int mark);
+
 MXNET_DLL int MXAutogradComputeGradient(mx_uint num_input,
                                         NDArrayHandle* input_handles,
                                         mx_uint num_output,

--- a/include/mxnet/executor.h
+++ b/include/mxnet/executor.h
@@ -59,7 +59,6 @@ class Executor {
    * \param head_grads the gradient of head nodes to be backproped.
    */
   virtual void Backward(const std::vector<NDArray> &head_grads) = 0;
-  virtual void Run(nnvm::NodeEntryMap<NDArray> feed_dict) = 0;
   /*!
    * \brief print the execution plan info to output stream.
    * \param os the output stream we like to print to.
@@ -70,7 +69,6 @@ class Executor {
    * \return array of outputs in the executor.
    */
   virtual const std::vector<NDArray> &outputs() const = 0;
-  virtual const std::vector<NDArray> &grads() const = 0;
   /*!
    * \brief Create an operator by bind symbol with context and arguments.
    *  If user do not want to compute the gradients of i-th argument, grad_req_type[i] can be kNullOp.
@@ -93,9 +91,6 @@ class Executor {
                         const std::vector<OpReqType> &grad_req_type,
                         const std::vector<NDArray> &aux_states,
                         Executor* shared_exec = NULL);
-
-  static Executor *NewBind(nnvm::Symbol symbol,
-                           nnvm::NodeEntryMap<NDArray>& feed_dict);
   /*!
    * \brief the prototype of user-defined monitor callback
    */

--- a/include/mxnet/executor.h
+++ b/include/mxnet/executor.h
@@ -59,6 +59,7 @@ class Executor {
    * \param head_grads the gradient of head nodes to be backproped.
    */
   virtual void Backward(const std::vector<NDArray> &head_grads) = 0;
+  virtual void Run(nnvm::NodeEntryMap<NDArray> feed_dict) = 0;
   /*!
    * \brief print the execution plan info to output stream.
    * \param os the output stream we like to print to.
@@ -69,6 +70,7 @@ class Executor {
    * \return array of outputs in the executor.
    */
   virtual const std::vector<NDArray> &outputs() const = 0;
+  virtual const std::vector<NDArray> &grads() const = 0;
   /*!
    * \brief Create an operator by bind symbol with context and arguments.
    *  If user do not want to compute the gradients of i-th argument, grad_req_type[i] can be kNullOp.
@@ -91,6 +93,9 @@ class Executor {
                         const std::vector<OpReqType> &grad_req_type,
                         const std::vector<NDArray> &aux_states,
                         Executor* shared_exec = NULL);
+
+  static Executor *NewBind(nnvm::Symbol symbol,
+                           nnvm::NodeEntryMap<NDArray>& feed_dict);
   /*!
    * \brief the prototype of user-defined monitor callback
    */

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -75,14 +75,6 @@ class NDArray {
 #endif
   }
 
-  NDArray(const NDArray& nd) = default;
-
-  NDArray& operator=(const NDArray& ) = default;
-
-  NDArray(NDArray&& nd)
-    : ptr_(nd.ptr_), shape_(nd.shape_), offset_(nd.offset_),
-    dtype_(nd.dtype_), entry_(nd.entry_) {}
-
   /*!
    * \return the shape of current NDArray
    */

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -11,6 +11,7 @@
 #include <dmlc/io.h>
 #include <dmlc/type_traits.h>
 #include <dmlc/registry.h>
+#include <nnvm/node.h>
 #include <vector>
 #include <map>
 #include <string>
@@ -27,6 +28,10 @@
 #endif
 
 namespace mxnet {
+
+namespace ndarray {
+  class AutogradRuntime;
+}
 /*!
  * \brief ndarray interface
  */
@@ -67,6 +72,15 @@ class NDArray {
       Mkl_mem_ = std::make_shared<MKLMemHolder>();
 #endif
   }
+
+  NDArray(const NDArray& nd) = default;
+
+  NDArray& operator=(const NDArray& ) = default;
+
+  NDArray(NDArray&& nd)
+    : ptr_(nd.ptr_), shape_(nd.shape_), offset_(nd.offset_),
+    dtype_(nd.dtype_), entry_(nd.entry_) {}
+
   /*!
    * \return the shape of current NDArray
    */
@@ -344,6 +358,7 @@ class NDArray {
                    std::vector<std::string>* keys);
 
  private:
+  friend class ::mxnet::ndarray::AutogradRuntime;
   /*! \brief the real data chunk that backs NDArray */
   struct Chunk {
     /*! \brief storage handlefrom storage engine */
@@ -414,6 +429,8 @@ class NDArray {
   size_t offset_;
   /*! \brief type of data */
   int dtype_ = -1;
+
+  nnvm::NodeEntry entry_{nnvm::Node::Create(), 0, 0};
 };
 
 /*!

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -55,7 +55,7 @@ class NDArray {
   NDArray(const TShape &shape, Context ctx,
           bool delay_alloc = false, int dtype = mshadow::default_type_flag)
       : ptr_(std::make_shared<Chunk>(shape.Size(), ctx, delay_alloc, dtype)),
-        shape_(shape), offset_(0), dtype_(dtype) {
+        shape_(shape), offset_(0), dtype_(dtype), entry_({nnvm::Node::Create(), 0, 0}) {
 #if MKL_EXPERIMENTAL == 1
       Mkl_mem_ = std::make_shared<MKLMemHolder>();
 #endif
@@ -69,12 +69,11 @@ class NDArray {
    */
   NDArray(const TBlob &data, int dev_id)
       : ptr_(std::make_shared<Chunk>(data, dev_id)), shape_(data.shape_), offset_(0),
-        dtype_(data.type_flag_) {
+        dtype_(data.type_flag_), entry_({nnvm::Node::Create(), 0, 0}) {
 #if MKL_EXPERIMENTAL == 1
       Mkl_mem_ = std::make_shared<MKLMemHolder>();
 #endif
   }
-
   /*!
    * \return the shape of current NDArray
    */
@@ -423,8 +422,8 @@ class NDArray {
   size_t offset_;
   /*! \brief type of data */
   int dtype_ = -1;
-
-  nnvm::NodeEntry entry_{nnvm::Node::Create(), 0, 0};
+  /*! \brief node entry for autograd */
+  nnvm::NodeEntry entry_;
 };
 
 /*!

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -55,7 +55,7 @@ class NDArray {
   NDArray(const TShape &shape, Context ctx,
           bool delay_alloc = false, int dtype = mshadow::default_type_flag)
       : ptr_(std::make_shared<Chunk>(shape.Size(), ctx, delay_alloc, dtype)),
-        shape_(shape), offset_(0), dtype_(dtype), entry_({nnvm::Node::Create(), 0, 0}) {
+        shape_(shape), offset_(0), dtype_(dtype), entry_({nullptr, 0, 0}) {
 #if MKL_EXPERIMENTAL == 1
       Mkl_mem_ = std::make_shared<MKLMemHolder>();
 #endif
@@ -69,7 +69,7 @@ class NDArray {
    */
   NDArray(const TBlob &data, int dev_id)
       : ptr_(std::make_shared<Chunk>(data, dev_id)), shape_(data.shape_), offset_(0),
-        dtype_(data.type_flag_), entry_({nnvm::Node::Create(), 0, 0}) {
+        dtype_(data.type_flag_), entry_({nullptr, 0, 0}) {
 #if MKL_EXPERIMENTAL == 1
       Mkl_mem_ = std::make_shared<MKLMemHolder>();
 #endif

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -29,9 +29,11 @@
 
 namespace mxnet {
 
-namespace ndarray {
-  class AutogradRuntime;
+// forward declaration
+namespace autograd {
+class AutogradRuntime;
 }
+
 /*!
  * \brief ndarray interface
  */
@@ -358,7 +360,7 @@ class NDArray {
                    std::vector<std::string>* keys);
 
  private:
-  friend class ::mxnet::ndarray::AutogradRuntime;
+  friend class autograd::AutogradRuntime;
   /*! \brief the real data chunk that backs NDArray */
   struct Chunk {
     /*! \brief storage handlefrom storage engine */

--- a/python/minpy/README.md
+++ b/python/minpy/README.md
@@ -1,0 +1,4 @@
+MXNet Python Package
+====================
+
+This is the WIP directory for MinPy project.

--- a/python/minpy/README.md
+++ b/python/minpy/README.md
@@ -1,4 +1,0 @@
-MXNet Python Package
-====================
-
-This is the WIP directory for MinPy project.

--- a/python/mxnet/__init__.py
+++ b/python/mxnet/__init__.py
@@ -17,6 +17,7 @@ from . import recordio
 from . import operator
 # use mx.nd as short for mx.ndarray
 from . import ndarray as nd
+from . import autograd
 # use mx.rnd as short for mx.random
 from . import random as rnd
 from . import random

--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -32,7 +32,6 @@ def compute_gradient(inputs, outputs):
     Returns
     -------
     gradients: list of NDArray
-        A
     """
     input_handles = []
     for arr in inputs:

--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+"""Autograd for NDArray."""
+from __future__ import absolute_import
+from __future__ import division
+
+import ctypes
+import functools
+from .base import _LIB, check_call
+from .base import mx_uint, NDArrayHandle, c_array
+from .ndarray import NDArray
+from .ndarray import array as ndarray
+
+def set_recording(recording):
+    check_call(_LIB.MXAutogradSetRecording(
+        ctypes.c_int(recording)))
+
+def set_mark_for_record(arrays, mark):
+    handles = []
+    for arr in arrays:
+        handles.append(arr.handle)
+    check_call(_LIB.MXAutogradSetMarkForRecord(
+        len(handles),
+        c_array(NDArrayHandle, handles),
+        ctypes.c_int(mark)))
+
+def compute_gradient(inputs, outputs):
+    input_handles = []
+    for arr in inputs:
+        input_handles.append(arr.handle)
+    output_handles = []
+    for arr in outputs:
+        output_handles.append(arr.handle)
+
+    num_grad = mx_uint()
+    grad_handles = ctypes.POINTER(NDArrayHandle)()
+    check_call(_LIB.MXAutogradComputeGradient(
+        len(input_handles),
+        c_array(NDArrayHandle, input_handles),
+        len(output_handles),
+        c_array(NDArrayHandle, output_handles),
+        ctypes.byref(num_grad),
+        ctypes.byref(grad_handles)))
+    return [NDArray(NDArrayHandle(grad_handles[i])) for i in range(num_grad.value)]
+
+def grad_and_loss(func, argnum=0):
+    @functools.wraps(func)
+    def wrapped(*args):
+        inputs  = [a if isinstance(a, NDArray) else ndarray(a) for a in args]
+        argnums = [argnum] if isinstance(argnum, int) else argnum
+        marked_arrays = [inputs[i] for i in argnums]
+        set_recording(True)
+        set_mark_for_record(marked_arrays, True)
+        outputs = func(*inputs)
+        set_recording(False)
+        grad_vals = compute_gradient(
+            inputs, [outputs])
+        set_mark_for_record(marked_arrays, False)
+        if len(grad_vals) == 1:
+            grad_vals = grad_vals[0]
+        return grad_vals, outputs
+    return wrapped
+
+def grad(func, argnum=0):
+    grad_with_loss_func = grad_and_loss(func, argnum)
+    @functools.wraps(grad_with_loss_func)
+    def wrapped(*args):
+        return grad_with_loss_func(*args)[0]
+    return wrapped

--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -11,19 +11,29 @@ from .ndarray import NDArray
 from .ndarray import array as ndarray
 
 def set_recording(recording):
+    """Turn on or turn of operator recording.
+
+    Parameters
+    ----------
+    recording: bool
+    """
     check_call(_LIB.MXAutogradSetRecording(
         ctypes.c_int(recording)))
 
-def set_mark_for_record(arrays, mark):
-    handles = []
-    for arr in arrays:
-        handles.append(arr.handle)
-    check_call(_LIB.MXAutogradSetMarkForRecord(
-        len(handles),
-        c_array(NDArrayHandle, handles),
-        ctypes.c_int(mark)))
-
 def compute_gradient(inputs, outputs):
+    """Compute the gradients of outputs w.r.t inputs.
+
+    Parameters
+    ----------
+    inputs: list of NDArray
+
+    outputs: list of NDArray
+
+    Returns
+    -------
+    gradients: list of NDArray
+        A
+    """
     input_handles = []
     for arr in inputs:
         input_handles.append(arr.handle)
@@ -42,26 +52,45 @@ def compute_gradient(inputs, outputs):
         ctypes.byref(grad_handles)))
     return [NDArray(NDArrayHandle(grad_handles[i])) for i in range(num_grad.value)]
 
-def grad_and_loss(func, argnum=0):
+def grad_and_loss(func):
+    """Return function that computes both gradient of arguments and loss value.
+
+    Parameters
+    ----------
+    func: a python function
+        The forward (loss) function.
+
+    Returns
+    -------
+    grad_and_loss_func: a python function
+        A function that would compute both the gradient of arguments and loss value.
+    """
     @functools.wraps(func)
     def wrapped(*args):
+        """Wrapped function."""
         inputs  = [a if isinstance(a, NDArray) else ndarray(a) for a in args]
-        argnums = [argnum] if isinstance(argnum, int) else argnum
-        marked_arrays = [inputs[i] for i in argnums]
         set_recording(True)
-        set_mark_for_record(marked_arrays, True)
         outputs = func(*inputs)
         set_recording(False)
         grad_vals = compute_gradient(
-            inputs, [outputs])
-        set_mark_for_record(marked_arrays, False)
-        if len(grad_vals) == 1:
-            grad_vals = grad_vals[0]
+            inputs, outputs if isinstance(outputs, list) else [outputs])
         return grad_vals, outputs
     return wrapped
 
-def grad(func, argnum=0):
-    grad_with_loss_func = grad_and_loss(func, argnum)
+def grad(func):
+    """Return function that computes gradient of arguments.
+
+    Parameters
+    ----------
+    func: a python function
+        The forward (loss) function.
+
+    Returns
+    -------
+    grad_func: a python function
+        A function that would compute the gradient of arguments.
+    """
+    grad_with_loss_func = grad_and_loss(func)
     @functools.wraps(grad_with_loss_func)
     def wrapped(*args):
         return grad_with_loss_func(*args)[0]

--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -8,7 +8,6 @@ import functools
 from .base import _LIB, check_call
 from .base import mx_uint, NDArrayHandle, c_array
 from .ndarray import NDArray
-from .ndarray import array as ndarray
 
 def set_recording(recording):
     """Turn on or turn of operator recording.

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -416,16 +416,6 @@ int MXAutogradSetRecording(int recording) {
   API_END();
 }
 
-int MXAutogradSetMarkForRecord(mx_uint num_arr, NDArrayHandle *arrays, int mark) {
-  API_BEGIN();
-  std::vector<NDArray*> data;
-  for (mx_uint i = 0; i < num_arr; ++i) {
-    data.emplace_back(static_cast<NDArray*>(arrays[i]));
-  }
-  AutogradRuntime::Get()->SetMarkForRecord(data, bool(mark));
-  API_END();
-}
-
 int MXAutogradComputeGradient(mx_uint num_input,
                               NDArrayHandle *input_handles,
                               mx_uint num_output,
@@ -448,6 +438,7 @@ int MXAutogradComputeGradient(mx_uint num_input,
   std::vector<NDArray> grads =
     AutogradRuntime::Get()->ComputeGradient(inputs, outputs);
 
+  ret->ret_handles.resize(grads.size());
   for (size_t i = 0; i < grads.size(); ++i) {
     NDArray *ptr = new NDArray();
     *ptr = grads[i];

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -373,7 +373,7 @@ int MXImperativeInvoke(AtomicSymbolCreator creator,
     if (fn) {
       if (AutogradRuntime::Get()->IsRecording()) {
         AutogradRuntime::Get()->RecordImperativeFCompute(fn, op,
-            attrs, ndinputs, ndoutputs);
+            attrs, &ndinputs, &ndoutputs);
       }
       PushFCompute(fn, op, attrs, ctx, read_vars, write_vars,
           requested, ndinputs, ndoutputs);
@@ -382,7 +382,7 @@ int MXImperativeInvoke(AtomicSymbolCreator creator,
           createop[op](attrs, ctx, ret->arg_shapes, ret->arg_types));
       if (AutogradRuntime::Get()->IsRecording()) {
         AutogradRuntime::Get()->RecordImperativeOperator(opr, op,
-            attrs, ndinputs, ndoutputs);
+            attrs, &ndinputs, &ndoutputs);
       }
       PushOperator(opr, op, attrs, ctx, read_vars, write_vars,
           requested, auxidx, ndinputs, ndoutputs);
@@ -412,7 +412,7 @@ int MXImperativeInvoke(AtomicSymbolCreator creator,
 
 int MXAutogradSetRecording(int recording) {
   API_BEGIN();
-  AutogradRuntime::Get()->SetRecording(bool(recording));
+  AutogradRuntime::Get()->SetRecording(static_cast<bool>(recording));
   API_END();
 }
 
@@ -446,6 +446,5 @@ int MXAutogradComputeGradient(mx_uint num_input,
   }
   *num_grad = static_cast<mx_uint>(grads.size());
   *grad_handles = dmlc::BeginPtr(ret->ret_handles);
-
   API_END();
 }

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -42,7 +42,8 @@ class ForwardOpExecutor : public OpExecutor {
   Operator::ExecType exec_type() const override {
     return op_->exec_type();
   }
-  explicit ForwardOpExecutor(Operator* op, std::vector<uint32_t> aux_index)
+  explicit ForwardOpExecutor(std::shared_ptr<Operator> op,
+      std::vector<uint32_t> aux_index)
       : op_(op), aux_index_(aux_index) {
     std::sort(aux_index_.begin(), aux_index_.end());
   }
@@ -170,6 +171,8 @@ Graph AttachOpExecs(Graph g) {
   const auto& vdtype = g.GetAttr<DTypeVector>("dtype");
   const auto& vshape = g.GetAttr<ShapeVector>("shape");
   const auto& vctx = g.GetAttr<ContextVector>("context");
+  const auto& saved_opr = g.GetAttr<
+    std::unordered_map<const nnvm::Node*, std::shared_ptr<Operator>>>("saved_opr");
 
   // get the graph
   const auto& idx = g.indexed_graph();
@@ -191,9 +194,14 @@ Graph AttachOpExecs(Graph g) {
         ishape.emplace_back(vshape[idx.entry_id(e)]);
         itype.emplace_back(vdtype[idx.entry_id(e)]);
       }
-      ret[i] = std::make_shared<ForwardOpExecutor>(
-          fcreate_layer_op[inode.source->op()](
-              inode.source->attrs, vctx[i], ishape, itype), mutate_index);
+      std::shared_ptr<Operator> opr;
+      if (saved_opr.count(inode.source)) {
+        opr = saved_opr.at(inode.source);
+      } else {
+        opr.reset(fcreate_layer_op[inode.source->op()](
+              inode.source->attrs, vctx[i], ishape, itype));
+      }
+      ret[i] = std::make_shared<ForwardOpExecutor>(opr, mutate_index);
     } else if (is_layer_backward.get(inode.source->op(), false)) {
       CHECK_GE(inode.control_deps.size(), 1);
       uint32_t fwd_id = inode.control_deps[0];

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -195,8 +195,8 @@ Graph AttachOpExecs(Graph g) {
           fcreate_layer_op[inode.source->op()](
               inode.source->attrs, vctx[i], ishape, itype), mutate_index);
     } else if (is_layer_backward.get(inode.source->op(), false)) {
+      CHECK_GE(inode.control_deps.size(), 1);
       uint32_t fwd_id = inode.control_deps[0];
-      CHECK_GE(inode.control_deps.size(), 1U);
       CHECK(vctx[fwd_id] == vctx[i]);
       CHECK(ret[fwd_id] != nullptr);
       ret[i] = std::make_shared<BackwardOpExecutor>(

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -69,6 +69,10 @@ const std::vector<NDArray>& GraphExecutor::outputs() const {
   return output_arrays_;
 }
 
+const std::vector<NDArray>& GraphExecutor::grads() const {
+  return grad_arrays_;
+}
+
 nnvm::NodeEntry AttrHint(nnvm::NodeEntry src, nnvm::NodeEntry like) {
   static const Op* id_like = Op::Get("_identity_with_attr_like_rhs");
   nnvm::NodePtr n = nnvm::Node::Create();
@@ -401,6 +405,7 @@ Graph GraphExecutor::InitGraph(nnvm::Symbol symbol,
   arg_shapes.resize(idx.input_nodes().size(), TShape());
   arg_types.resize(idx.input_nodes().size(), -1);
   // other initializations
+  g.attrs["shape_hints"] = std::make_shared<dmlc::any>(shape_hints_);
   g = nnvm::pass::InferShape(g, arg_shapes, "__shape__");
   g = nnvm::pass::InferType(g, arg_types, "__dtype__");
 
@@ -727,4 +732,94 @@ Executor *Executor::Bind(nnvm::Symbol symbol,
              reinterpret_cast<Executor*>(shared_exec));
   return exec;
 }
+
+Executor *Executor::NewBind(nnvm::Symbol symbol,
+    nnvm::NodeEntryMap<NDArray>& feed_dict) {
+  using nnvm::NodePtr;
+  using nnvm::NodeEntry;
+
+  LOG(INFO) << "feed_dict";
+  for (const auto& kv : feed_dict) {
+    LOG(INFO) << kv.first.node->attrs.name << "(" << kv.first.index << ")";
+  }
+
+  std::vector<NodePtr> input_nodes =
+    symbol.ListInputs(nnvm::Symbol::ListInputOption::kAll);
+  LOG(INFO) << "input_nodes";
+  for (const NodePtr& n : input_nodes) {
+    LOG(INFO) << n->attrs.name;
+  }
+
+  std::vector<NDArray> inputs;
+  inputs.reserve(input_nodes.size());
+  for (const NodePtr& n : input_nodes) {
+    NodeEntry e = nnvm::NodeEntry{n, 0, 0};
+    if (feed_dict.count(e)) {
+      NDArray nd = feed_dict.at(e);
+      inputs.push_back(nd);
+    } else {
+      LOG(FATAL) << "no corresponding ndarray: " << n->attrs.name;
+    }
+  }
+
+  std::vector<NDArray> grads;
+  std::vector<OpReqType> grad_reqs;
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    NDArray grad(inputs[i].shape(), inputs[i].ctx());
+    grad = static_cast<real_t>(1.0);
+    grads.push_back(grad);
+    grad_reqs.push_back(OpReqType::kWriteTo);
+  }
+
+  Context ctx = Context::CPU(); // (TODO) fixme
+  std::map<std::string, Context> ctx_map;
+  std::vector<NDArray> aux_states;
+
+  nnvm::NodeEntryMap<TShape> shapes;
+  for (const auto& kv : feed_dict) {
+    shapes.insert({kv.first, kv.second.shape()});
+  }
+  auto exec = new exec::GraphExecutor();
+  exec->shape_hints_ = shapes;
+  exec->Init(symbol, ctx, ctx_map,
+             inputs, grads, grad_reqs, aux_states);
+
+  return exec;
+}
+
+namespace exec {
+
+void GraphExecutor::Run(nnvm::NodeEntryMap<NDArray> feed_dict) {
+  const nnvm::IndexedGraph& idx = graph_.indexed_graph();
+
+  for (const auto& kv : feed_dict) {
+    if (idx.exist(kv.first.node.get())) {
+      uint32_t entry_id = idx.entry_id(kv.first);
+      LOG(INFO) << "Copy " << kv.first.node->attrs.name
+                << "(" << kv.first.index << ")";
+      CopyFromTo(kv.second, &(data_entry_[entry_id]));
+    }
+  }
+
+  std::vector<NDArray> head_grads;
+  head_grads.reserve(head_grad_array_.size());
+  LOG(INFO) << "head_grad_size: " << head_grad_array_.size();
+
+  for (size_t i = 0; i < output_arrays_.size(); ++i) {
+    NDArray grad(output_arrays_[i].shape(), output_arrays_[i].ctx());
+    grad = static_cast<real_t>(1.0);
+    head_grads.push_back(grad);
+  }
+
+  Backward(head_grads);
+
+  LOG(INFO) << grad_store_.size();
+  for (const auto& kv : grad_store_) {
+    LOG(INFO) << "push grad_store";
+    grad_arrays_.emplace_back(kv.second);
+  }
+}
+
+}
+
 }  // namespace mxnet

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -402,7 +402,6 @@ Graph GraphExecutor::InitGraph(nnvm::Symbol symbol,
   arg_shapes.resize(idx.input_nodes().size(), TShape());
   arg_types.resize(idx.input_nodes().size(), -1);
   // other initializations
-  g.attrs["shape_hints"] = std::make_shared<dmlc::any>(shape_hints_);
   g = nnvm::pass::InferShape(g, arg_shapes, "__shape__");
   g = nnvm::pass::InferType(g, arg_types, "__dtype__");
 
@@ -729,5 +728,4 @@ Executor *Executor::Bind(nnvm::Symbol symbol,
              reinterpret_cast<Executor*>(shared_exec));
   return exec;
 }
-
 }  // namespace mxnet

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -30,11 +30,11 @@ class GraphExecutor;
 }
 
 // forward declaration
-// (TODO) This part should be put into executor in the future
 namespace autograd {
-exec::GraphExecutor *NewBind(nnvm::Symbol symbol,
-                       const nnvm::NodeEntryMap<TShape>& shapes,
-                       const NodeOperatorMap& saved_opr);
+exec::GraphExecutor *Bind(nnvm::Symbol symbol,
+                          const nnvm::NodeEntryMap<TShape>& shapes,
+                          const nnvm::NodeEntryMap<Context>& ctxs,
+                          const NodeOperatorMap& saved_opr);
 std::vector<NDArray> Run(exec::GraphExecutor* exec,
                          const nnvm::NodeEntryMap<NDArray>& feed_dict);
 }
@@ -46,11 +46,12 @@ using nnvm::Graph;
 // graph executors
 class GraphExecutor : public Executor {
  public:
-  friend GraphExecutor *autograd::NewBind(nnvm::Symbol symbol,
-                       const nnvm::NodeEntryMap<TShape>& shapes,
-                       const NodeOperatorMap& saved_opr);
+  friend GraphExecutor *autograd::Bind(nnvm::Symbol symbol,
+                                       const nnvm::NodeEntryMap<TShape>& shapes,
+                                       const nnvm::NodeEntryMap<Context>& ctxs,
+                                       const NodeOperatorMap& saved_opr);
   friend std::vector<NDArray> autograd::Run(GraphExecutor* exec,
-    const nnvm::NodeEntryMap<NDArray>& feed_dict);
+                                            const nnvm::NodeEntryMap<NDArray>& feed_dict);
 
   using Executor::MonitorCallback;
 
@@ -129,10 +130,9 @@ class GraphExecutor : public Executor {
   size_t num_forward_inputs_{0};
   // number of forward nodes
   size_t num_forward_nodes_{0};
-  // monitor call back
-  nnvm::NodeEntryMap<TShape> shape_hints_;
+  // saved operator for autograd
   NodeOperatorMap saved_opr_;
-
+  // monitor call back
   std::function<void(const char*, void*)> monitor_callback_{nullptr};
 };
 

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -33,7 +33,9 @@ class GraphExecutor : public Executor {
   void Forward(bool is_train) override;
   void PartialForward(bool is_train, int step, int *step_left) override;
   void Backward(const std::vector<NDArray> &head_grads) override;
+  void Run(nnvm::NodeEntryMap<NDArray> feed_dict) override;
   const std::vector<NDArray>& outputs() const override;
+  const std::vector<NDArray>& grads() const override;
   void Print(std::ostream &os) const override; // NOLINT(*)
   void SetMonitorCallback(const MonitorCallback& callback) override;
   // initialized the executor
@@ -45,6 +47,8 @@ class GraphExecutor : public Executor {
             const std::vector<OpReqType>& grad_req_type,
             const std::vector<NDArray>& aux_states,
             Executor* shared_exec = nullptr);
+
+  nnvm::NodeEntryMap<TShape> shape_hints_;
 
  protected:
   // Information about operational node
@@ -92,6 +96,7 @@ class GraphExecutor : public Executor {
   std::vector<NDArray> output_arrays_;
   // gradient store
   std::vector<std::pair<OpReqType, NDArray> > grad_store_;
+  std::vector<NDArray> grad_arrays_;
   // array to hold head gradient.
   std::vector<NDArray> head_grad_array_;
   // entry to hold head gradient

--- a/src/ndarray/autograd.cc
+++ b/src/ndarray/autograd.cc
@@ -1,0 +1,177 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file autograd.cc
+ * \brief (TODO)
+ */
+
+#include <mxnet/operator.h>
+#include <mxnet/executor.h>
+#include <nnvm/pass_functions.h>
+#include <unordered_set>
+#include <iostream>
+#include "../executor/graph_executor.h"
+#include "./autograd.h"
+
+namespace mxnet {
+
+// forward declaration
+namespace exec {
+nnvm::NodeEntry AttrHint(nnvm::NodeEntry src, nnvm::NodeEntry like);
+nnvm::NodeEntry AggregateGradient(std::vector<nnvm::NodeEntry>&& v);
+}  // namespace exec
+
+namespace ndarray {
+
+using nnvm::Node;
+using nnvm::NodePtr;
+using nnvm::NodeEntry;
+using nnvm::NodeEntryMap;
+
+AutogradRuntime* AutogradRuntime::instance_ = new AutogradRuntime();
+
+AutogradRuntime* AutogradRuntime::Get() {
+  return instance_;
+}
+
+AutogradRuntime::AutogradRuntime() {}
+
+void AutogradRuntime::SetRecording(bool recording) {
+  is_recording_ = recording;
+}
+
+bool AutogradRuntime::IsRecording() {
+  return is_recording_;
+}
+
+void AutogradRuntime::SetMarkForRecord(const std::vector<NDArray*>& arrays, bool mark) {
+  for (const NDArray* arr : arrays) {
+    bp_flags[arr] = mark;
+  }
+}
+
+void AutogradRuntime::RecordImperative(const nnvm::Op* op,
+                                       const nnvm::NodeAttrs& attrs,
+                                       std::vector<NDArray>& inputs,
+                                       std::vector<NDArray>& outputs) {
+  NodePtr node = Node::Create();
+  // (TODO) name of operator
+  node->attrs = attrs;
+  node->attrs.name = op->name + "_temp";
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    NodeEntry &e = inputs[i].entry_;
+    if (e.node->is_variable() &&
+        e.node->attrs.name.empty()) {
+      e.node->attrs.name = "variable_" + std::to_string(i);
+      entry_ndarray_map_[e] = inputs[i];
+    }
+    node->inputs.push_back(e);
+  }
+
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    NodeEntry &e = outputs[i].entry_;
+    e.node = node;
+    e.index = i;
+    entry_ndarray_map_[e] = outputs[i];
+  }
+}
+
+std::vector<NDArray> AutogradRuntime::ComputeGradient(std::vector<NDArray>& inputs,
+                                      std::vector<NDArray>& outputs) {
+
+  nnvm::Symbol ff_sym;
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    ff_sym.outputs.push_back(outputs[i].entry_);
+  }
+  PrintSymbol(ff_sym, "Forward Graph");
+
+  // nnvm::Graph full_graph = GetBackwardGraph(ff_sym);
+  // PrintSymbol(full_graph, "Full Graph");
+  // nnvm::Symbol full_sym;
+  // full_sym.outputs = full_graph.outputs;
+  // (TODO) should pass full_sym
+  // std::vector<NDArray> result = Execute(ff_sym, entry_ndarray_map_);
+  std::vector<NDArray> result = Execute(ff_sym, entry_ndarray_map_);
+  return result;
+}
+
+template<typename ValueType>
+inline ValueType get_node_attr(
+    const nnvm::Node& node,
+    const std::string& key, ValueType default_value) {
+  auto it = node.attrs.dict.find(key);
+  if (it == node.attrs.dict.end()) {
+    return default_value;
+  } else {
+    ValueType ret;
+    dmlc::parameter::FieldEntry<ValueType> e;
+    e.Init(key, &ret, ret);
+    e.Set(&ret, it->second);
+    return ret;
+  }
+}
+
+nnvm::Graph GetBackwardGraph(nnvm::Graph g) {
+  Symbol symbol;
+  symbol.outputs = g.outputs;
+
+  std::vector<NodeEntry> head_grad_entry;
+  static int head_grad_count = 0;
+  for (size_t i = 0; i < g.outputs.size(); ++i) {
+    NodeEntry ngrad{nnvm::Node::Create(), 0, 0};
+    ngrad.node->attrs.name = "head_grad" + std::to_string(head_grad_count++);
+    head_grad_entry.emplace_back(exec::AttrHint(ngrad, g.outputs[i]));
+  }
+  std::vector<NodePtr> args = symbol.ListInputs(nnvm::Symbol::kReadOnlyArgs);
+  std::vector<NodeEntry> xs;
+  for (size_t i = 0; i < args.size(); ++i) {
+    xs.emplace_back(NodeEntry{args[i], 0, 0});
+  }
+
+  int do_mirror = dmlc::GetEnv("MXNET_BACKWARD_DO_MIRROR", 0);
+  auto need_mirror = [do_mirror](const nnvm::Node& node) -> int {
+    if (node.is_variable()) return 0;
+    const std::string& type = node.attrs.op->name;
+    if (type == "Dropout") return false;
+    if (get_node_attr(node, "__force_mirroring__", false)) return true;
+    if (do_mirror == 0) return false;
+    if (type == "Convolution") return false;
+    if (type == "FullyConnected") return false;
+    if (type == "Concat") return false;
+    if (type == "SoftmaxOutput") return false;
+    if (type == "CuDNNBatchNorm") return false;
+    return true;
+  };
+  // take gradient
+  nnvm::Graph g_grad = nnvm::pass::Gradient(
+      g, symbol.outputs, xs, head_grad_entry,
+      exec::AggregateGradient, need_mirror);
+  CHECK_EQ(g_grad.outputs.size(), xs.size());
+
+  return g_grad;
+}
+
+std::vector<NDArray> AutogradRuntime::Execute(nnvm::Symbol sym,
+    nnvm::NodeEntryMap<NDArray> feed_dict) {
+
+  // (TODO) only forward part now
+  // const Op* id = nnvm::Op::Get("_identity_with_attr_like_rhs");
+  // DFSVisit(sym.outputs, [&](const NodePtr& node) {
+  //     if (node->op() == id) {
+  //       NDArray output = feed_dict.at(node->inputs[1]);
+  //       NDArray grad(output.shape(), output.ctx());
+  //       grad = static_cast<real_t>(1.0);
+  //       feed_dict.insert({node->inputs[0], grad});
+  //     }
+  //   });
+
+  std::cout << std::endl;
+  LOG(INFO) << "bind";
+  Executor *exec = Executor::NewBind(sym, feed_dict);
+  LOG(INFO) << "Enter Run";
+  exec->Run(feed_dict);
+  LOG(INFO) << "Exit Run";
+  return exec->grads();
+}
+
+}  // namespace ndarray
+}  // namespace mxnet

--- a/src/ndarray/autograd.h
+++ b/src/ndarray/autograd.h
@@ -19,38 +19,64 @@
 namespace mxnet {
 namespace autograd {
 
+/*!
+ * \brief AutogradRuntime Interface
+ */
 class AutogradRuntime {
  public:
+  /*! \brief turn on or turn off operator recording for autograd. */
   void SetRecording(bool recording);
+  /*! \brief whether operator recording is on. */
   bool IsRecording() const;
-  void SetMarkForRecord(const std::vector<NDArray*>& arrays, bool mark);
+  /*! \brief record imperative operator which is executed by fcompute. */
   void RecordImperativeFCompute(FCompute fn,
                                 const nnvm::Op* op,
                                 const nnvm::NodeAttrs& attrs,
                                 std::vector<NDArray>& inputs,
                                 std::vector<NDArray>& outputs);
+  /*! \brief record imperative operator which is executed by operator. */
   void RecordImperativeOperator(std::shared_ptr<Operator> opr,
                                 const nnvm::Op* op,
                                 const nnvm::NodeAttrs& attrs,
                                 std::vector<NDArray>& inputs,
                                 std::vector<NDArray>& outputs);
+  /*! \brief compute the gradient of outputs w.r.t inputs. */
   std::vector<NDArray> ComputeGradient(std::vector<NDArray>& inputs,
-                                       std::vector<NDArray>& grad_outputs);
+                                       std::vector<NDArray>& outputs);
+  /*! \return AutogradRuntime singleton */
   static AutogradRuntime* Get();
+  /*! \brief Get shared pointer reference to AutogradRuntime singleton.
+   *   Most user should not call this function.
+   *   This function is called by another singleton X who requires
+   *   AutogradRuntime to be destructed after X.
+   *
+   *  \return A shared pointer to AutogradRuntime singleton.
+   */
   static std::shared_ptr<AutogradRuntime> _GetSharedRef();
 
  protected:
+  /*! \brief make constructor protected. */
   AutogradRuntime();
 
  private:
-  void ClearRecords();
+  /*! \brief to record operator, return corresponding node. */
   nnvm::NodePtr RecordOp(const nnvm::Op* op,
                          const nnvm::NodeAttrs& attrs,
                          std::vector<NDArray>& inputs,
                          std::vector<NDArray>& outputs);
+  /*! \brief clear the record data. */
+  void ClearRecords();
+  /*! \brief AutogradRuntime singleton. */
   static AutogradRuntime* instance_;
+  /*! \brief indicate whether operator recording is on. */
   bool is_recording_{false};
+  /*! \brief node count used for naming */
+  int node_count_{0};
+  /*! \brief variable count used for naming */
+  int variable_count_{0};
+  /*! \brief mapping from node entry to saved ndarray. */
   nnvm::NodeEntryMap<NDArray> saved_ndarray_;
+  /*! \brief mapping from node to saved operator. */
   std::unordered_map<const nnvm::Node*, std::shared_ptr<Operator>> saved_opr_;
 };
 

--- a/src/ndarray/autograd.h
+++ b/src/ndarray/autograd.h
@@ -1,0 +1,69 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file autograd.h
+ * \brief (TODO)
+ */
+#ifndef MXNET_NDARRAY_AUTOGRAD_H_
+#define MXNET_NDARRAY_AUTOGRAD_H_
+
+#include <dmlc/logging.h>
+#include <mxnet/base.h>
+#include <mxnet/ndarray.h>
+#include <nnvm/symbolic.h>
+#include <nnvm/op.h>
+#include <nnvm/graph.h>
+#include <vector>
+#include <unordered_map>
+
+namespace mxnet {
+namespace ndarray {
+
+class AutogradRuntime {
+ public:
+  void SetRecording(bool recording);
+  bool IsRecording();
+  void SetMarkForRecord(const std::vector<NDArray*>& arrays, bool mark);
+  void RecordImperative(const nnvm::Op* op,
+                const nnvm::NodeAttrs& attrs,
+                std::vector<NDArray>& inputs,
+                std::vector<NDArray>& outputs);
+  std::vector<NDArray> ComputeGradient(std::vector<NDArray>& inputs,
+                       std::vector<NDArray>& grad_outputs);
+  static AutogradRuntime* Get();
+
+ protected:
+  AutogradRuntime();
+
+ private:
+  std::vector<NDArray> Execute(nnvm::Symbol sym,
+      nnvm::NodeEntryMap<NDArray> feed_dict);
+
+  static AutogradRuntime* instance_;
+  std::unordered_map<const NDArray*, bool> bp_flags;
+  bool is_recording_{false};
+  nnvm::NodeEntryMap<NDArray> entry_ndarray_map_;
+  nnvm::NodeEntryMap<nnvm::NodePtr> new_input_variables_;
+  nnvm::NodeEntryMap<TShape> entry_shape_map_;
+  std::unordered_map<const nnvm::Node*, nnvm::NodeEntry> var_entry_map_;
+  // Symbol graph;
+};
+
+nnvm::Graph GetBackwardGraph(nnvm::Graph g);
+
+// I will delete this after finish
+inline void PrintSymbol(nnvm::Symbol s, std::string name = "") {
+  std::cout << "\n\n";
+  LOG(INFO) << name;
+  s.Print(std::cout);
+  std::cout << "\n\n";
+}
+
+inline void PrintSymbol(nnvm::Graph g, std::string name = "") {
+  nnvm::Symbol s;
+  s.outputs = g.outputs;
+  PrintSymbol(s, name);
+}
+
+}  // namespace ndarray
+}  // namespace mxnet
+#endif  // MXNET_NDARRAY_AUTOGRAD_H_

--- a/src/ndarray/autograd.h
+++ b/src/ndarray/autograd.h
@@ -32,17 +32,17 @@ class AutogradRuntime {
   void RecordImperativeFCompute(FCompute fn,
                                 const nnvm::Op* op,
                                 const nnvm::NodeAttrs& attrs,
-                                std::vector<NDArray>& inputs,
-                                std::vector<NDArray>& outputs);
+                                std::vector<NDArray>* p_inputs,
+                                std::vector<NDArray>* p_outputs);
   /*! \brief record imperative operator which is executed by operator. */
   void RecordImperativeOperator(std::shared_ptr<Operator> opr,
                                 const nnvm::Op* op,
                                 const nnvm::NodeAttrs& attrs,
-                                std::vector<NDArray>& inputs,
-                                std::vector<NDArray>& outputs);
+                                std::vector<NDArray>* p_inputs,
+                                std::vector<NDArray>* p_outputs);
   /*! \brief compute the gradient of outputs w.r.t inputs. */
-  std::vector<NDArray> ComputeGradient(std::vector<NDArray>& inputs,
-                                       std::vector<NDArray>& outputs);
+  std::vector<NDArray> ComputeGradient(const std::vector<NDArray>& inputs,
+                                       const std::vector<NDArray>& outputs);
   /*! \return AutogradRuntime singleton */
   static AutogradRuntime* Get();
   /*! \brief Get shared pointer reference to AutogradRuntime singleton.
@@ -62,8 +62,8 @@ class AutogradRuntime {
   /*! \brief to record operator, return corresponding node. */
   nnvm::NodePtr RecordOp(const nnvm::Op* op,
                          const nnvm::NodeAttrs& attrs,
-                         std::vector<NDArray>& inputs,
-                         std::vector<NDArray>& outputs);
+                         std::vector<NDArray>* p_inputs,
+                         std::vector<NDArray>* p_outputs);
   /*! \brief clear the record data. */
   void ClearRecords();
   /*! \brief AutogradRuntime singleton. */

--- a/src/ndarray/autograd.h
+++ b/src/ndarray/autograd.h
@@ -28,6 +28,8 @@ class AutogradRuntime {
   void SetRecording(bool recording);
   /*! \brief whether operator recording is on. */
   bool IsRecording() const;
+  /*! \brief mark variables for computing gradients. */
+  void MarkVariables(std::vector<NDArray*>* p_variables);
   /*! \brief record imperative operator which is executed by fcompute. */
   void RecordImperativeFCompute(FCompute fn,
                                 const nnvm::Op* op,
@@ -40,9 +42,8 @@ class AutogradRuntime {
                                 const nnvm::NodeAttrs& attrs,
                                 std::vector<NDArray>* p_inputs,
                                 std::vector<NDArray>* p_outputs);
-  /*! \brief compute the gradient of outputs w.r.t inputs. */
-  std::vector<NDArray> ComputeGradient(const std::vector<NDArray>& inputs,
-                                       const std::vector<NDArray>& outputs);
+  /*! \brief compute the gradient of outputs w.r.t variables. */
+  std::vector<NDArray> ComputeGradient(const std::vector<NDArray>& outputs);
   /*! \return AutogradRuntime singleton */
   static AutogradRuntime* Get();
   /*! \brief Get shared pointer reference to AutogradRuntime singleton.

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -174,7 +174,6 @@ void BinaryBroadcastBackwardUseNone(const nnvm::NodeAttrs& attrs,
                                     const std::vector<TBlob>& inputs,
                                     const std::vector<OpReqType>& req,
                                     const std::vector<TBlob>& outputs) {
-  // LOG(INFO) << attrs.name;
   using namespace broadcast;
   TShape new_lshape, new_rshape, new_oshape;
   int ndim = BinaryBroadcastShapeCompact(outputs[0].shape_, outputs[1].shape_, inputs[0].shape_,

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -1,63 +1,62 @@
 import mxnet.ndarray as nd
 from mxnet.autograd import grad, grad_and_loss
 
-def f_exp(x):
-    return nd.exp(x)
+def autograd_assert(*args, **kwargs):
+    f = kwargs["func"]
+    grad_f = kwargs["grad_func"]
 
-def f_half(x):
-    return x/2
-
-def f_square(x):
-    return x**2
-
-def f_add(x, y):
-    return x+y
-
-def f_mul(x, y):
-    return x*y
-
-def f_composition(x, y):
-    return x+x*y
-
-def test_unary_func_grad(f):
-    inputs = [[1, 2, 3],
-              [4, 5, 6]]
     grad_func = grad_and_loss(f)
-    grad_vals, outputs = grad_func(inputs)
-    print(outputs.asnumpy())
-    print(grad_vals.asnumpy())
+    grad_vals, output = grad_func(*args)
+    res = f(*args)
+    assert output == res
+    grad_res = grad_f(*args)
+    assert len(grad_vals) == len(grad_res)
+    for a, b in zip(grad_vals, grad_res):
+        assert a == b
 
-def test_binary_func_grad(f):
-    x = [[1, 2, 3],
-         [4, 5, 6]]
-    y = [[1, 2, 3],
-         [4, 5, 6]]
-    grad_func = grad_and_loss(f)
-    grad_vals, outputs = grad_func(x, y)
-    print(outputs.asnumpy())
-    for grad_val in grad_vals:
-        print(grad_val.asnumpy())
+def test_unary_func():
+    x = nd.uniform(shape=(4, 5))
+    f_exp         = lambda x: nd.exp(x)
+    f_exp_grad    = lambda x: [x]
+    autograd_assert(x, func=f_exp, grad_func=f_exp_grad)
+    f_half        = lambda x: x/2
+    f_half_grad   = lambda x: [nd.ones(x.shape) * 0.5]
+    autograd_assert(x, func=f_half, grad_func=f_half_grad)
+    f_square      = lambda x: x**2
+    f_square_grad = lambda x: [2*x]
+    autograd_assert(x, func=f_square, grad_func=f_square_grad)
+
+def test_binary_func():
+    x = nd.uniform(shape=(4, 5))
+    y = nd.uniform(shape=(4, 5))
+    f_add      = lambda x, y: x+y
+    f_add_grad = lambda x, y: [nd.ones(x.shape), nd.ones(y.shape)]
+    autograd_assert(x, y, func=f_add, grad_func=f_add_grad)
+    f_mul      = lambda x, y: x*y
+    f_mul_grad = lambda x, y: [y, x]
+    autograd_assert(x, y, func=f_mul, grad_func=f_mul_grad)
+    f_compose  = lambda x, y: x+x*y
+    f_compose_grad = lambda x, y: [nd.ones(x.shape) + y, x]
+    autograd_assert(x, y, func=f_compose, grad_func=f_compose_grad)
 
 def test_operator_with_state():
-    def f_fc(x, weight, bias):
-        out = nd.FullyConnected(
+    def f_fc(a, b, weight, bias):
+        x = a*b
+        fc = nd.FullyConnected(
             x, weight, bias, num_hidden=32)
-        return out
+        return fc
 
     a = nd.uniform(shape=(64, 50))
     b = nd.uniform(shape=(64, 50))
-    x = a+b
     weight = nd.uniform(shape=(32, 50))
     bias = nd.uniform(shape=(32, ))
 
     grad_func = grad_and_loss(f_fc)
-    grad_vals, outputs = grad_func(x, weight, bias)
+    grad_vals, outputs = grad_func(a, b, weight, bias)
+    # (TODO) assert
 
 
-test_unary_func_grad(f_exp)
-test_unary_func_grad(f_half)
-test_unary_func_grad(f_square)
-test_binary_func_grad(f_add)
-test_binary_func_grad(f_mul)
-test_binary_func_grad(f_composition)
-test_operator_with_state()
+if __name__ == "__main__":
+    test_unary_func()
+    test_binary_func()
+    test_operator_with_state()

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -1,0 +1,47 @@
+import mxnet.ndarray as nd
+from mxnet.autograd import grad, grad_and_loss
+
+def f_exp(x):
+    return nd.exp(x)
+
+def f_half(x):
+    return x/2
+
+def f_square(x):
+    return x**2
+
+def f_add(x, y):
+    return x+y
+
+def f_mul(x, y):
+    return x*y
+
+def f_composition(x, y):
+    return x+x*y
+
+def test_unary_func_grad(f):
+    inputs = [[1, 2, 3],
+              [4, 5, 6]]
+    grad_func = grad_and_loss(f)
+    grad_vals, outputs = grad_func(inputs)
+    print(outputs.asnumpy())
+    print(grad_vals.asnumpy())
+
+def test_binary_func_grad(f):
+    x = [[1, 2, 3],
+         [4, 5, 6]]
+    y = [[1, 2, 3],
+         [4, 5, 6]]
+    grad_func = grad_and_loss(f)
+    grad_vals, outputs = grad_func(x, y)
+    print(outputs.asnumpy())
+    for grad_val in grad_vals:
+        print(grad_val.asnumpy())
+
+
+test_unary_func_grad(f_exp)
+test_unary_func_grad(f_half)
+test_unary_func_grad(f_square)
+test_binary_func_grad(f_add)
+test_binary_func_grad(f_mul)
+test_binary_func_grad(f_composition)

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -38,6 +38,21 @@ def test_binary_func_grad(f):
     for grad_val in grad_vals:
         print(grad_val.asnumpy())
 
+def test_operator_with_state():
+    def f_fc(x, weight, bias):
+        out = nd.FullyConnected(
+            x, weight, bias, num_hidden=32)
+        return out
+
+    a = nd.uniform(shape=(64, 50))
+    b = nd.uniform(shape=(64, 50))
+    x = a+b
+    weight = nd.uniform(shape=(32, 50))
+    bias = nd.uniform(shape=(32, ))
+
+    grad_func = grad_and_loss(f_fc)
+    grad_vals, outputs = grad_func(x, weight, bias)
+
 
 test_unary_func_grad(f_exp)
 test_unary_func_grad(f_half)
@@ -45,3 +60,4 @@ test_unary_func_grad(f_square)
 test_binary_func_grad(f_add)
 test_binary_func_grad(f_mul)
 test_binary_func_grad(f_composition)
+test_operator_with_state()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -691,7 +691,8 @@ def check_deconvolution_gradient(input_shape, num_filter, pad):
     exe_deconv.forward(is_train=True)
     deconv_out_grad = conv_data[:]
     exe_deconv.backward(deconv_out_grad)
-    assert_almost_equal(conv_args_grad[1].asnumpy(), deconv_args_grad[1].asnumpy(), rtol=1e-3)
+    assert_almost_equal(conv_args_grad[1].asnumpy(), deconv_args_grad[1].asnumpy(),
+        rtol=2e-3, atol=1e-2)
     # Test AddTo
     exe_deconv_addto = deconv.bind(default_context(), args=deconv_args,
                                    args_grad=deconv_addto_args_grad,


### PR DESCRIPTION
## Brief Introduction

Bring the idea from [MinPy](https://github.com/dmlc/minpy). Autograd for NDArray will allow users compute gradient for imperative programs easily:

``` python
from mxnet.autograd import grad
import mxnet.ndarray as nd
import random

def foo(x):
    r = random.randint(0, 1)
    if r % 2:
        return x**2
    else:
        return x/3

for i in range(10):
    inputs = nd.array([[1, 2, 3], [4, 5, 6]])
    grad_func = grad(foo)
    grad_val  = grad_func(inputs)
```

## Progress

- [x] Support for stateless ndarray operators
- [x] Support for ndarray operators with state

## Future
- Partial Gradient
- Support for hybrid of symbol and ndarray


@jermainewang @mli 