### PR TITLE
Memory allocator bug fix #5035

### DIFF
--- a/example/rnn/lstm_bucketing.py
+++ b/example/rnn/lstm_bucketing.py
@@ -34,7 +34,8 @@ parser.add_argument('--disp-batches', type=int, default=50,
 def tokenize_text(fname, vocab=None, invalid_label=-1, start_label=0):
     lines = open(fname).readlines()
     lines = [filter(None, i.split(' ')) for i in lines]
-    sentences, vocab = mx.rnn.encode_sentences(lines, vocab=vocab, invalid_label=invalid_label, start_label=start_label)
+    sentences, vocab = mx.rnn.encode_sentences(lines, vocab=vocab, invalid_label=invalid_label,
+                                               start_label=start_label)
     return sentences, vocab
 
 

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -153,6 +153,7 @@ class BaseModule(object):
         self.params_initialized = False
         self.optimizer_initialized = False
         self._symbol = None
+        self.total_exec_bytes = 0
 
     ################################################################################
     # High Level API

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -153,7 +153,7 @@ class BaseModule(object):
         self.params_initialized = False
         self.optimizer_initialized = False
         self._symbol = None
-        self.total_exec_bytes = 0
+        self._total_exec_bytes = 0
 
     ################################################################################
     # High Level API

--- a/python/mxnet/module/bucketing_module.py
+++ b/python/mxnet/module/bucketing_module.py
@@ -316,7 +316,7 @@ class BucketingModule(BaseModule):
                             state_names=self._state_names)
             module.bind(data_shapes, label_shapes, self._curr_module.for_training,
                         self._curr_module.inputs_need_grad,
-                        force_rebind=False, shared_module=self._curr_module)
+                        force_rebind=False, shared_module=self._buckets[self._default_bucket_key])
             self._buckets[bucket_key] = module
 
         self._curr_module = self._buckets[bucket_key]

--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -125,7 +125,7 @@ class DataParallelExecutorGroup(object):
         self.inputs_need_grad = inputs_need_grad
 
         self.logger = logger
-        #TODO need a cleaner interface to profile memory per device (haibin)
+        #In the future we should have a better way to profile memory per device (haibin)
         self.total_exec_bytes = 0
         self.fixed_param_names = fixed_param_names
         if self.fixed_param_names is None:

--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -126,7 +126,7 @@ class DataParallelExecutorGroup(object):
 
         self.logger = logger
         #In the future we should have a better way to profile memory per device (haibin)
-        self.total_exec_bytes = 0
+        self._total_exec_bytes = 0
         self.fixed_param_names = fixed_param_names
         if self.fixed_param_names is None:
             self.fixed_param_names = []
@@ -617,7 +617,7 @@ class DataParallelExecutorGroup(object):
                                     args_grad=grad_arrays, aux_states=aux_arrays,
                                     grad_req=self.grad_req, shared_exec=shared_exec)
         # Get the total bytes allocated for this executor
-        self.total_exec_bytes += int(executor.debug_str().split('\n')[-3].split()[1])
+        self._total_exec_bytes += int(executor.debug_str().split('\n')[-3].split()[1])
         return executor
 
     def _sliced_shape(self, shapes, i, major_axis):

--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -125,7 +125,8 @@ class DataParallelExecutorGroup(object):
         self.inputs_need_grad = inputs_need_grad
 
         self.logger = logger
-
+        #TODO need a cleaner interface to profile memory per device (haibin)
+        self.total_exec_bytes = 0
         self.fixed_param_names = fixed_param_names
         if self.fixed_param_names is None:
             self.fixed_param_names = []
@@ -615,6 +616,8 @@ class DataParallelExecutorGroup(object):
         executor = self.symbol.bind(ctx=context, args=arg_arrays,
                                     args_grad=grad_arrays, aux_states=aux_arrays,
                                     grad_req=self.grad_req, shared_exec=shared_exec)
