### PR TITLE
Correct handling of weight decay in Adam and RMSProp, uncentered version of RMSProp, weight clipping for RMSProp

### DIFF
--- a/perl-package/AI-MXNet/t/optimizers.t
+++ b/perl-package/AI-MXNet/t/optimizers.t
@@ -58,7 +58,8 @@ method update($index, $weight, $grad, $state)
     $self->_update_count($index);
     my $t = $self->_index_update_count->{$index};
     my ($mean, $variance) = @$state;
-    $grad *= $self->rescale_grad;
+    my $wd = $self->_get_wd($index);
+    $grad = $grad * $self->rescale_grad + $wd * $weight;
     if($self->clip_gradient)
     {
         mx->nd->clip($grad, -$self->clip_gradient, $self->clip_gradient, { out => $grad });
@@ -73,12 +74,6 @@ method update($index, $weight, $grad, $state)
     my $coef2 = 1 - $self->beta2**$t;
     $lr *= sqrt($coef2)/$coef1;
     $weight -= $lr*$mean/(mx->nd->sqrt($variance) + $self->epsilon);
-
-    my $wd = $self->_get_wd($index);
-    if($wd > 0)
-    {
-        $weight -= ($lr * $wd) * $weight;
-    }
 }
 
 package main;

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -3,7 +3,7 @@
 import math
 import pickle
 from .ndarray import NDArray, zeros, clip, sqrt
-from .ndarray import sgd_update, sgd_mom_update, adam_update, rmsprop_update
+from .ndarray import sgd_update, sgd_mom_update, adam_update, rmsprop_update, rmspropalex_update
 from .random import normal
 
 
@@ -632,6 +632,68 @@ class AdaGrad(Optimizer):
 class RMSProp(Optimizer):
     """RMSProp optimizer of Tieleman & Hinton, 2012,
 
+    This code follows the version in http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf
+    by Tieleman & Hinton, 2012
+
+    Parameters
+    ----------
+    learning_rate : float, optional
+        Step size.
+        Default value is set to 0.002.
+    gamma1: float, optional
+        decay factor of moving average for gradient^2.
+        Default value is set to 0.95.
+    wd : float, optional
+        L2 regularization coefficient add to all the weights
+    rescale_grad : float, optional
+        rescaling factor of gradient.
+    clip_gradient : float, optional
+        clip gradient in range [-clip_gradient, clip_gradient]
+    """
+    def __init__(self, learning_rate=0.002, gamma1=0.95,
+                 epsilon=1e-8, **kwargs):
+        super(RMSProp, self).__init__(learning_rate=learning_rate, **kwargs)
+        self.gamma1 = gamma1
+        self.kwargs = {'gamma1': gamma1, 'epsilon': epsilon,
+                       'rescale_grad': self.rescale_grad}
+        if self.clip_gradient:
+            self.kwargs['clip_gradient'] = self.clip_gradient
+
+    def create_state(self, index, weight):
+        """Create additional optimizer state: n
+        Parameters
+        ----------
+        weight : NDArray
+            The weight data
+        """
+        return (zeros(weight.shape, weight.context), )  # n
+
+    def update(self, index, weight, grad, state):
+        """Update the parameters.
+        Parameters
+        ----------
+        index : int
+            An unique integer key used to index the parameters
+        weight : NDArray
+            weight ndarray
+        grad : NDArray
+            grad ndarray
+        state : NDArray or other objects returned by init_state
+            The auxiliary state used in optimization.
+        """
+        assert(isinstance(weight, NDArray))
+        assert(isinstance(grad, NDArray))
+        lr = self._get_lr(index)
+        wd = self._get_wd(index)
+        self._update_count(index)
+        (n, ) = state
+        rmsprop_update(weight, grad, n, out=weight, lr=lr, wd=wd, **self.kwargs)
+
+
+@register
+class RMSPropAlex(Optimizer):
+    """RMSPropAlex optimizer of Tieleman & Hinton, 2012,
+
     This code follows the version in  http://arxiv.org/pdf/1308.0850v5.pdf Eq(38) - Eq(45)
     by Alex Graves, 2013.
 
@@ -639,7 +701,7 @@ class RMSProp(Optimizer):
     ----------
     learning_rate : float, optional
         Step size.
-        Default value is set to 0.002.
+        Default value is set to 0.001.
     gamma1: float, optional
         decay factor of moving average for gradient, gradient^2.
         Default value is set to 0.95.
@@ -657,7 +719,7 @@ class RMSProp(Optimizer):
     """
     def __init__(self, learning_rate=0.001, gamma1=0.95, gamma2=0.9,
                  epsilon=1e-8, **kwargs):
