### PR TITLE
float16 training for resnet

### DIFF
--- a/example/image-classification/symbols/resnet_fp16.py
+++ b/example/image-classification/symbols/resnet_fp16.py
@@ -1,0 +1,192 @@
+'''
+Adapted from https://github.com/tornadomeet/ResNet/blob/master/symbol_resnet.py
+Original author Wei Wu
+
+Implemented the following paper:
+
+Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun. "Identity Mappings in Deep Residual Networks"
+'''
+import mxnet as mx
+import numpy as np
+
+def residual_unit(data, num_filter, stride, dim_match, name, bottle_neck=True, bn_mom=0.9, workspace=256, memonger=False):
+    """Return ResNet Unit symbol for building ResNet
+    Parameters
+    ----------
+    data : str
+        Input data
+    num_filter : int
+        Number of output channels
+    bnf : int
+        Bottle neck channels factor with regard to num_filter
+    stride : tupe
+        Stride used in convolution
+    dim_match : Boolen
+        True means channel number between input and output is the same, otherwise means differ
+    name : str
+        Base name of the operators
+    workspace : int
+        Workspace used in convolution operator
+    """
+    if bottle_neck:
+        # the same as https://github.com/facebook/fb.resnet.torch#notes, a bit difference with origin paper
+        bn1 = mx.sym.BatchNorm(data=data, fix_gamma=False, eps=2e-5, momentum=bn_mom, name=name + '_bn1')
+        act1 = mx.sym.Activation(data=bn1, act_type='relu', name=name + '_relu1')
+        weight = mx.symbol.Variable(name=name + '_conv1_weight', dtype=np.float32)
+        weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+        conv1 = mx.sym.Convolution(data=act1, weight=weight, num_filter=int(num_filter*0.25), kernel=(1,1), stride=(1,1), pad=(0,0),
+                                   no_bias=True, workspace=workspace, name=name + '_conv1')
+        bn2 = mx.sym.BatchNorm(data=conv1, fix_gamma=False, eps=2e-5, momentum=bn_mom, name=name + '_bn2')
+        act2 = mx.sym.Activation(data=bn2, act_type='relu', name=name + '_relu2')
+        weight = mx.symbol.Variable(name=name + '_conv2_weight', dtype=np.float32)
+        weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+        conv2 = mx.sym.Convolution(data=act2, weight=weight, num_filter=int(num_filter*0.25), kernel=(3,3), stride=stride, pad=(1,1),
+                                   no_bias=True, workspace=workspace, name=name + '_conv2')
+        bn3 = mx.sym.BatchNorm(data=conv2, fix_gamma=False, eps=2e-5, momentum=bn_mom, name=name + '_bn3')
+        act3 = mx.sym.Activation(data=bn3, act_type='relu', name=name + '_relu3')
+        weight = mx.symbol.Variable(name=name + '_conv3_weight', dtype=np.float32)
+        weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+        conv3 = mx.sym.Convolution(data=act3, weight=weight, num_filter=num_filter, kernel=(1,1), stride=(1,1), pad=(0,0), no_bias=True,
+                                   workspace=workspace, name=name + '_conv3')
+        if dim_match:
+            shortcut = data
+        else:
+            weight = mx.symbol.Variable(name=name + '_sc_weight', dtype=np.float32)
+            weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+            shortcut = mx.sym.Convolution(data=act1, weight=weight, num_filter=num_filter, kernel=(1,1), stride=stride, no_bias=True,
+                                            workspace=workspace, name=name+'_sc')
+        if memonger:
+            shortcut._set_attr(mirror_stage='True')
+        return conv3 + shortcut
+    else:
+        bn1 = mx.sym.BatchNorm(data=data, fix_gamma=False, momentum=bn_mom, eps=2e-5, name=name + '_bn1')
+        act1 = mx.sym.Activation(data=bn1, act_type='relu', name=name + '_relu1')
+        weight = mx.symbol.Variable(name=name + '_conv1_weight', dtype=np.float32)
+        weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+        conv1 = mx.sym.Convolution(data=act1, weight=weight, num_filter=num_filter, kernel=(3,3), stride=stride, pad=(1,1),
+                                      no_bias=True, workspace=workspace, name=name + '_conv1')
+        bn2 = mx.sym.BatchNorm(data=conv1, fix_gamma=False, momentum=bn_mom, eps=2e-5, name=name + '_bn2')
+        act2 = mx.sym.Activation(data=bn2, act_type='relu', name=name + '_relu2')
+        weight = mx.symbol.Variable(name=name + '_conv2_weight', dtype=np.float32)
+        weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+        conv2 = mx.sym.Convolution(data=act2, weight=weight, num_filter=num_filter, kernel=(3,3), stride=(1,1), pad=(1,1),
+                                      no_bias=True, workspace=workspace, name=name + '_conv2')
+        if dim_match:
+            shortcut = data
+        else:
+            weight = mx.symbol.Variable(name=name + '_sc_weight', dtype=np.float32)
+            weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+            shortcut = mx.sym.Convolution(data=act1, weight=weight, num_filter=num_filter, kernel=(1,1), stride=stride, no_bias=True,
+                                            workspace=workspace, name=name+'_sc')
+        if memonger:
+            shortcut._set_attr(mirror_stage='True')
+        return conv2 + shortcut
+
+def resnet(units, num_stages, filter_list, num_classes, image_shape, bottle_neck=True, bn_mom=0.9, workspace=256, memonger=False):
+    """Return ResNet symbol of
+    Parameters
+    ----------
+    units : list
+        Number of units in each stage
+    num_stages : int
+        Number of stage
+    filter_list : list
+        Channel size of each stage
+    num_classes : int
+        Ouput size of symbol
+    dataset : str
+        Dataset type, only cifar10 and imagenet supports
+    workspace : int
+        Workspace used in convolution operator
+    """
+    num_unit = len(units)
+    assert(num_unit == num_stages)
+    data = mx.sym.Variable(name='data')
+    data = mx.symbol.Cast(data=data, dtype=np.float16)
+    data = mx.sym.BatchNorm(data=data, fix_gamma=True, eps=2e-5, momentum=bn_mom, name='bn_data')
+    (nchannel, height, width) = image_shape
+    weight = mx.symbol.Variable(name='conv0_weight', dtype=np.float32)
+    weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+    if height <= 32:            # such as cifar10
+        body = mx.sym.Convolution(data=data, weight=weight, num_filter=filter_list[0], kernel=(3, 3), stride=(1,1), pad=(1, 1),
+                                  no_bias=True, name="conv0", workspace=workspace)
+    else:                       # often expected to be 224 such as imagenet
+        body = mx.sym.Convolution(data=data, weight=weight, num_filter=filter_list[0], kernel=(7, 7), stride=(2,2), pad=(3, 3),
+                                  no_bias=True, name="conv0", workspace=workspace)
+        body = mx.sym.BatchNorm(data=body, fix_gamma=False, eps=2e-5, momentum=bn_mom, name='bn0')
+        body = mx.sym.Activation(data=body, act_type='relu', name='relu0')
+        body = mx.symbol.Pooling(data=body, kernel=(3, 3), stride=(2,2), pad=(1,1), pool_type='max')
+
+    for i in range(num_stages):
+        body = residual_unit(body, filter_list[i+1], (1 if i==0 else 2, 1 if i==0 else 2), False,
+                             name='stage%d_unit%d' % (i + 1, 1), bottle_neck=bottle_neck, workspace=workspace,
+                             memonger=memonger)
+        for j in range(units[i]-1):
+            body = residual_unit(body, filter_list[i+1], (1,1), True, name='stage%d_unit%d' % (i + 1, j + 2),
+                                 bottle_neck=bottle_neck, workspace=workspace, memonger=memonger)
+    bn1 = mx.sym.BatchNorm(data=body, fix_gamma=False, eps=2e-5, momentum=bn_mom, name='bn1')
+    relu1 = mx.sym.Activation(data=bn1, act_type='relu', name='relu1')
+    # Although kernel is not used here when global_pool=True, we should put one
+    pool1 = mx.symbol.Pooling(data=relu1, global_pool=True, kernel=(7, 7), pool_type='avg', name='pool1')
+    flat = mx.symbol.Flatten(data=pool1)
+    weight = mx.symbol.Variable(name='fc1_weight', dtype=np.float32)
+    bias = mx.symbol.Variable(name='fc1_bias', dtype=np.float32)
+    weight = mx.symbol.Cast(data=weight, dtype=np.float16)
+    bias = mx.symbol.Cast(data=bias, dtype=np.float16)
+    fc1 = mx.symbol.FullyConnected(data=flat, weight=weight, bias=bias, num_hidden=num_classes, name='fc1')
+    label = mx.symbol.Variable(name='softmax_label')
+    label = mx.symbol.Cast(data=label, dtype=np.float16)
+    return mx.symbol.SoftmaxOutput(data=fc1, name='softmax', label=label)
+
+def get_symbol(num_classes, num_layers, image_shape, conv_workspace=256, **kwargs):
+    """
+    Adapted from https://github.com/tornadomeet/ResNet/blob/master/train_resnet.py
+    Original author Wei Wu
+    """
+    image_shape = [int(l) for l in image_shape.split(',')]
+    (nchannel, height, width) = image_shape
+    if height <= 28:
+        num_stages = 3
+        if (num_layers-2) % 9 == 0 and num_layers >= 164:
+            per_unit = [(num_layers-2)//9]
+            filter_list = [16, 64, 128, 256]
+            bottle_neck = True
+        elif (num_layers-2) % 6 == 0 and num_layers < 164:
+            per_unit = [(num_layers-2)//6]
+            filter_list = [16, 16, 32, 64]
+            bottle_neck = False
+        else:
+            raise ValueError("no experiments done on num_layers {}, you can do it youself".format(num_layers))
+        units = per_unit * num_stages
+    else:
+        if num_layers >= 50:
+            filter_list = [64, 256, 512, 1024, 2048]
+            bottle_neck = True
+        else:
+            filter_list = [64, 64, 128, 256, 512]
+            bottle_neck = False
+        num_stages = 4
+        if num_layers == 18:
+            units = [2, 2, 2, 2]
+        elif num_layers == 34:
+            units = [3, 4, 6, 3]
+        elif num_layers == 50:
+            units = [3, 4, 6, 3]
+        elif num_layers == 101:
+            units = [3, 4, 23, 3]
+        elif num_layers == 152:
+            units = [3, 8, 36, 3]
+        elif num_layers == 200:
+            units = [3, 24, 36, 3]
+        elif num_layers == 269:
+            units = [3, 30, 48, 8]
+        else:
+            raise ValueError("no experiments done on num_layers {}, you can do it youself".format(num_layers))
+
+    return resnet(units       = units,
+                  num_stages  = num_stages,
+                  filter_list = filter_list,
+                  num_classes = num_classes,
+                  image_shape = image_shape,
+                  bottle_neck = bottle_neck,
+                  workspace   = conv_workspace)

--- a/src/operator/batch_norm.cu
+++ b/src/operator/batch_norm.cu
@@ -12,15 +12,19 @@ namespace mxnet {
 namespace op {
 template<>
 Operator *CreateOp<gpu>(BatchNormParam param, int dtype) {
+  Operator *op = NULL;
 #if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 5
   if (!param.use_global_stats) {
-    return new CuDNNBatchNormOp(param);
+    MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+      op = new CuDNNBatchNormOp<DType>(param);
+    })
   } else {
-    return new BatchNormOp<gpu>(param);
+    op = new BatchNormOp<gpu>(param);
   }
 #else
-  return new BatchNormOp<gpu>(param);
+  op = new BatchNormOp<gpu>(param);
 #endif
+  return op;
 }
 
 }  // namespace op

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -23,12 +23,17 @@ enum CuDNNBatchNormOpAuxiliary {kMovingMean, kMovingInvVar};
 }  // namespace cudnnbatchnorm
 
 #if defined(__CUDACC__)