+        # Get the total bytes allocated for this executor
+        self.total_exec_bytes += int(executor.debug_str().split('\n')[-3].split()[1])
         return executor
 
     def _sliced_shape(self, shapes, i, major_axis):

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -384,6 +384,7 @@ class Module(BaseModule):
                                                      fixed_param_names=self._fixed_param_names,
                                                      grad_req=grad_req,
                                                      state_names=self._state_names)
+        self.total_exec_bytes = self._exec_group.total_exec_bytes
         if shared_module is not None:
             self.params_initialized = True
             self._arg_params = shared_module._arg_params

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -384,7 +384,7 @@ class Module(BaseModule):
                                                      fixed_param_names=self._fixed_param_names,
                                                      grad_req=grad_req,
                                                      state_names=self._state_names)
-        self.total_exec_bytes = self._exec_group.total_exec_bytes
+        self._total_exec_bytes = self._exec_group._total_exec_bytes
         if shared_module is not None:
             self.params_initialized = True
             self._arg_params = shared_module._arg_params

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -486,8 +486,10 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
   data_pool_.resize(pool_info.size());
 
   // sort the pool info the descending order before allocating memory
-  std::vector<size_t> sorted_pool_index(pool_info.size());
-  std::iota(sorted_pool_index.begin(), sorted_pool_index.end(), 0);
+  std::vector<size_t> sorted_pool_index;
+  for (size_t i = 0; i < pool_info.size(); i++) {
+    sorted_pool_index.push_back(i);
+  }
   auto pool_comparator = [&pool_info](int lhs, int rhs){
     return pool_info[lhs].second > pool_info[rhs].second;
   };

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -321,7 +321,6 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
                          const std::vector<OpReqType>& grad_req_type,
                          const std::vector<NDArray>& aux_states,
                          Executor* shared_exec) {
-  //std::vector<NDArray>* shared_pool = nullptr;
   std::vector<SharedStorageEntry> shared_pool;
   if (shared_exec != nullptr) {
      for (auto& nd : dynamic_cast<GraphExecutor*>(shared_exec)->data_pool_) {
@@ -369,8 +368,6 @@ Graph GraphExecutor::InitGraph(nnvm::Symbol symbol,
                                const std::vector<SharedStorageEntry> shared_pool) {
   // setup gradient
   nnvm::Graph g = InitFullGraph(symbol, grad_req_type, arg_grad_store);
-  // TODO avoid making it shared?
-  //g.attrs["shared_pool"] = std::make_shared<nnvm::any>(shared_pool);
   g.attrs["shared_pool"] = std::make_shared<nnvm::any>(shared_pool);
   g = AssignContext(g, default_ctx, ctx_map,
                     in_args,
@@ -515,8 +512,10 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
       TShape shape{index_t(nword)};
       NDArray nd(shape, ctx);
       data_pool_.push_back(nd);
-//NDArray(shape, ctx));
-      if (shared_pool != nullptr)  shared_pool->push_back(nd);    
+      // put the new allocated arrays to shared pool
+      if (shared_pool != nullptr)  {
+        shared_pool->push_back(nd);
+      }
       num_new_ndarray++;
     }
   }

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -328,7 +328,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
   g = AttachOpResources(g);
   graph_ = std::move(g);
   if (shared_exec != nullptr) {
-    this->InitDataEntryMemory((&dynamic_cast<GraphExecutor*>(shared_exec)->data_pool_));
+    this->InitDataEntryMemory(&(dynamic_cast<GraphExecutor*>(shared_exec)->data_pool_));
   } else {
     this->InitDataEntryMemory(nullptr);
   }

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -28,7 +28,6 @@ using nnvm::Graph;
 class GraphExecutor : public Executor {
  public:
   using Executor::MonitorCallback;
-  using SharedStorageEntry = std::pair<int, size_t>;
 
   virtual ~GraphExecutor();
   void Forward(bool is_train) override;
@@ -68,8 +67,7 @@ class GraphExecutor : public Executor {
                   const std::vector<NDArray>& in_args,
                   const std::vector<NDArray>& arg_grad_store,
                   const std::vector<OpReqType>& grad_req_type,
-                  const std::vector<NDArray>& aux_states,
-                  const std::vector<SharedStorageEntry> shared_pool);
+                  const std::vector<NDArray>& aux_states);
   // initialize the full graph, including gradient.
   Graph InitFullGraph(nnvm::Symbol symbol,
                       const std::vector<OpReqType>& grad_req_type,

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -28,6 +28,8 @@ using nnvm::Graph;
 class GraphExecutor : public Executor {
  public:
   using Executor::MonitorCallback;
+  using SharedStorageEntry = std::pair<int, size_t>;
+
   virtual ~GraphExecutor();
   void Forward(bool is_train) override;
   void PartialForward(bool is_train, int step, int *step_left) override;
@@ -67,8 +69,7 @@ class GraphExecutor : public Executor {
                   const std::vector<NDArray>& arg_grad_store,
                   const std::vector<OpReqType>& grad_req_type,
                   const std::vector<NDArray>& aux_states,
-std::multimap<size_t, size_t> shared_pool
-);
+                  const std::vector<SharedStorageEntry> shared_pool);
   // initialize the full graph, including gradient.
   Graph InitFullGraph(nnvm::Symbol symbol,
                       const std::vector<OpReqType>& grad_req_type,
@@ -78,7 +79,7 @@ std::multimap<size_t, size_t> shared_pool
   // initialize the resources in the graph
   // initialize the memory of data entries
   // shared_pool: extra memory shared from other parts
-  void InitDataEntryMemory(const std::vector<NDArray>& shared_pool);
+  void InitDataEntryMemory(std::vector<NDArray>* shared_pool);
   // run ops from topo order start to end
   void RunOps(bool is_train, size_t topo_start, size_t topo_end);
   // internal graph

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -66,7 +66,9 @@ class GraphExecutor : public Executor {
                   const std::vector<NDArray>& in_args,
                   const std::vector<NDArray>& arg_grad_store,
                   const std::vector<OpReqType>& grad_req_type,
-                  const std::vector<NDArray>& aux_states);
+                  const std::vector<NDArray>& aux_states,
+std::multimap<size_t, size_t> shared_pool
+);
   // initialize the full graph, including gradient.
   Graph InitFullGraph(nnvm::Symbol symbol,
                       const std::vector<OpReqType>& grad_req_type,

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -108,8 +108,63 @@ def test_module_states():
     for x1, x2 in zip(out1, out2):
         assert not mx.test_utils.almost_equal(x1.asnumpy(), x2.asnumpy(), rtol=1e-3)
 
+def test_module_switch_bucket():
+    vocab_dim = 5000
+    num_hidden = 100
+    num_embedding = 100
+    num_layer = 2
+    default_key = 10
+    test_key = 5
+    batch_size = 32
+    contexts = [mx.cpu(0)]
+    initializer = mx.init.Xavier(factor_type="in", magnitude=2.34)
+
+    #generate symbols for an LSTM network
+    def sym_gen(seq_len):
+        data = mx.sym.Variable('data')
+        label = mx.sym.Variable('softmax_label')
+        embed = mx.sym.Embedding(data=data, input_dim=vocab_dim,
+                                 output_dim=num_embedding, name='embed')
+        stack = mx.rnn.SequentialRNNCell()
+        for i in range(num_layer):
+            stack.add(mx.rnn.LSTMCell(num_hidden=num_hidden, prefix='lstm_l%d_'%i))
+        outputs, states = stack.unroll(seq_len, inputs=embed, merge_outputs=True)
+
+        pred = mx.sym.Reshape(outputs, shape=(-1, num_hidden))
+        pred = mx.sym.FullyConnected(data=pred, num_hidden=vocab_dim, name='pred')
+
+        label = mx.sym.Reshape(label, shape=(-1,))
+        pred = mx.sym.SoftmaxOutput(data=pred, label=label, name='softmax')
+
+        return pred, ('data',), ('softmax_label',)
+
+    def create_bucketing_module(key):
+        model = mx.mod.BucketingModule(
+            sym_gen             = sym_gen,
+            default_bucket_key  = key,
+            context             = contexts)
+        model.bind([('data', (batch_size, key))],
+                    [('softmax_label', (batch_size, key))], True, False)
+        model.init_params(initializer=initializer)
+        return model
+    #initialize the bucketing module with the default bucket key
+    bucketing_model = create_bucketing_module(default_key)
+    #switch to test_key
+    bucketing_model.switch_bucket(test_key, [('data', (batch_size, test_key))],
+                                  [('softmax_label', (batch_size, test_key))])
+    total_bytes_before = bucketing_model._buckets[default_key].total_exec_bytes
+
+    #remove test_key and switch again
+    del bucketing_model._buckets[test_key]
+    bucketing_model.switch_bucket(test_key, [('data', (batch_size, test_key))],
+                                  [('softmax_label', (batch_size, test_key))])
+    total_bytes_after = bucketing_model._buckets[default_key].total_exec_bytes
+    #the default bucket is expected to reuse the bytes allocated
+    assert total_bytes_after == total_bytes_before
+
 if __name__ == '__main__':
     test_module_states()
     test_module_reshape()
     test_save_load()
     test_module_layout()
+    test_module_switch_bucket()

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -152,13 +152,13 @@ def test_module_switch_bucket():
     #switch to test_key
     bucketing_model.switch_bucket(test_key, [('data', (batch_size, test_key))],
                                   [('softmax_label', (batch_size, test_key))])
-    total_bytes_before = bucketing_model._buckets[default_key].total_exec_bytes
+    total_bytes_before = bucketing_model._buckets[default_key]._total_exec_bytes
 
     #remove test_key and switch again
     del bucketing_model._buckets[test_key]
     bucketing_model.switch_bucket(test_key, [('data', (batch_size, test_key))],
                                   [('softmax_label', (batch_size, test_key))])
-    total_bytes_after = bucketing_model._buckets[default_key].total_exec_bytes
+    total_bytes_after = bucketing_model._buckets[default_key]._total_exec_bytes
     #the default bucket is expected to reuse the bytes allocated
     assert total_bytes_after == total_bytes_before
 


### PR DESCRIPTION
#4795
#5123
#5035 

(Together with NNVM PR https://github.com/dmlc/nnvm/pull/105) 


Found some inefficiency in the system and made a few changes related to memory allocation in MXNet: 

1.  In the bucketing module, `curr_module` is passed in as the `shared_module`, but instead the module with default_bucket_key should be passed. [Link](https://github.com/eric-haibin-lin/mxnet/blob/memory/python/mxnet/module/bucketing_module.py#L214).  
2.  When the memory pool of the default bucket module doesn't hold sufficient memory for other bucket to bind, extra NDArrays are allocated. But these NDArrays are not added back to the pool.  [Link](https://github.com/eric-haibin-lin/mxnet/blob/memory/src/executor/graph_executor.cc#L517)
3.  While matching new memory required to the existing memory slots in the pool, the new memory list is not sorted based on size, which could result in small memory blocks occupying a big one. 
4. The `NNVM_EXEC_MATCH_RANGE` variable has impact on the result of memory planning. Instead of letting the user to choose it, the backend could just try different values and choose the best one to automate the process. Some users are not even aware of this variable. [Link](https://github.com/eric-haibin-lin/nnvm/blob/memory/src/pass/plan_memory.cc#L299)

Fixing 1 and 2 reduce the memory quite a lot, while 3 and 4 bring marginal reduction if 1 and 2 are fixed (5% ~ 10%). 



Benchmark result on LSTM workload: 

| Version ( | 22673b6 (baseline) | 1 | 1 + 2 | 1 + 2 + 3 | 1 + 2 + 3 + 4 |
| --- | --- | --- | --- | --- | --- | 
| Memory (MB) | > 12288 (Out of Memory) | 4297 | 1956 | 1774 | 1718

Benchmark result on Neural Style workload 

| Version ( | 22673b6 (baseline) | 1 + 2 + 3 + 4 |
| --- | --- | --- | 
| Memory (MB) | > 12288 (Out of Memory) | 2034 |

* LSTM configuration:  python lstm_bucketing.py --gpus=0 --num-layers=4 --num-hidden=1024 --num-embed=512 --num-epochs=1
* Neural style uses default configuration