### PR TITLE
Fixed docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,13 @@ MXNet Change Log
 ## 0.9.3
 - Move symbolic API to NNVM @tqchen
   - Most front-end C API are backward  compatible
-  - Removed symbolic api in MXNet and relies on NNVM
+  - Removed symbolic API in MXNet and relies on NNVM
 - New features:
-  - MXNet profiler for profiling operator level executions
+  - MXNet profiler for profiling operator-level executions
   - mxnet.image package for fast image loading and processing
 - Change of JSON format
   - param and attr field are merged to attr
-  - New code is backward compatible can load old json format
+  - New code is backward-compatible can load old json format
 - OpProperty registration now is deprecated
   - New operators are encouraged to register their property to NNVM op registry attribute
 - Known features removed limitations to be fixed

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Features
 * Mix and match good flavours of programming to maximize flexibility and efficiency
 * Lightweight, memory efficient and portable to smart devices
 * Scales up to multi GPUs and distributed setting with auto parallelism
-* Support for python, R, C++ and Julia
+* Support for Python, R, C++ and Julia
 * Cloud-friendly and directly compatible with S3, HDFS, and Azure
 
 Ask Questions
 -------------
-* Please use [mxnet/issues](https://github.com/dmlc/mxnet/issues) for how to use mxnet and reporting bugs 
+* Please use [mxnet/issues](https://github.com/dmlc/mxnet/issues) for how to use mxnet and reporting bugs
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ In Neural Information Processing Systems, Workshop on Machine Learning Systems, 
 
 History
 -------
-MXNet is initiated and designed in collaboration by the authors of [cxxnet](https://github.com/dmlc/cxxnet), [minerva](https://github.com/dmlc/minerva) and [purine2](https://github.com/purine/purine2). The project reflects what we have learnt from the past projects. It combines important flavors of the existing projects for efficiency, flexibility and memory efficiency.
+MXNet emerged from a collaboration by the authors of [cxxnet](https://github.com/dmlc/cxxnet), [minerva](https://github.com/dmlc/minerva), and [purine2](https://github.com/purine/purine2). The project reflects what we have learned from the past projects. MXNet combines aspects of these prior projects to achieve flexibility, speed, and the efficient use of memory.

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ In Neural Information Processing Systems, Workshop on Machine Learning Systems, 
 
 History
 -------
-MXNet emerged from a collaboration by the authors of [cxxnet](https://github.com/dmlc/cxxnet), [minerva](https://github.com/dmlc/minerva), and [purine2](https://github.com/purine/purine2). The project reflects what we have learned from the past projects. MXNet combines aspects of these prior projects to achieve flexibility, speed, and the efficient use of memory.
+MXNet emerged from a collaboration by the authors of [cxxnet](https://github.com/dmlc/cxxnet), [minerva](https://github.com/dmlc/minerva), and [purine2](https://github.com/purine/purine2). The project reflects what we have learned from the past projects. MXNet combines aspects of each of these projects to achieve flexibility, speed, and memory efficiency.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![banner](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/banner.png)
 
 MXNet is a deep learning framework designed for both *efficiency* and *flexibility*.
-It allows you to ***mix*** [symbolic and imperative programming](http://mxnet.io/architecture/index.html#deep-learning-system-design-concepts) of symbolic
+It allows you to ***mix*** [symbolic and imperative programming](http://mxnet.io/architecture/index.html#deep-learning-system-design-concepts)
 to ***maximize*** efficiency and productivity.
 At its core, MXNet contains a dynamic dependency scheduler that automatically parallelizes both symbolic and imperative operations on the fly.
 A graph optimization layer on top of that makes symbolic execution fast and memory efficient.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 ![banner](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/banner.png)
 
 MXNet is a deep learning framework designed for both *efficiency* and *flexibility*.
-It allows you to ***mix*** the [flavours](http://mxnet.io/architecture/index.html#deep-learning-system-design-concepts) of symbolic
-programming and imperative programming to ***maximize*** efficiency and productivity.
+It allows you to ***mix*** [symbolic and imperative programming](http://mxnet.io/architecture/index.html#deep-learning-system-design-concepts) of symbolic
+to ***maximize*** efficiency and productivity.
 At its core, MXNet contains a dynamic dependency scheduler that automatically parallelizes both symbolic and imperative operations on the fly.
 A graph optimization layer on top of that makes symbolic execution fast and memory efficient.
 MXNet is portable and lightweight, scaling effectively to multiple GPUs and multiple machines.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Features
 --------
 * Design notes providing useful insights that can re-used by other DL projects
 * Flexible configuration for arbitrary computation graph
-* Mix and match good flavours of programming to maximize flexibility and efficiency
+* Mix and match imperative and symbolic programming to maximize flexibility and efficiency
 * Lightweight, memory efficient and portable to smart devices
 * Scales up to multi GPUs and distributed setting with auto parallelism
 * Support for Python, R, C++ and Julia
@@ -79,4 +79,4 @@ In Neural Information Processing Systems, Workshop on Machine Learning Systems, 
 
 History
 -------
-MXNet is initiated and designed in collaboration by the authors of [cxxnet](https://github.com/dmlc/cxxnet), [minerva](https://github.com/dmlc/minerva) and [purine2](https://github.com/purine/purine2). The project reflects what we have learnt from the past projects. It combines important flavours of the existing projects for efficiency, flexibility and memory efficiency.
+MXNet is initiated and designed in collaboration by the authors of [cxxnet](https://github.com/dmlc/cxxnet), [minerva](https://github.com/dmlc/minerva) and [purine2](https://github.com/purine/purine2). The project reflects what we have learnt from the past projects. It combines important flavors of the existing projects for efficiency, flexibility and memory efficiency.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 MXNet is a deep learning framework designed for both *efficiency* and *flexibility*.
 It allows you to ***mix*** the [flavours](http://mxnet.io/architecture/index.html#deep-learning-system-design-concepts) of symbolic
 programming and imperative programming to ***maximize*** efficiency and productivity.
-In its core, a dynamic dependency scheduler that automatically parallelizes both symbolic and imperative operations on the fly.
+At its core, MXNet contains a dynamic dependency scheduler that automatically parallelizes both symbolic and imperative operations on the fly.
 A graph optimization layer on top of that makes symbolic execution fast and memory efficient.
-The library is portable and lightweight, and it scales to multiple GPUs and multiple machines.
+MXNet is portable and lightweight, scaling effectively to multiple GPUs and multiple machines.
 
 MXNet is also more than a deep learning project. It is also a collection of
 [blue prints and guidelines](http://mxnet.io/architecture/index.html#deep-learning-system-design-concepts) for building
-deep learning system, and interesting insights of DL systems for hackers.
+deep learning systems, and interesting insights of DL systems for hackers.
 
 [![Join the chat at https://gitter.im/dmlc/mxnet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dmlc/mxnet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/docs/api/python/symbol.md
+++ b/docs/api/python/symbol.md
@@ -15,8 +15,8 @@ layer (e.g. convolution layer). We can bind data to a symbol to execute the
 computation.
 
 ```python
->>> a = mx.sym.var('a')
->>> b = mx.sym.var('b')
+>>> a = mx.sym.Variable('a')
+>>> b = mx.sym.Variable('b')
 >>> c = 2 * a + b
 >>> type(c)
 <class 'mxnet.symbol.Symbol'>


### PR DESCRIPTION
symbol.md referred to mxnet.symbol.var (doesn't exist)
~~~~
 a = mx.sym.var('a')
~~~~

Fixed in all places to Variable, e.g. 
~~~~
 a = mx.sym.Variable('a')
~~~~

Also improved documentation on README.md