### PR TITLE
fix Profiler timestamp when using VC12

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -124,3 +124,4 @@ List of Contributors
 * [Chihiro Komaki](https://github.com/ckomaki)
 * [Piyush Singh](https://github.com/Piyush3dB)
 * [Freddy Chua](https://github.com/freddycct)
+* [Jie Zhang](https://github.com/luoyetx)

--- a/src/engine/profiler.cc
+++ b/src/engine/profiler.cc
@@ -13,6 +13,10 @@
 #include <fstream>
 #include "./profiler.h"
 
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+#include <Windows.h>
+#endif
+
 namespace mxnet {
 namespace engine {
 #if MXNET_USE_PROFILER
@@ -180,8 +184,15 @@ void Profiler::DumpProfile() {
 
 
 inline uint64_t NowInUsec() {
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+  LARGE_INTEGER frequency, counter;
+  QueryPerformanceFrequency(&frequency);
+  QueryPerformanceCounter(&counter);
+  return counter.QuadPart * 1000000 / frequency.QuadPart;
+#else
   return std::chrono::duration_cast<std::chrono::microseconds>(
     std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+#endif
 }
 
 void SetOprStart(OprExecStat* opr_stat) {


### PR DESCRIPTION
function `Profiler::NowInUsec()` uses `high_resolution_clock` to get the time stamp. However, the implement of the class is not accuracy before VC15.

Using high_resolution_clock in VC12
![before](https://cloud.githubusercontent.com/assets/2768843/23392659/4bdafe96-fdb8-11e6-9a50-8c9f72e4b93a.png)

Using QueryPerformanceCounter functions
![after](https://cloud.githubusercontent.com/assets/2768843/23392687/70f7540e-fdb8-11e6-993f-66ecead1c946.png)

More detail can be found [here](https://msdn.microsoft.com/en-us/library/windows/desktop/dn553408(v=vs.85).aspx) and [here](https://msdn.microsoft.com/en-us/library/hh874757(v=vs.140).aspx)