+template<typename DType>
 class CuDNNBatchNormOp : public Operator {
  public:
   explicit CuDNNBatchNormOp(BatchNormParam param) {
+    using namespace mshadow;
     this->param_ = param;
     init_cudnn_ = false;
-    dtype_ = CUDNN_DATA_FLOAT;
+    dtype_ = DataType<DType>::kCudnnFlag;
+    // For float16 input type beta, gamma, mean, and average are stored in float32.
+    // For other input types, these parameters have the same type as input
+    dtype_param_ = (dtype_ == CUDNN_DATA_HALF) ? CUDNN_DATA_FLOAT : dtype_;
   }
 
   ~CuDNNBatchNormOp() {
@@ -75,70 +80,82 @@ class CuDNNBatchNormOp : public Operator {
                                           shape_[1],
                                           shape_[2],
                                           shape_[3]), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnSetTensor4dDescriptor(mean_desc_,
-                                          CUDNN_TENSOR_NCHW,
-                                          dtype_,
-                                          1,
-                                          shape_[1],
-                                          1,
-                                          1), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnDeriveBNTensorDescriptor(mean_desc_,
+                                             io_desc_,
+                                             CUDNN_BATCHNORM_SPATIAL), CUDNN_STATUS_SUCCESS);
+      // CHECK_EQ(cudnnSetTensor4dDescriptor(mean_desc_,
+      //                                     CUDNN_TENSOR_NCHW,
+      //                                     dtype_param_,
+      //                                     1,
+      //                                     shape_[1],
+      //                                     1,
+      //                                     1), CUDNN_STATUS_SUCCESS);
       init_cudnn_  = true;
     }
 
     Stream<gpu> *s = ctx.get_stream<gpu>();
