### PR TITLE
Add stacked fused RNN example

### DIFF
--- a/example/rnn/cudnn_lstm_bucketing.py
+++ b/example/rnn/cudnn_lstm_bucketing.py
@@ -35,7 +35,14 @@ parser.add_argument('--batch-size', type=int, default=32,
                     help='the batch size.')
 parser.add_argument('--disp-batches', type=int, default=50,
                     help='show progress for every n batches')
-
+# When training a deep, complex model, it's recommended to stack fused RNN cells (one
+# layer per cell) together instead of one with all layers. The reason is that fused RNN
+# cells doesn't set gradients to be ready until the computation for the entire layer is
+# completed. Breaking a multi-layer fused RNN cell into several one-layer ones allows
+# gradients to be processed ealier. This reduces communication overhead, especially with
+# multiple GPUs.
+parser.add_argument('--stack-rnn', default=False,
+                    help='stack fused RNN cells to reduce communication overhead')
 
 #buckets = [32]
 buckets = [10, 20, 30, 40, 50, 60]
@@ -64,15 +71,7 @@ def get_data(layout):
 
 def train(args):
     data_train, data_val, vocab = get_data('TN')
-
-    # When training a deep, complex model, it's recommended to stack fused RNN cells (one
-    # layer per cell) together instead of one with all layers. The reason is that fused RNN
-    # cells doesn't set gradients to be ready until the computation for the entire layer is
-    # completed. Breaking a multi-layer fused RNN cell into several one-layer ones allows
-    # gradients to be processed ealier. This reduces communication overhead, especially with
-    # multiple GPUs.
-    stack_fused_rnn = args.num_layers >= 4
-    if stack_fused_rnn:
+    if args.stack_rnn:
         cells = []
         for layer in xrange(args.num_layers):
             cell = mx.rnn.FusedRNNCell(args.num_hidden, num_layers=1, mode='lstm', prefix='fused_rnn' + str(layer))
@@ -85,7 +84,7 @@ def train(args):
         label = mx.sym.Variable('softmax_label')
         embed = mx.sym.Embedding(data=data, input_dim=len(vocab), output_dim=args.num_embed,name='embed')
 
-        if stack_fused_rnn:
+        if args.stack_rnn:
             output = embed
             for i in xrange(args.num_layers):
                 cells[i].reset()

--- a/example/rnn/cudnn_lstm_bucketing.py
+++ b/example/rnn/cudnn_lstm_bucketing.py
@@ -185,6 +185,10 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG, format=head)
 
     args = parser.parse_args()
+
+    if args.num_layers >= 4 and len(args.gpus.split(',')) >= 4 and not args.stack_rnn:
+        print('WARNING: stack-rnn is recommended to train complex model on multiple GPUs')
+
     if args.test:
         # Demonstrates how to load a model trained with CuDNN RNN and predict
         # with non-fused MXNet symbol


### PR DESCRIPTION
Stack multiple fused RNN cells instead of one cell with multiple layer. 

Benchmark result: 

| Version | baseline | stacked |
| --- | --- | --- 
| Seconds per epoch | 226.58 | 123.0 (1.8x speedup)

* cudnn_lstm_bucketing.py --gpus=0,1,2,3,4,5,6,7,8 --num-layers=4 --num-embed=512 --num-hidden=1024