### PR TITLE
fix caffe importer

### DIFF
--- a/tools/caffe_converter/caffe_parser.py
+++ b/tools/caffe_converter/caffe_parser.py
@@ -42,7 +42,7 @@ def read_caffemodel(prototxt_fname, caffemodel_fname):
         return (layers, layer_names)
     else:
         proto = caffe_pb2.NetParameter()
-        with open(fname, 'rb') as f:
+        with open(caffemodel_fname, 'rb') as f:
             proto.ParseFromString(f.read())
         return (get_layers(proto), None)
 


### PR DESCRIPTION
Fixing undefined variable `fname` being passed to `open`. Affects the importer when only protobuf is installed, not Caffe.