### PR TITLE
remove redundancy head in storage

### DIFF
--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -9,7 +9,6 @@
 #include "./naive_storage_manager.h"
 #include "./pooled_storage_manager.h"
 #include "./cpu_device_storage.h"
-#include "./gpu_device_storage.h"
 #include "./pinned_memory_storage.h"
 #include "../common/cuda_utils.h"
 #include "../common/lazy_alloc_array.h"


### PR DESCRIPTION
ps, i found ```src/storage/gpu_device_storage.h``` is no need more, should we also delete it?