### PR TITLE
Add unfuse() to FusedRNNCell

### DIFF
--- a/python/mxnet/rnn/rnn_cell.py
+++ b/python/mxnet/rnn/rnn_cell.py
@@ -750,6 +750,36 @@ class FusedRNNCell(BaseRNNCell):
 
         return outputs, states
 
+    def unfuse(self):
+        """Unfuse the fused RNN
+
+        Returns
+        -------
+        cell : SequentialRNNCell
+            unfused cell that can be used for stepping, and can run on CPU.
+        """
+        stack = SequentialRNNCell()
+        get_cell = {'rnn_relu': lambda cell_prefix: RNNCell(self._num_hidden,
+                                                            activation='relu',
+                                                            prefix=cell_prefix),
+                    'rnn_tanh': lambda cell_prefix: RNNCell(self._num_hidden,
+                                                            activation='tanh',
+                                                            prefix=cell_prefix),
+                    'lstm': lambda cell_prefix: LSTMCell(self._num_hidden,
+                                                         prefix=cell_prefix),
+                    'gru': lambda cell_prefix: GRUCell(self._num_hidden,
+                                                       prefix=cell_prefix)}[self._mode]
+        for i in range(self._num_layers):
+            if self._bidirectional:
+                stack.add(BidirectionalCell(
+                    get_cell('%sl%d_'%(self._prefix, i)),
+                    get_cell('%sr%d_'%(self._prefix, i)),
+                    output_prefix='%sbi_%s_%d'%(self._prefix, self._mode, i)))
+            else:
+                stack.add(get_cell('%sl%d_'%(self._prefix, i)))
+        return stack
+
+
 
 class SequentialRNNCell(BaseRNNCell):
     """Sequantially stacking multiple RNN cells

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -377,12 +377,23 @@ def test_bidirectional():
     check_rnn_consistency(fused, stack)
     check_rnn_consistency(stack, fused)
 
+def test_unfuse():
+    for mode in ['rnn_tanh', 'rnn_relu', 'lstm', 'gru']:
+        fused = mx.rnn.FusedRNNCell(100, num_layers=2, mode=mode,
+                prefix='test_%s'%mode,
+                bidirectional=True)
+
+        stack = fused.unfuse()
+
+        check_rnn_consistency(fused, stack)
+        check_rnn_consistency(stack, fused)
 
 if __name__ == '__main__':
     test_bidirectional()
     test_lstm()
     test_gru()
     test_rnn()
+    test_unfuse()
     test_convolution_options()
     test_convolution_with_type()
     test_pooling_with_type()

--- a/tests/python/unittest/test_rnn.py
+++ b/tests/python/unittest/test_rnn.py
@@ -62,9 +62,20 @@ def test_bidirectional():
     args, outs, auxs = outputs.infer_shape(rnn_t0_data=(10,50), rnn_t1_data=(10,50), rnn_t2_data=(10,50))
     assert outs == [(10, 200), (10, 200), (10, 200)]
 
+def test_unfuse():
+    cell = mx.rnn.FusedRNNCell(100, num_layers=1, mode='lstm',
+            prefix='test_', bidirectional=True).unfuse()
+    outputs, _ = cell.unroll(3, input_prefix='rnn_')
+    outputs = mx.sym.Group(outputs)
+    assert outputs.list_outputs() == ['test_bi_lstm_0t0_output', 'test_bi_lstm_0t1_output', 'test_bi_lstm_0t2_output']
+
+    args, outs, auxs = outputs.infer_shape(rnn_t0_data=(10,50), rnn_t1_data=(10,50), rnn_t2_data=(10,50))
+    assert outs == [(10, 200), (10, 200), (10, 200)]
+
 if __name__ == '__main__':
     test_rnn()
     test_lstm()
     test_gru()
     test_stack()
     test_bidirectional()
+    test_unfuse()


### PR DESCRIPTION
@piiswrong This pr adds `unfuse()` to `FusedRNNCell` which generates an equivalent SequentialRNNCell of the FusedRNNCell of the same spec, which can be used for step unroll and can run on CPU. This helps solve the problem that users have to understand the naming convention of the FusedRNN parameters by taking care of the naming conventions inside the function.