### PR TITLE
solved issue with multiple outputs in visualize in python

### DIFF
--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -298,6 +298,11 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
                     if draw_shape:
                         if input_node["op"] != "null":
                             key = input_name + "_output"
+                            if "attr" in input_node:
+                                params = input_node["attr"]
+                                if "num_outputs" in params:
+                                    key += str(int(params["num_outputs"]) - 1)
+                                    params["num_outputs"] = int(params["num_outputs"]) - 1
                             shape = shape_dict[key][1:]
                             label = "x".join([str(x) for x in shape])
                             attr["label"] = label

--- a/tests/python/unittest/test_viz.py
+++ b/tests/python/unittest/test_viz.py
@@ -9,10 +9,11 @@ def test_print_summary():
     mp1 = mx.symbol.Pooling(data = act1, name = 'mp1', kernel=(2,2), stride=(2,2), pool_type='max')
     fc1 = mx.sym.FullyConnected(data=mp1, bias=bias, name='fc1', num_hidden=10, lr_mult=0)
     fc2 = mx.sym.FullyConnected(data=fc1, name='fc2', num_hidden=10, wd_mult=0.5)
-    mx.viz.print_summary(fc2)
+    sc1 = mx.symbol.SliceChannel(data=fc2, num_outputs=10, name="slice_1", squeeze_axis=0)
+    mx.viz.print_summary(sc1)
     shape = {}
     shape["data"]=(1,3,28,28)
-    mx.viz.print_summary(fc2, shape)
+    mx.viz.print_summary(sc1, shape)
 
 if __name__ == "__main__":
     test_print_summary()


### PR DESCRIPTION
When the symbol has multiple outputs and get input shape argument
visualization.py crashed into issues.
For example, when I use the symbol like slicechannel(name=slice_1) which has multiple output(for example 2 ouputs)
the shape_dict's keys were made like 'slice_1_output1' and 'slice_1_output2'.
But by the difference of input_nodes and shape_dict, it attempts to finds 'slice_1_output' instead of the 'slice_1_output1'.
So I added code to overcome this issue, and
made an additional test with sliceChannel symbol to confirm.
Related Issue is #3221