### PR TITLE
Fix broken amalgamation

### DIFF
--- a/amalgamation/amalgamation.py
+++ b/amalgamation/amalgamation.py
@@ -8,7 +8,7 @@ blacklist = [
     'kvstore_dist.h', 'mach/clock.h', 'mach/mach.h',
     'malloc.h', 'mkl.h', 'mkl_cblas.h', 'mkl_vsl.h', 'mkl_vsl_functions.h',
     'nvml.h', 'opencv2/opencv.hpp', 'sys/stat.h', 'sys/types.h', 'cuda.h', 'cuda_fp16.h',
-    'omp.h', 'execinfo.h', 'packet/sse-inl.h', 'emmintrin.h'
+    'omp.h', 'execinfo.h', 'packet/sse-inl.h', 'emmintrin.h', 'thrust/device_vector.h'
     ]
 
 minimum = int(sys.argv[6]) if len(sys.argv) > 5 else 0


### PR DESCRIPTION
Amalgamation build is broken due to a recent change in `matrix_op-inl.h`.  

This PR provides a fix by adding `thrust/device_vector.h` to the blacklist.