-    Tensor<gpu, 4> x = in_data[cudnnbatchnorm::kData].get_with_shape<gpu, 4, real_t>(shape_, s);
-    Tensor<gpu, 1> gamma =
-      in_data[cudnnbatchnorm::kGamma].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    Tensor<gpu, 1> beta =
-      in_data[cudnnbatchnorm::kBeta].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    Tensor<gpu, 4> y = out_data[cudnnbatchnorm::kOut].get_with_shape<gpu, 4, real_t>(shape_, s);
-    Tensor<gpu, 1> moving_mean =
-      aux_states[cudnnbatchnorm::kMovingMean].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    Tensor<gpu, 1> moving_inv_var =
-      aux_states[cudnnbatchnorm::kMovingInvVar]
-      .get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    float a = 1.0f, b = 0.0f;
+    Tensor<gpu, 4, DType> x =
+      in_data[cudnnbatchnorm::kData].get_with_shape<gpu, 4, DType>(shape_, s);
 
-    if (param_.fix_gamma) gamma = 1.f;
+    Tensor<gpu, 4, DType> y =
+      out_data[cudnnbatchnorm::kOut].get_with_shape<gpu, 4, DType>(shape_, s);
 
-    if (ctx.is_train) {
-      Tensor<gpu, 1> save_mean =
-        out_data[cudnnbatchnorm::kMean].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-      Tensor<gpu, 1> save_inv_var =
-        out_data[cudnnbatchnorm::kInvVar].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-      CHECK_EQ(cudnnBatchNormalizationForwardTraining(s->dnn_handle_,
-                                                      CUDNN_BATCHNORM_SPATIAL,
-                                                      &a,
-                                                      &b,
-                                                      io_desc_,
-                                                      x.dptr_,
-                                                      io_desc_,
-                                                      y.dptr_,
-                                                      mean_desc_,
-                                                      gamma.dptr_,
-                                                      beta.dptr_,
-                                                      1 - param_.momentum,
-                                                      moving_mean.dptr_,
-                                                      moving_inv_var.dptr_,
-                                                      param_.eps,
-                                                      save_mean.dptr_,
-                                                      save_inv_var.dptr_), CUDNN_STATUS_SUCCESS);
-    } else {
-      CHECK_EQ(cudnnBatchNormalizationForwardInference(s->dnn_handle_,
-                                                       CUDNN_BATCHNORM_SPATIAL,
-                                                       &a,
-                                                       &b,
-                                                       io_desc_,
-                                                       x.dptr_,
-                                                       io_desc_,
-                                                       y.dptr_,
-                                                       mean_desc_,
-                                                       gamma.dptr_,
-                                                       beta.dptr_,
-                                                       moving_mean.dptr_,
-                                                       moving_inv_var.dptr_,
-                                                       param_.eps), CUDNN_STATUS_SUCCESS);
-    }
+    MSHADOW_REAL_TYPE_SWITCH(dtype_param_, DTypeParam, {
+      Tensor<gpu, 1, DTypeParam> gamma =
+        in_data[cudnnbatchnorm::kGamma].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      Tensor<gpu, 1, DTypeParam> beta =
+        in_data[cudnnbatchnorm::kBeta].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      Tensor<gpu, 1, DTypeParam> moving_mean =
+        aux_states[cudnnbatchnorm::kMovingMean]
+        .get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      Tensor<gpu, 1, DTypeParam> moving_inv_var =
+        aux_states[cudnnbatchnorm::kMovingInvVar]
+        .get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      typename DataType<DType>::ScaleType a = 1.0f;
+      typename DataType<DType>::ScaleType b = 0.0f;
+
+      if (param_.fix_gamma) gamma = 1.f;
+
+      if (ctx.is_train) {
+        Tensor<gpu, 1, DTypeParam> save_mean =
+          out_data[cudnnbatchnorm::kMean].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+        Tensor<gpu, 1, DTypeParam> save_inv_var =
+          out_data[cudnnbatchnorm::kInvVar]
+          .get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+        CHECK_EQ(cudnnBatchNormalizationForwardTraining(s->dnn_handle_,
+                                                        CUDNN_BATCHNORM_SPATIAL,
+                                                        &a,
+                                                        &b,
+                                                        io_desc_,
+                                                        x.dptr_,
+                                                        io_desc_,
+                                                        y.dptr_,
+                                                        mean_desc_,
+                                                        gamma.dptr_,
+                                                        beta.dptr_,
+                                                        1 - param_.momentum,
+                                                        moving_mean.dptr_,
+                                                        moving_inv_var.dptr_,
+                                                        param_.eps,
+                                                        save_mean.dptr_,
+                                                        save_inv_var.dptr_), CUDNN_STATUS_SUCCESS);
+      } else {
+        CHECK_EQ(cudnnBatchNormalizationForwardInference(s->dnn_handle_,
+                                                         CUDNN_BATCHNORM_SPATIAL,
+                                                         &a,
+                                                         &b,
+                                                         io_desc_,
+                                                         x.dptr_,
+                                                         io_desc_,
+                                                         y.dptr_,
+                                                         mean_desc_,
+                                                         gamma.dptr_,
+                                                         beta.dptr_,
+                                                         moving_mean.dptr_,
+                                                         moving_inv_var.dptr_,
+                                                         param_.eps), CUDNN_STATUS_SUCCESS);
+      }
+    })
   }
 
   virtual void Backward(const OpContext &ctx,
@@ -158,71 +175,79 @@ class CuDNNBatchNormOp : public Operator {
         << "use global statistics is not yet supported in CuDNNBatchNorm";
 
     Stream<gpu> *s = ctx.get_stream<gpu>();
-    Tensor<gpu, 4> x = in_data[cudnnbatchnorm::kData].get_with_shape<gpu, 4, real_t>(shape_, s);
-    Tensor<gpu, 4> dx = in_grad[cudnnbatchnorm::kData].get_with_shape<gpu, 4, real_t>(shape_, s);
-    Tensor<gpu, 4> dy = out_grad[cudnnbatchnorm::kOut].get_with_shape<gpu, 4, real_t>(shape_, s);
-    Tensor<gpu, 1> gamma =
-      in_data[cudnnbatchnorm::kGamma].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    Tensor<gpu, 1> dbeta =
-      in_grad[cudnnbatchnorm::kBeta].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    Tensor<gpu, 1> dgamma =
-      in_grad[cudnnbatchnorm::kGamma].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    Tensor<gpu, 1> save_mean =
-      out_data[cudnnbatchnorm::kMean].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    Tensor<gpu, 1> save_inv_var =
-      out_data[cudnnbatchnorm::kInvVar].get_with_shape<gpu, 1, real_t>(Shape1(shape_[1]), s);
-    float a = 1.0f;
-    float b = 0.0f;
-    float b_add = 1.0f;
-    CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+    Tensor<gpu, 4, DType> x =
+      in_data[cudnnbatchnorm::kData].get_with_shape<gpu, 4, DType>(shape_, s);
+    Tensor<gpu, 4, DType> dx =
+      in_grad[cudnnbatchnorm::kData].get_with_shape<gpu, 4, DType>(shape_, s);
+    Tensor<gpu, 4, DType> dy =
+      out_grad[cudnnbatchnorm::kOut].get_with_shape<gpu, 4, DType>(shape_, s);
 
-    if (param_.fix_gamma) gamma = 1.f;
+    MSHADOW_REAL_TYPE_SWITCH(dtype_param_, DTypeParam, {
+      Tensor<gpu, 1, DTypeParam> gamma =
+        in_data[cudnnbatchnorm::kGamma].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      Tensor<gpu, 1, DTypeParam> dbeta =
+        in_grad[cudnnbatchnorm::kBeta].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      Tensor<gpu, 1, DTypeParam> dgamma =
+        in_grad[cudnnbatchnorm::kGamma].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      Tensor<gpu, 1, DTypeParam> save_mean =
+        out_data[cudnnbatchnorm::kMean].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+      Tensor<gpu, 1, DTypeParam> save_inv_var =
+        out_data[cudnnbatchnorm::kInvVar].get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+
+      typename DataType<DType>::ScaleType a = 1.0f;
+      typename DataType<DType>::ScaleType b = 0.0f;
+      typename DataType<DType>::ScaleType b_add = 1.0f;
+      CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
+
+      if (param_.fix_gamma) gamma = 1.f;
 
 #if CUDNN_VERSION >= 4007
-    CHECK_EQ(cudnnBatchNormalizationBackward(s->dnn_handle_,
-                                             CUDNN_BATCHNORM_SPATIAL,
-                                             &a,
-                                             &b,
-                                             &a,
-                                             req[cudnnbatchnorm::kGamma] == kWriteTo ? &b: &b_add,
-                                             io_desc_,
-                                             x.dptr_,
-                                             io_desc_,
-                                             dy.dptr_,
-                                             io_desc_,
-                                             dx.dptr_,
-                                             mean_desc_,
-                                             gamma.dptr_,
-                                             dgamma.dptr_,
-                                             dbeta.dptr_,
-                                             param_.eps,
-                                             save_mean.dptr_,
-                                             save_inv_var.dptr_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnBatchNormalizationBackward(s->dnn_handle_,
+                                               CUDNN_BATCHNORM_SPATIAL,
+                                               &a,
+                                               &b,
+                                               &a,
+                                               req[cudnnbatchnorm::kGamma] == kWriteTo ? &b: &b_add,
+                                               io_desc_,
+                                               x.dptr_,
+                                               io_desc_,
+                                               dy.dptr_,
+                                               io_desc_,
+                                               dx.dptr_,
+                                               mean_desc_,
+                                               gamma.dptr_,
+                                               dgamma.dptr_,
+                                               dbeta.dptr_,
+                                               param_.eps,
+                                               save_mean.dptr_,
+                                               save_inv_var.dptr_), CUDNN_STATUS_SUCCESS);
 #else  // CUDNN_VERSION < 4007
-    CHECK_EQ(cudnnBatchNormalizationBackward(s->dnn_handle_,
-                                             CUDNN_BATCHNORM_SPATIAL,
-                                             &a,
-                                             &b,
-                                             io_desc_,
-                                             x.dptr_,
-                                             io_desc_,
-                                             dy.dptr_,
-                                             io_desc_,
-                                             dx.dptr_,
-                                             mean_desc_,
-                                             gamma.dptr_,
-                                             dgamma.dptr_,
-                                             dbeta.dptr_,
-                                             param_.eps,
-                                             save_mean.dptr_,
-                                             save_inv_var.dptr_), CUDNN_STATUS_SUCCESS);
+      CHECK_EQ(cudnnBatchNormalizationBackward(s->dnn_handle_,
+                                               CUDNN_BATCHNORM_SPATIAL,
+                                               &a,
+                                               &b,
+                                               io_desc_,
+                                               x.dptr_,
+                                               io_desc_,
+                                               dy.dptr_,
+                                               io_desc_,
+                                               dx.dptr_,
+                                               mean_desc_,
+                                               gamma.dptr_,
+                                               dgamma.dptr_,
+                                               dbeta.dptr_,
+                                               param_.eps,
+                                               save_mean.dptr_,
+                                               save_inv_var.dptr_), CUDNN_STATUS_SUCCESS);
 #endif
-    if (param_.fix_gamma) dgamma = 0.f;
+      if (param_.fix_gamma) dgamma = 0.f;
+    })
   }
 
  private:
   bool init_cudnn_;
   cudnnDataType_t dtype_;
+  cudnnDataType_t dtype_param_;
   cudnnTensorDescriptor_t io_desc_, mean_desc_;
   mshadow::Shape<4> shape_;
   BatchNormParam param_;

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -33,7 +33,7 @@ class CuDNNBatchNormOp : public Operator {
     dtype_ = DataType<DType>::kCudnnFlag;
     // For float16 input type beta, gamma, mean, and average are stored in float32.
     // For other input types, these parameters have the same type as input
-    dtype_param_ = (dtype_ == CUDNN_DATA_HALF) ? CUDNN_DATA_FLOAT : dtype_;
+    dtype_param_ = (dtype_ == CUDNN_DATA_HALF) ? kFloat32 : DataType<DType>::kFlag;
   }
 
   ~CuDNNBatchNormOp() {
@@ -240,7 +240,7 @@ class CuDNNBatchNormOp : public Operator {
  private:
   bool init_cudnn_;
   cudnnDataType_t dtype_;
-  cudnnDataType_t dtype_param_;
+  int dtype_param_;
   cudnnTensorDescriptor_t io_desc_, mean_desc_;
   mshadow::Shape<4> shape_;
   BatchNormParam param_;

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -83,13 +83,6 @@ class CuDNNBatchNormOp : public Operator {
       CHECK_EQ(cudnnDeriveBNTensorDescriptor(mean_desc_,
                                              io_desc_,
                                              CUDNN_BATCHNORM_SPATIAL), CUDNN_STATUS_SUCCESS);
-      // CHECK_EQ(cudnnSetTensor4dDescriptor(mean_desc_,
-      //                                     CUDNN_TENSOR_NCHW,
-      //                                     dtype_param_,
-      //                                     1,
-      //                                     shape_[1],
-      //                                     1,
-      //                                     1), CUDNN_STATUS_SUCCESS);
       init_cudnn_  = true;
     }
 

--- a/src/operator/cudnn_batch_norm.cu
+++ b/src/operator/cudnn_batch_norm.cu
@@ -13,7 +13,7 @@ namespace op {
 #if CUDNN_MAJOR == 4
 template<>
 Operator *CreateOp_CuDNNv4<gpu>(BatchNormParam param) {
-  return new CuDNNBatchNormOp(param);
+  return new CuDNNBatchNormOp<float>(param);
 }
 #endif  // CUDNN_MAJOR == 4
 }  // namespace op


### PR DESCRIPTION
Adds float16 training for cudnn batch_norm. Introduces example resnet_fp16.py script for float16 training of the resnet model. Tested for convergence on resnet-50 by comparing results with float32 training.