### PR TITLE
Remove static keyword from ilog2

### DIFF
--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -170,7 +170,7 @@ void EmbeddingOpForward(const nnvm::NodeAttrs& attrs,
 }
 
 // Returns integer log2(a) rounded up
-static int ilog2(unsigned int a) {
+int ilog2(unsigned int a) {
   int k = 1;
   while (a >>= 1) k++;
   return k;


### PR DESCRIPTION
In file included from src/operator/tensor/ordering_op.cc:7:
In file included from src/operator/tensor/./ordering_op-inl.h:17:
src/operator/tensor/./indexing_op.h:173:12: warning: unused function 'ilog2' [-Wunused-function]
static int ilog2(unsigned int a) {
           ^
1 warning generated.