-        super(RMSProp, self).__init__(learning_rate=learning_rate, **kwargs)
+        super(RMSPropAlex, self).__init__(learning_rate=learning_rate, **kwargs)
         self.gamma1 = gamma1
         self.gamma2 = gamma2
         self.kwargs = {'gamma1': gamma1, 'gamma2': gamma2, 'epsilon': epsilon,
@@ -666,7 +728,7 @@ class RMSProp(Optimizer):
             self.kwargs['clip_gradient'] = self.clip_gradient
 
     def create_state(self, index, weight):
-        """Create additional optimizer state: mean, variance
+        """Create additional optimizer state: n, g, delta
 
         Parameters
         ----------
@@ -701,7 +763,7 @@ class RMSProp(Optimizer):
         wd = self._get_wd(index)
         self._update_count(index)
         n, g, delta = state
-        rmsprop_update(weight, grad, n, g, delta, out=weight,
+        rmspropalex_update(weight, grad, n, g, delta, out=weight,
                        lr=lr, wd=wd, **self.kwargs)
 
 @register

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -661,20 +661,25 @@ class RMSProp(Optimizer):
         rescaling factor of gradient.
     clip_gradient : float, optional
         clip gradient in range [-clip_gradient, clip_gradient]
+    clip_weights : float, optional
+        clip weights in range [-clip_weights, clip_weights]
 
     """
     def __init__(self, learning_rate=0.001, gamma1=0.9, gamma2=0.9,
-                 epsilon=1e-8, centered=False, **kwargs):
+                 epsilon=1e-8, centered=False, clip_weights=None, **kwargs):
         super(RMSProp, self).__init__(learning_rate=learning_rate, **kwargs)
         self.gamma1 = gamma1
         self.gamma2 = gamma2
         self.centered = centered
+        self.clip_weights = clip_weights
         self.kwargs = {'gamma1': gamma1, 'epsilon': epsilon,
                        'rescale_grad': self.rescale_grad}
         if self.centered:
             self.kwargs['gamma2'] = gamma2
         if self.clip_gradient:
             self.kwargs['clip_gradient'] = self.clip_gradient
+        if self.clip_weights:
+            self.kwargs['clip_weights'] = self.clip_weights
 
     def create_state(self, index, weight):
         """Create additional optimizer state.

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -193,7 +193,9 @@ inline void AdamUpdate(const nnvm::NodeAttrs& attrs,
       var = scalar<DType>(param.beta2)*var + scalar<DType>(1.f-param.beta2) * F<square>(grad);
     }
     Assign(out, req[0],
-           weight - scalar<DType>(param.lr)*mean/(F<square_root>(var)+scalar<DType>(param.epsilon)));
+           weight -
+           scalar<DType>(param.lr) * mean /
+           (F<square_root>(var) + scalar<DType>(param.epsilon)));
   });
 }
 

--- a/src/operator/optimizer_op.cc
+++ b/src/operator/optimizer_op.cc
@@ -13,6 +13,7 @@ DMLC_REGISTER_PARAMETER(SGDParam);
 DMLC_REGISTER_PARAMETER(SGDMomParam);
 DMLC_REGISTER_PARAMETER(AdamParam);
 DMLC_REGISTER_PARAMETER(RMSPropParam);
+DMLC_REGISTER_PARAMETER(RMSPropAlexParam);
 
 NNVM_REGISTER_OP(sgd_update)
 .describe("Updater function for sgd optimizer")
@@ -55,18 +56,35 @@ NNVM_REGISTER_OP(adam_update)
 NNVM_REGISTER_OP(rmsprop_update)
 .describe("Updater function for RMSProp optimizer."
           " The RMSProp code follows the version in"
+          " http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf "
+          "Tieleman & Hinton, 2012.")
+.set_num_inputs(3)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<RMSPropParam>)
+.set_attr<nnvm::FInferShape>("FInferShape", ElemwiseShape<3, 1>)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<3, 1>)
+.set_attr<nnvm::FMutateInputs>("FMutateInputs",
+  [](const nnvm::NodeAttrs &attrs) {
+    return std::vector<uint32_t>{2};
+  })
+.set_attr<FCompute>("FCompute<cpu>", RMSPropUpdate<cpu>)
+.add_arguments(RMSPropParam::__FIELDS__());
+
+NNVM_REGISTER_OP(rmspropalex_update)
+.describe("Updater function for RMSPropAlex optimizer."
+          " The RMSPropAlex code follows the version in"
           " http://arxiv.org/pdf/1308.0850v5.pdf Eq(38) - Eq(45) by Alex Graves, 2013.")
 .set_num_inputs(5)
 .set_num_outputs(1)
