### PR TITLE
Remove static keyword from ilog2

### DIFF
--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -170,7 +170,7 @@ void EmbeddingOpForward(const nnvm::NodeAttrs& attrs,
 }
 
 // Returns integer log2(a) rounded up
-static int ilog2(unsigned int a) {
+inline int ilog2(unsigned int a) {
   int k = 1;
   while (a >>= 1) k++;
   return k;

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -1,6 +1,6 @@
 /*!
  *  Copyright (c) 2015 by Contributors
- * \file broadcast_reduce_op-inl.h
+ * \file matrix_op-inl.h
  * \brief Function defintion of matrix related operators
  */
 #ifndef MXNET_OPERATOR_TENSOR_MATRIX_OP_INL_H_


### PR DESCRIPTION
In file included from src/operator/tensor/ordering_op.cc:7:
In file included from src/operator/tensor/./ordering_op-inl.h:17:
src/operator/tensor/./indexing_op.h:173:12: warning: unused function 'ilog2' [-Wunused-function]
static int ilog2(unsigned int a) {
           ^
1 warning generated.

Also fix filename in documentation.