### PR TITLE
Fix char RNN dataset URLs

### DIFF
--- a/scala-package/examples/scripts/rnn/run_test_charrnn.sh
+++ b/scala-package/examples/scripts/rnn/run_test_charrnn.sh
@@ -4,8 +4,8 @@ MXNET_ROOT=$(cd "$(dirname $0)/../../../.."; pwd)
 CLASS_PATH=$MXNET_ROOT/scala-package/assembly/linux-x86_64-gpu/target/*:$MXNET_ROOT/scala-package/examples/target/*:$MXNET_ROOT/scala-package/examples/target/classes/lib/*
 
 # you can get the training data file using the following command
-# wget http://data.mxnet.io/mxnet/data/lab_data.zip
-# unzip -o lab_data.zip
+# wget http://data.mxnet.io/data/char_lstm.zip
+# unzip -o char_lstm.zip
 # for example ./datas/obama.txt
 DATA_PATH=$1
 # for example ./models/obama

--- a/scala-package/examples/scripts/rnn/run_train_charrnn.sh
+++ b/scala-package/examples/scripts/rnn/run_train_charrnn.sh
@@ -6,8 +6,8 @@ CLASS_PATH=$MXNET_ROOT/scala-package/assembly/linux-x86_64-gpu/target/*:$MXNET_R
 # which gpu card to use, -1 means cpu
 GPU=$1
 # you can get the training data file using the following command
-# wget http://data.mxnet.io/mxnet/data/lab_data.zip
-# unzip -o lab_data.zip
+# wget http://data.mxnet.io/data/char_lstm.zip
+# unzip -o char_lstm.zip
 # for example ./datas/obama.txt
 DATA_PATH=$2
 # for example ./models


### PR DESCRIPTION
The URLs in the comments of the shell scripts for the Scala char RNN examples appear to be outdated.