-.set_attr_parser(ParamParser<RMSPropParam>)
+.set_attr_parser(ParamParser<RMSPropAlexParam>)
 .set_attr<nnvm::FInferShape>("FInferShape", ElemwiseShape<5, 1>)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<5, 1>)
 .set_attr<nnvm::FMutateInputs>("FMutateInputs",
   [](const nnvm::NodeAttrs& attrs) {
     return std::vector<uint32_t>{2, 3, 4};
   })
-.set_attr<FCompute>("FCompute<cpu>", RMSPropUpdate<cpu>)
-.add_arguments(RMSPropParam::__FIELDS__());
+.set_attr<FCompute>("FCompute<cpu>", RMSPropAlexUpdate<cpu>)
+.add_arguments(RMSPropAlexParam::__FIELDS__());
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/optimizer_op.cu
+++ b/src/operator/optimizer_op.cu
@@ -21,5 +21,8 @@ NNVM_REGISTER_OP(adam_update)
 NNVM_REGISTER_OP(rmsprop_update)
 .set_attr<FCompute>("FCompute<gpu>", RMSPropUpdate<gpu>);
 
+NNVM_REGISTER_OP(rmspropalex_update)
+.set_attr<FCompute>("FCompute<gpu>", RMSPropAlexUpdate<gpu>);
+
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -94,7 +94,9 @@ class PyAdam(mx.optimizer.Optimizer):
 
         t = self._index_update_count[index]
         mean, variance = state
-        grad *= self.rescale_grad
+
+        wd = self._get_wd(index)
+        grad = grad * self.rescale_grad + wd * weight
         if self.clip_gradient is not None:
             mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient, out=grad)
 
@@ -109,10 +111,6 @@ class PyAdam(mx.optimizer.Optimizer):
         lr *= math.sqrt(coef2)/coef1
 
         weight -= lr*mean/(mx.nd.sqrt(variance) + self.epsilon)
-
-        wd = self._get_wd(index)
-        if wd > 0.:
-            weight[:] -= (lr * wd) * weight
 
 
 def test_adam():

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -211,14 +211,14 @@ class PyRMSProp(mx.optimizer.Optimizer):
         lr = self._get_lr(index)
         wd = self._get_wd(index)
         self._update_count(index)
-        grad = grad * self.rescale_grad
+        grad = grad * self.rescale_grad + wd * weight
 
         if not self.centered:
             (n, ) = state
             if self.clip_gradient is not None:
                 grad = mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient)
             n[:] = (1 - self.gamma1) * (grad * grad) + self.gamma1 * n
-            weight[:] -= lr * (grad/(mx.nd.sqrt(n) + self.epsilon) + wd * weight)
+            weight[:] -= lr * grad/(mx.nd.sqrt(n) + self.epsilon)
 
         else:
             n, g, delta = state
@@ -226,7 +226,7 @@ class PyRMSProp(mx.optimizer.Optimizer):
                 grad = mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient)
             n[:] = (1 - self.gamma1) * (grad * grad) + self.gamma1 * n
             g[:] = (1 - self.gamma1) * grad + self.gamma1 * g
-            delta[:] = (self.gamma2) * delta - lr * (grad/(mx.nd.sqrt(n - g*g) + self.epsilon) + wd * weight)
+            delta[:] = (self.gamma2) * delta - lr * grad/(mx.nd.sqrt(n - g*g) + self.epsilon)
             weight[:] += delta
 
 

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -132,7 +132,7 @@ def test_adam():
 
 # RMSProp
 
-class PyRMSProp(mx.optimizer.Optimizer):
+class PyRMSPropAlex(mx.optimizer.Optimizer):
     """RMSProp optimizer of Tieleman & Hinton, 2012,
 
     This code follows the version in  http://arxiv.org/pdf/1308.0850v5.pdf Eq(38) - Eq(45)
@@ -158,13 +158,13 @@ class PyRMSProp(mx.optimizer.Optimizer):
     """
     def __init__(self, learning_rate=0.001, gamma1=0.95, gamma2=0.9,
                  epsilon=1e-8, **kwargs):
