### PR TITLE
[Scala] add SequentialModule

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -330,8 +330,8 @@ abstract class BaseModule {
     val auxParams = scala.collection.mutable.HashMap.empty[String, NDArray]
     (saveDict._1 zip saveDict._2) foreach { case (key, value) =>
       key.split(":", 2) match {
-        case Array(argType, name) if argType == "arg " => argParams.put(name, value)
-        case Array(argType, name) if argType == "aux " => auxParams.put(name, value)
+        case Array(argType, name) if argType == "arg" => argParams.put(name, value)
+        case Array(argType, name) if argType == "aux" => auxParams.put(name, value)
         case _ => throw new IOException("Invalid param file " + fname)
       }
     }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/SequentialModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/SequentialModule.scala
@@ -1,0 +1,402 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet.module
+
+import ml.dmlc.mxnet._
+import org.slf4j.LoggerFactory
+import scala.collection.mutable.ArrayBuffer
+import ml.dmlc.mxnet.optimizer.SGD
+import scala.collection.immutable.ListMap
+
+/**
+ * A SequentialModule is a container module that can chain multiple modules together.
+ * Note building a computation graph with this kind of imperative container is less
+ * flexible and less efficient than the symbolic graph.
+ * So this should be only used as a handy utility.
+ */
+class SequentialModule extends BaseModule {
+  private val logger = LoggerFactory.getLogger(classOf[SequentialModule])
+
+  private val META_TAKE_LABELS = "take_labels"
+  private val META_AUTO_WIRING = "auto_wiring"
+  private val metaKeys = Set(META_TAKE_LABELS, META_AUTO_WIRING)
+
+  private val modules = ArrayBuffer[BaseModule]()
+  private val metas = ArrayBuffer[Map[String, Boolean]]()
+  private var labelShapesVar: Option[IndexedSeq[DataDesc]] = None
+
+  /**
+   * Add a module to the chain.
+   * An example of addinging two modules to a chain:
+   * val seqMod = new SequentialModule()
+   * seqMod.add(mod1).add(mod2)
+   * @param module The new module to add.
+   * @param kwargs All the keyword arguments are saved as meta information
+   *                                for the added module. The currently known meta includes
+   *                                - "take_labels": indicating whether the module expect to
+   *                                take labels when doing computation. Note any module in
+   *                                the chain can take labels (not necessarily only the top
+   *                                most one), and they all take the same labels passed
+   *                                from the original data batch for the `SequentialModule`.
+   * @return This function returns `this` to allow us to easily chain a series of `add` calls.
+   */
+  def add(module: BaseModule, kwargs: (String, Boolean)*): SequentialModule = {
+    this.modules += module
+
+    // a sanity check to avoid typo
+    kwargs.foreach { case (k, v) =>
+      require(this.metaKeys.contains(k), s"Unknown meta $k,auxParams a typo?")
+    }
+
+    this.metas += kwargs.map(kw => kw._1 -> kw._2).toMap
+
+    // after adding new modules, we are reset back to raw states, needs
+    // to bind, init_params, etc.
+    this.binded = false
+    this.paramsInitialized = false
+    this.optimizerInitialized = false
+
+    this
+  }
+
+  /**
+   * @return A list of names for data required by this module.
+   */
+  override def dataNames: IndexedSeq[String] = {
+    if (this.modules.length > 0) this.modules.head.dataNames
+    else IndexedSeq[String]()
+  }
+
+  /**
+   * @return A list of names for the outputs of this module.
+   */
+  override def outputNames: IndexedSeq[String] = {
+    if (this.modules.length > 0) this.modules.reverse.head.outputNames
+    else IndexedSeq[String]()
+  }
+
+  /**
+   * Get data shapes.
+   * @return The data shapes of the first module is the data shape of a SequentialModule.
+   */
+  override def dataShapes: IndexedSeq[DataDesc] = {
+    require(this.binded)
+    this.modules.head.dataShapes
+  }
+
+  /**
+   * Get label shapes.
+   * @return The return value could be null if
+   * the module does not need labels, or if the module is not binded for
+   * training (in this case, label information is not available).
+   */
+  override def labelShapes: IndexedSeq[DataDesc] = {
+    require(this.binded)
+    this.labelShapesVar.orNull
+  }
+
+  /**
+   * Get output shapes.
+   * @return The output shapes of the last
+   * module is the output shape of a SequentialModule.
+   */
+  override def outputShapes: IndexedSeq[(String, Shape)] = {
+    require(this.binded)
+    this.modules.reverse.head.outputShapes
+  }
+
+    /**
+   * Get current parameters.
+   * @return (argParams, auxParams),
+   * each a Map of name to parameters (in NDArray) mapping.
+   */
+  override def getParams: (Map[String, NDArray], Map[String, NDArray]) = {
+    require(this.binded && this.paramsInitialized)
+    ((Map[String, NDArray](), Map[String, NDArray]()) /: this.modules){ (result, module) =>
+      val (arg, aux) = module.getParams
+      (result._1 ++ arg, result._2 ++ aux)
+    }
+  }
+
+  /**
+   * Initialize the parameters and auxiliary states.
+   * @param initializer Called to initialize parameters if needed.
+   * @param argParams If not None, should be a dictionary of existing arg_params.
+   *                  Initialization will be copied from that.
+   * @param auxParams If not None, should be a dictionary of existing aux_params.
+   *                  Initialization will be copied from that.
+   * @param allowMissing If true, params could contain missing values,
+   *                     and the initializer will be called to fill those missing params.
+   * @param forceInit If true, will force re-initialize even if already initialized.
+   */
+  override def initParams(initializer: Initializer = new Uniform(0.01f),
+                          argParams: Map[String, NDArray] = null,
+                          auxParams: Map[String, NDArray] = null,
+                          allowMissing: Boolean = false, forceInit: Boolean = false): Unit = {
+    if (this.paramsInitialized && !forceInit) {
+      return
+    }
+    require(this.binded, "call bind before initializing the parameters")
+
+    for (module <- this.modules) {
+      module.initParams(initializer = initializer, argParams = argParams,
+          auxParams = auxParams, allowMissing = allowMissing, forceInit = forceInit)
+    }
+
+    // Internal function to help checking duplicated names,
+    // make sure we do not have duplicated parameter names.
+    def checkName(knownNames: scala.collection.mutable.Map[String, Int],
+      newNames: Array[String], modules: ArrayBuffer[BaseModule], i: Int): Unit = {
+      for (name <- newNames) {
+        require(!knownNames.contains(name), s"Duplicated parameter names: " +
+            s"name $name in layer $i (${modules(i).getClass.getName}) is already " +
+            s"used in layer ${knownNames("name")}" +
+            s"(${modules(knownNames("name")).getClass.getName})")
+        knownNames(name) = i
+      }
+    }
+
+    val argNames = scala.collection.mutable.Map[String, Int]()
+    val auxNames = scala.collection.mutable.Map[String, Int]()
+    for ((module, iLayer) <- this.modules.zipWithIndex) {
+      val (argParams, auxParams) = module.getParams
+      checkName(argNames, argParams.keys.toArray, this.modules, iLayer)
+      checkName(auxNames, auxParams.keys.toArray, this.modules, iLayer)
+    }
+    this.paramsInitialized = true
+  }
+
+  /**
+   * Bind the symbols to construct executors. This is necessary before one
+   * can perform computation with the module.
+   * @param dataShapes Typically is `dataIter.provideData`.
+   * @param labelShapes Typically is `data_iter.provide_label`.
+   * @param forTraining Default is `true`. Whether the executors should be bind for training.
+   * @param inputsNeedGrad Default is `false`.
+   *                       Whether the gradients to the input data need to be computed.
+   *                       Typically this is not needed.
+   *                       But this might be needed when implementing composition of modules.
+   * @param forceRebind Default is `false`.
+   *                    This function does nothing if the executors are already binded.
+   *                    But with this `true`, the executors will be forced to rebind.
+   * @param sharedModule Default is `None`. This is used in bucketing.
+   *                     When not `None`, the shared module essentially corresponds to
+   *                     a different bucket -- a module with different symbol
+   *                     but with the same sets of parameters
+   *                     (e.g. unrolled RNNs with different lengths).
+   * @param gradReq Requirement for gradient accumulation (globally).
+   *                Can be 'write', 'add', or 'null' (default to 'write').
+   */
+  override def bind(dataShapes: IndexedSeq[DataDesc],
+                    labelShapes: Option[IndexedSeq[DataDesc]] = None,
+                    forTraining: Boolean = true, inputsNeedGrad: Boolean = false,
+                    forceRebind: Boolean = false, sharedModule: Option[BaseModule] = None,
+                    gradReq: String = "write"): Unit = {
+    if (this.binded && !forceRebind) {
+      logger.warn(s"Already binded, ignoring bind()")
+      return
+    }
+
+    if (inputsNeedGrad) {
+      require(forTraining == true)
+    }
+
+    require(sharedModule == None, "Shared module is not supported")
+    require(this.modules.length > 0, "Attempting to bind an empty SequentialModule")
+
+    this.forTraining = forTraining
+    this.inputsNeedGrad = inputsNeedGrad
+    this.binded = true
+
+    // the same label shapes are used for all chained modules
+    this.labelShapesVar = labelShapes
+
+    var myDataShapes = dataShapes
+    var myLabelShapes = labelShapes
+    var anybodyEverNeedsLabel = false
+    for ((module, iLayer) <- this.modules.zipWithIndex) {
+      val meta = this.metas(iLayer)
+      if (meta.contains(META_TAKE_LABELS) && meta(META_TAKE_LABELS)) {
+        myLabelShapes = labelShapes
+        anybodyEverNeedsLabel = true
+      } else myLabelShapes = None
+
+      val myInputsNeedGrad = if (inputsNeedGrad || (forTraining && iLayer > 0)) true else false
+      if (meta.contains(META_AUTO_WIRING) && meta(META_AUTO_WIRING)) {
+        val dataNames = module.dataNames
+        require(dataNames.length == myDataShapes.length)
+        myDataShapes = dataNames.zip(myDataShapes).map { case (newName, dataDes) =>
+          DataDesc(newName, dataDes.shape)
+        }
+      }
+
+      module.bind(myDataShapes, myLabelShapes, forTraining, myInputsNeedGrad,
+          forceRebind, sharedModule = None, gradReq)
+      // the output of the previous module is the data of the next module
+      myDataShapes = module.outputShapes.map{case (name, shape) => DataDesc(name, shape)}
+    }
+
+
+    if (!anybodyEverNeedsLabel) {
+      // then I do not need label either
+      this.labelShapesVar = None
+    }
+  }
+
+  /**
+   * Install and initialize optimizers.
+   * @param kvstore
+   * @param optimizer
+   * @param resetOptimizer Default `True`, indicating whether we should set `rescaleGrad`
+   *                       & `idx2name` for optimizer according to executorGroup
+   * @param forceInit Default `False`, indicating whether we should force re-initializing
+   *                  the optimizer in the case an optimizer is already installed.
+   */
+  override def initOptimizer(kvstore: String = "local", optimizer: Optimizer = new SGD(),
+      resetOptimizer: Boolean = true, forceInit: Boolean = false): Unit = {
+    require(this.binded && this.paramsInitialized)
+    if (optimizerInitialized && !forceInit) {
+      logger.warn("optimizer already initialized, ignoring ...")
+    } else {
+      for (module <- this.modules) {
+        module.initOptimizer(kvstore, optimizer, resetOptimizer, forceInit)
+      }
+    }
+    this.optimizerInitialized = true
+  }
+
+  /**
+   * Forward computation.
+   * @param dataBatch input data
+   * @param isTrain Default is `None`, which means `isTrain` takes the value of `forTraining`.
+   */
+  override def forward(dataBatch: DataBatch, isTrain: Option[Boolean] = None): Unit = {
+    require(this.binded && this.paramsInitialized)
+
+    var data = dataBatch
+    for ((module, iLayer) <- this.modules.zipWithIndex) {
+      module.forward(data, isTrain = isTrain)
+      // the last layer, do not need to do the followings
+      if (iLayer < this.modules.length - 1) {
+        val out = module.getOutputs()
+        // need to update this, in case the internal module is using bucketing
+        // or whatever
+        val dataNames = module.outputShapes.map(_._1)
+        require(dataNames.length == data.data.length)
+        var provideData = ListMap[String, Shape]()
+        for ((name, x) <- dataNames.zip(out.head)) {
+          provideData += name -> x.shape
+        }
+        data = new DataBatch(out.head, data.label, data.index,
+            data.pad, data.bucketKey, provideData, data.provideLabel)
+      }
+    }
+  }
+
+  /**
+   * Backward computation.
+   * @param outGrads Gradient on the outputs to be propagated back.
+   *                 This parameter is only needed when bind is called
+   *                 on outputs that are not a loss function.
+   */
+  override def backward(outGrads: Array[NDArray] = null): Unit = {
+    require(this.binded && this.paramsInitialized)
+    var grad = outGrads
+    for ((module, iLayer) <- this.modules.zipWithIndex.reverse) {
+      module.backward(outGrads = grad)
+      if (iLayer > 0) {
+        grad = module.getInputGradsMerged().toArray
+      }
+    }
+  }
+
+  // Update parameters according to the installed optimizer and the gradients computed
+  // in the previous forward-backward batch.
+  override def update(): Unit = {
+    require(this.binded && this.paramsInitialized && this.optimizerInitialized)
+    this.modules.foreach(_.update())
+  }
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be collected from multiple devices.
+   *         The results will look like `[[out1_dev1, out1_dev2], [out2_dev1, out2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  def getOutputs(): IndexedSeq[IndexedSeq[NDArray]] = {
+    require(this.binded && this.paramsInitialized)
+    this.modules.reverse.head.getOutputs()
+  }
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[out1, out2]`
+   */
+  def getOutputsMerged(): IndexedSeq[NDArray] = {
+    require(this.binded && this.paramsInitialized)
+    this.modules.reverse.head.getOutputsMerged()
+  }
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be collected from multiple devices.
+   *         The results will look like `[[grad1_dev1, grad1_dev2], [grad2_dev1, grad2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  def getInputGrads(): IndexedSeq[IndexedSeq[NDArray]] = {
+    require(this.binded && this.paramsInitialized && inputsNeedGrad)
+    this.modules.head.getInputGrads()
+  }
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[grad1, grad2]`
+   */
+  def getInputGradsMerged(): IndexedSeq[NDArray] = {
+    require(this.binded && this.paramsInitialized && inputsNeedGrad)
+    this.modules.head.getInputGradsMerged()
+  }
+
+  /**
+   * Evaluate and accumulate evaluation metric on outputs of the last forward computation.
+   * @param evalMetric
+   * @param labels
+   */
+  def updateMetric(evalMetric: EvalMetric, labels: IndexedSeq[NDArray]): Unit = {
+    require(this.binded && this.paramsInitialized)
+    for ((meta, module) <- this.metas.zip(this.modules)) {
+      if (meta.contains(META_TAKE_LABELS) && meta(META_TAKE_LABELS)) {
+        module.updateMetric(evalMetric, labels)
+      }
+    }
+  }
+
+  // Install monitor on all executors
+  def installMonitor(monitor: Monitor): Unit = {
+    require(this.binded)
+    this.modules.foreach(_.installMonitor(monitor))
+  }
+}

--- a/scala-package/examples/scripts/module/run_sequential_module.sh
+++ b/scala-package/examples/scripts/module/run_sequential_module.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+ROOT_DIR=$(cd `dirname $0`/../../..; pwd)
+CLASSPATH=$ROOT_DIR/assembly/linux-x86_64-cpu/target/*:$ROOT_DIR/examples/target/*:$ROOT_DIR/examples/target/classes/lib/*
+
+DATA_DIR=$ROOT_DIR/core/data
+
+SAVE_MODEL_PATH=.
+
+# LOAD_MODEL=seqModule-0001.params
+
+java -Xmx4G -cp $CLASSPATH \
+            ml.dmlc.mxnet.examples.module.SequentialModuleEx \
+            --data-dir $DATA_DIR \
+            --batch-size 10 \
+            --num-epoch 2 \
+            --lr 0.01 \
+            --save-model-path $SAVE_MODEL_PATH \
+            # --load-model-path $LOAD_MODEL

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/SequentialModuleEx.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/module/SequentialModuleEx.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet.examples.module
+
+import ml.dmlc.mxnet._
+import ml.dmlc.mxnet.module.{FitParams, Module, SequentialModule}
+import ml.dmlc.mxnet.DataDesc._
+import ml.dmlc.mxnet.optimizer.SGD
+import org.kohsuke.args4j.{Option, CmdLineParser}
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+
+object SequentialModuleEx {
+  private val logger = LoggerFactory.getLogger(classOf[SequentialModuleEx])
+
+  def getSeqModule(): SequentialModule = {
+    val contexts = Array(Context.cpu(), Context.cpu())
+
+    // module1
+    val data = Symbol.Variable("data")
+    val fc1 = Symbol.FullyConnected("fc1")()(Map("data" -> data, "num_hidden" -> 128))
+    val act1 = Symbol.Activation("relu1")()(Map("data" -> fc1, "act_type" -> "relu"))
+
+    val mod1 = new Module(act1, labelNames = null, contexts = contexts(0))
+
+    // module2
+    val data2 = Symbol.Variable("data")
+    val fc2 = Symbol.FullyConnected("fc2")()(Map("data" -> data2, "num_hidden" -> 64))
+    val act2 = Symbol.Activation("relu2")()(Map("data" -> fc2, "act_type" -> "relu"))
+    val fc3 = Symbol.FullyConnected("fc3")()(Map("data" -> act2, "num_hidden" -> 10))
+    val softmax = Symbol.SoftmaxOutput("softmax")()(Map("data" -> fc3))
+
+    val mod2 = new Module(softmax, contexts = contexts(1))
+
+    // Container module
+    val modSeq = new SequentialModule()
+    modSeq.add(mod1).add(mod2, ("take_labels", true), ("auto_wiring", true))
+    modSeq
+  }
+
+  def runIntermediateLevelApi(train: DataIter, eval: DataIter,
+    cmdLine: SequentialModuleEx): Unit = {
+    // Intermediate-level API
+    val modSeq = getSeqModule()
+    modSeq.bind(dataShapes = train.provideData, labelShapes = Some(train.provideLabel))
+    if (cmdLine.loadModelPath != null) {
+      logger.info(s"Load checkpoint from ${cmdLine.loadModelPath}")
+      modSeq.loadParams(cmdLine.loadModelPath)
+     } else modSeq.initParams()
+
+     modSeq.initOptimizer(optimizer = new SGD(learningRate = cmdLine.lr, momentum = 0.9f))
+
+    val metric = new Accuracy()
+
+    for (epoch <- 0 until cmdLine.numEpoch) {
+      while (train.hasNext) {
+        val batch = train.next()
+        modSeq.forward(batch)
+        modSeq.updateMetric(metric, batch.label)
+        modSeq.backward()
+        modSeq.update()
+      }
+
+      val fname = "%s-%04d.params".format(s"${cmdLine.saveModelPath}/seqModule", epoch)
+      modSeq.saveParams(fname)
+
+      val (name, value) = metric.get
+      logger.info(s"epoch $epoch $name=$value")
+      metric.reset()
+      train.reset()
+    }
+  }
+
+  def runHighLevelApi(train: DataIter, test: DataIter, cmdLine: SequentialModuleEx): Unit = {
+    // High-level API
+    train.reset()
+    val modSeq = getSeqModule()
+    val fitParams = new FitParams
+    fitParams.setOptimizer(new SGD(learningRate = cmdLine.lr, momentum = 0.9f))
+    modSeq.fit(train, evalData = scala.Option(test),
+        numEpoch = cmdLine.numEpoch, fitParams = fitParams)
+
+    // prediction iterator API
+    var iBatch = 0
+    test.reset()
+    while (test.hasNext) {
+      val batch = test.next()
+      val preds = modSeq.predict(batch)
+      val predLabel: Array[Int] = NDArray.argmax_channel(preds(0)).toArray.map(_.toInt)
+      val label = batch.label(0).toArray.map(_.toInt)
+      val acc = predLabel.zip(label).map { case (py, y) =>
+        if (py == y) 1 else 0
+      }.sum / predLabel.length.toFloat
+      if (iBatch % 20 == 0) {
+        logger.info(s"Batch $iBatch acc: $acc")
+      }
+      iBatch += 1
+    }
+
+    // a dummy call just to test if the API works
+    modSeq.predict(test)
+
+    // perform prediction and calculate accuracy manually
+    val preds = modSeq.predictEveryBatch(test)
+    test.reset()
+    var accSum = 0.0f
+    var accCnt = 0
+    var i = 0
+    while (test.hasNext) {
+      val batch = test.next()
+      val predLabel: Array[Int] = NDArray.argmax_channel(preds(i)(0)).toArray.map(_.toInt)
+      val label = batch.label(0).toArray.map(_.toInt)
+      accSum += (predLabel zip label).map { case (py, y) =>
+        if (py == y) 1 else 0
+      }.sum
+      accCnt += predLabel.length
+      i += 1
+    }
+    logger.info(s"Validation Accuracy: ${accSum / accCnt.toFloat}")
+
+    // evaluate on validation set with a evaluation metric
+    val (name, value) = modSeq.score(test, new Accuracy).get
+    logger.info(s"Scored $name = $value")
+  }
+
+  def main(args: Array[String]): Unit = {
+    val alex = new SequentialModuleEx
+    val parser = new CmdLineParser(alex)
+    try {
+      parser.parseArgument(args.toList.asJava)
+      require(alex.dataDir != null)
+
+      val trainDataIter = IO.MNISTIter(Map(
+        "image" -> s"${alex.dataDir}/train-images-idx3-ubyte",
+        "label" -> s"${alex.dataDir}/train-labels-idx1-ubyte",
+        "label_name" -> "softmax_label",
+        "input_shape" -> "(784,)",
+        "batch_size" -> alex.batchSize.toString,
+        "shuffle" -> "True",
+        "flat" -> "True", "silent" -> "False", "seed" -> "10"))
+      val evalDataIter = IO.MNISTIter(Map(
+        "image" -> s"${alex.dataDir}/t10k-images-idx3-ubyte",
+        "label" -> s"${alex.dataDir}/t10k-labels-idx1-ubyte",
+        "label_name" -> "softmax_label",
+        "input_shape" -> "(784,)",
+        "batch_size" -> alex.batchSize.toString,
+        "flat" -> "True", "silent" -> "False"))
+
+      logger.info("Run intermediate level api from beginning.")
+      runIntermediateLevelApi(trainDataIter, evalDataIter, alex)
+      logger.info("Run high level api")
+      runHighLevelApi(trainDataIter, evalDataIter, alex)
+
+    } catch {
+      case ex: Exception =>
+        logger.error(ex.getMessage, ex)
+        parser.printUsage(System.err)
+        sys.exit(1)
+    }
+  }
+}
+
+class SequentialModuleEx {
+  @Option(name = "--data-dir", usage = "the input data directory")
+  private val dataDir: String = null
+  @Option(name = "--lr", usage = "the initial learning rate")
+  private val lr: Float = 0.01f
+  @Option(name = "--batch-size", usage = "the batch size for data iterator")
+  private val batchSize: Int = 100
+  @Option(name = "--num-epoch", usage = "number of training epoches")
+  private val numEpoch: Int = 100
+  @Option(name = "--save-model-path", usage = "the model saving path")
+  private val saveModelPath: String = ""
+  @Option(name = "--load-model-path", usage = "the model to be loaded")
+  private val loadModelPath: String = null
+}


### PR DESCRIPTION
follows: https://github.com/dmlc/mxnet/blob/master/python/mxnet/module/sequential_module.py

training log:
```bash
2017-03-11 11:26:08,193 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Run intermediate level api from beginning.
2017-03-11 11:26:18,015 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - epoch 0 accuracy=0.81341666
2017-03-11 11:26:25,783 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - epoch 1 accuracy=0.96106666
2017-03-11 11:26:25,783 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Run high level api
2017-03-11 11:26:33,682 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Train-accuracy=0.8149167
2017-03-11 11:26:33,682 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Time cost=7894
2017-03-11 11:26:34,197 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Validation-accuracy=0.9522
2017-03-11 11:26:41,499 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Train-accuracy=0.9615833
2017-03-11 11:26:41,500 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Time cost=7303
2017-03-11 11:26:41,857 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Validation-accuracy=0.9678
2017-03-11 11:26:41,859 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 0 acc: 0.9
2017-03-11 11:26:41,868 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 20 acc: 1.0
2017-03-11 11:26:41,875 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 40 acc: 0.9
2017-03-11 11:26:41,882 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 60 acc: 1.0
2017-03-11 11:26:41,890 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 80 acc: 0.9
2017-03-11 11:26:41,898 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 100 acc: 1.0
2017-03-11 11:26:41,905 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 120 acc: 0.9
2017-03-11 11:26:41,912 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 140 acc: 1.0
2017-03-11 11:26:41,920 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 160 acc: 0.9
2017-03-11 11:26:41,929 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 180 acc: 0.9
2017-03-11 11:26:41,936 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 200 acc: 1.0
2017-03-11 11:26:41,943 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 220 acc: 1.0
2017-03-11 11:26:41,951 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 240 acc: 1.0
2017-03-11 11:26:41,974 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 260 acc: 1.0
2017-03-11 11:26:41,983 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 280 acc: 1.0
2017-03-11 11:26:41,991 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 300 acc: 0.9
2017-03-11 11:26:41,998 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 320 acc: 1.0
2017-03-11 11:26:42,005 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 340 acc: 0.9
2017-03-11 11:26:42,013 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 360 acc: 1.0
2017-03-11 11:26:42,020 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 380 acc: 1.0
2017-03-11 11:26:42,028 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 400 acc: 1.0
2017-03-11 11:26:42,035 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 420 acc: 0.9
2017-03-11 11:26:42,047 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 440 acc: 1.0
2017-03-11 11:26:42,055 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 460 acc: 1.0
2017-03-11 11:26:42,073 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 480 acc: 0.9
2017-03-11 11:26:42,080 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 500 acc: 1.0
2017-03-11 11:26:42,088 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 520 acc: 1.0
2017-03-11 11:26:42,098 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 540 acc: 1.0
2017-03-11 11:26:42,106 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 560 acc: 1.0
2017-03-11 11:26:42,113 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 580 acc: 0.9
2017-03-11 11:26:42,120 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 600 acc: 0.8
2017-03-11 11:26:42,139 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 620 acc: 1.0
2017-03-11 11:26:42,147 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 640 acc: 0.8
2017-03-11 11:26:42,155 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 660 acc: 1.0
2017-03-11 11:26:42,162 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 680 acc: 1.0
2017-03-11 11:26:42,170 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 700 acc: 1.0
2017-03-11 11:26:42,177 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 720 acc: 0.9
2017-03-11 11:26:42,185 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 740 acc: 1.0
2017-03-11 11:26:42,193 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 760 acc: 0.9
2017-03-11 11:26:42,200 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 780 acc: 1.0
2017-03-11 11:26:42,208 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 800 acc: 0.9
2017-03-11 11:26:42,217 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 820 acc: 1.0
2017-03-11 11:26:42,225 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 840 acc: 0.9
2017-03-11 11:26:42,232 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 860 acc: 1.0
2017-03-11 11:26:42,267 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 880 acc: 0.9
2017-03-11 11:26:42,274 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 900 acc: 1.0
2017-03-11 11:26:42,282 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 920 acc: 1.0
2017-03-11 11:26:42,289 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 940 acc: 1.0
2017-03-11 11:26:42,297 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 960 acc: 1.0
2017-03-11 11:26:42,304 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 980 acc: 1.0
2017-03-11 11:26:43,092 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Validation Accuracy: 0.9678
2017-03-11 11:26:43,466 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Scored accuracy = 0.9678
```

and load checkpoint:
```bash
2017-03-11 11:40:10,422 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Run intermediate level api from beginning.
2017-03-11 11:40:10,496 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Load checkpoint from ./seqModule-0001.params
2017-03-11 11:40:24,306 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - epoch 0 accuracy=0.98268336
2017-03-11 11:40:32,863 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - epoch 1 accuracy=0.98506665
2017-03-11 11:40:32,863 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Run high level api
2017-03-11 11:40:40,062 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Train-accuracy=0.81341666
2017-03-11 11:40:40,062 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Time cost=7192
2017-03-11 11:40:40,724 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Validation-accuracy=0.9473
2017-03-11 11:40:47,357 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Train-accuracy=0.96106666
2017-03-11 11:40:47,357 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Time cost=6633
2017-03-11 11:40:47,665 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Validation-accuracy=0.9628
2017-03-11 11:40:47,666 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 0 acc: 1.0
2017-03-11 11:40:47,674 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 20 acc: 1.0
2017-03-11 11:40:47,682 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 40 acc: 1.0
2017-03-11 11:40:47,688 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 60 acc: 1.0
2017-03-11 11:40:47,694 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 80 acc: 1.0
2017-03-11 11:40:47,702 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 100 acc: 0.8
2017-03-11 11:40:47,707 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 120 acc: 1.0
2017-03-11 11:40:47,718 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 140 acc: 1.0
2017-03-11 11:40:47,724 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 160 acc: 0.9
2017-03-11 11:40:47,731 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 180 acc: 0.9
2017-03-11 11:40:47,737 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 200 acc: 1.0
2017-03-11 11:40:47,743 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 220 acc: 1.0
2017-03-11 11:40:47,749 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 240 acc: 1.0
2017-03-11 11:40:47,757 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 260 acc: 1.0
2017-03-11 11:40:47,763 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 280 acc: 1.0
2017-03-11 11:40:47,774 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 300 acc: 0.9
2017-03-11 11:40:47,780 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 320 acc: 1.0
2017-03-11 11:40:47,785 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 340 acc: 1.0
2017-03-11 11:40:47,791 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 360 acc: 1.0
2017-03-11 11:40:47,796 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 380 acc: 0.9
2017-03-11 11:40:47,804 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 400 acc: 1.0
2017-03-11 11:40:47,814 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 420 acc: 0.9
2017-03-11 11:40:47,820 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 440 acc: 1.0
2017-03-11 11:40:47,825 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 460 acc: 1.0
2017-03-11 11:40:47,830 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 480 acc: 1.0
2017-03-11 11:40:47,835 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 500 acc: 1.0
2017-03-11 11:40:47,841 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 520 acc: 0.9
2017-03-11 11:40:47,850 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 540 acc: 1.0
2017-03-11 11:40:47,856 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 560 acc: 1.0
2017-03-11 11:40:47,861 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 580 acc: 0.9
2017-03-11 11:40:47,867 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 600 acc: 0.9
2017-03-11 11:40:47,885 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 620 acc: 1.0
2017-03-11 11:40:47,890 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 640 acc: 0.8
2017-03-11 11:40:47,897 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 660 acc: 1.0
2017-03-11 11:40:47,902 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 680 acc: 0.9
2017-03-11 11:40:47,908 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 700 acc: 1.0
2017-03-11 11:40:47,914 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 720 acc: 1.0
2017-03-11 11:40:47,919 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 740 acc: 1.0
2017-03-11 11:40:47,925 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 760 acc: 0.9
2017-03-11 11:40:47,931 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 780 acc: 1.0
2017-03-11 11:40:47,940 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 800 acc: 0.9
2017-03-11 11:40:47,946 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 820 acc: 1.0
2017-03-11 11:40:47,952 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 840 acc: 0.9
2017-03-11 11:40:47,957 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 860 acc: 1.0
2017-03-11 11:40:47,963 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 880 acc: 0.9
2017-03-11 11:40:47,968 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 900 acc: 1.0
2017-03-11 11:40:47,974 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 920 acc: 0.8
2017-03-11 11:40:47,984 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 940 acc: 1.0
2017-03-11 11:40:47,991 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 960 acc: 1.0
2017-03-11 11:40:47,997 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Batch 980 acc: 1.0
2017-03-11 11:40:48,784 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Validation Accuracy: 0.9628
2017-03-11 11:40:49,129 [main] [ml.dmlc.mxnet.examples.module.SequentialModuleEx] [INFO] - Scored accuracy = 0.9628
```