-        super(PyRMSProp, self).__init__(learning_rate=learning_rate, **kwargs)
+        super(PyRMSPropAlex, self).__init__(learning_rate=learning_rate, **kwargs)
         self.gamma1 = gamma1
         self.gamma2 = gamma2
         self.epsilon = epsilon
 
     def create_state(self, index, weight):
-        """Create additional optimizer state: mean, variance
+        """Create additional optimizer state: n, g, delta
 
         Parameters
         ----------
@@ -205,6 +205,88 @@ class PyRMSProp(mx.optimizer.Optimizer):
         delta[:] = (self.gamma2) * delta - lr * (grad/(mx.nd.sqrt(n - g*g) + self.epsilon) + wd * weight)
         weight[:] += delta
 
+
+def test_rms_alex():
+    mx.random.seed(0)
+    opt1 = PyRMSPropAlex
+    opt2 = mx.optimizer.RMSPropAlex
+    shape = (3, 4, 5)
+    kwargs = [{},
+              {'clip_gradient': 0.5},
+              {'clip_gradient': 0.4, 'rescale_grad': 0.14},
+              {'rescale_grad': 0.8},
+              {'clip_gradient': 0.5, 'wd': 0.07},
+              {'clip_gradient': 0.4, 'rescale_grad': 0.14, 'wd': 0.03},
+              {'rescale_grad': 0.8, 'wd': 0.05}]
+    for kwarg in kwargs:
+        compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape)
+
+
+class PyRMSProp(mx.optimizer.Optimizer):
+    """RMSProp optimizer of Tieleman & Hinton, 2012,
+
+    This code follows the version in http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf
+    by Tieleman & Hinton, 2012
+
+    Parameters
+    ----------
+    learning_rate : float, optional
+        Step size.
+        Default value is set to 0.002.
+    gamma1: float, optional
+        decay factor of moving average for gradient, gradient^2.
+        Default value is set to 0.95.
+    wd : float, optional
+        L2 regularization coefficient add to all the weights
+    rescale_grad : float, optional
+        rescaling factor of gradient.
+    clip_gradient : float, optional
+        clip gradient in range [-clip_gradient, clip_gradient]
+    """
+    def __init__(self, learning_rate=0.002, gamma1=0.95, gamma2=0.9,
+                 epsilon=1e-8, **kwargs):
+        super(PyRMSProp, self).__init__(learning_rate=learning_rate, **kwargs)
+        self.gamma1 = gamma1
+        self.epsilon = epsilon
+
+    def create_state(self, index, weight):
+        """Create additional optimizer state: n
+
+        Parameters
+        ----------
+        weight : NDArray
+            The weight data
+
+        """
+        return (mx.nd.zeros(weight.shape, weight.context), )  # n
+
+    def update(self, index, weight, grad, state):
+        """Update the parameters.
+
+        Parameters
+        ----------
+        index : int
+            An unique integer key used to index the parameters
+
+        weight : NDArray
+            weight ndarray
+
+        grad : NDArray
+            grad ndarray
+
+        state : NDArray or other objects returned by init_state
+            The auxiliary state used in optimization.
+        """
+        lr = self._get_lr(index)
+        wd = self._get_wd(index)
+        self._update_count(index)
+        (n, ) = state
+        grad = grad * self.rescale_grad
+        if self.clip_gradient is not None:
+            grad = mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient)
+        n[:] = (1 - self.gamma1) * (grad * grad) + self.gamma1 * n
+        weight[:] -= lr * (grad/(mx.nd.sqrt(n) + self.epsilon) + wd * weight)
+
 def test_rms():
     mx.random.seed(0)
     opt1 = PyRMSProp
@@ -222,4 +304,5 @@ def test_rms():
 
 if __name__ == '__main__':
     test_adam()
+    test_rms_alex()
     test_rms()


### PR DESCRIPTION
See #5099 on the handling of weight decay.

Weight clipping is necessary to train WassersteinGAN. Clipping the weights directly in the optimizer speeds things up compared to iterating over the weight / bias arrays in Python and performing the weight clipping there. WassersteinGAN are typically trained with RMSProp.

This pull request obsoletes #5116 and introduces the uncentered version of RMSProp.