### PR TITLE
add dropout parity for unfuse() in FusedRNNCell

### DIFF
--- a/python/mxnet/rnn/rnn_cell.py
+++ b/python/mxnet/rnn/rnn_cell.py
@@ -776,6 +776,8 @@ class FusedRNNCell(BaseRNNCell):
             get_cell = get_vanilla_cell
 
         for i in range(self._num_layers):
+            if i == self._num_layers - 1:
+                get_cell = get_vanilla_cell
             if self._bidirectional:
                 stack.add(BidirectionalCell(
                     get_cell('%sl%d_'%(self._prefix, i)),

--- a/python/mxnet/rnn/rnn_cell.py
+++ b/python/mxnet/rnn/rnn_cell.py
@@ -759,16 +759,22 @@ class FusedRNNCell(BaseRNNCell):
             unfused cell that can be used for stepping, and can run on CPU.
         """
         stack = SequentialRNNCell()
-        get_cell = {'rnn_relu': lambda cell_prefix: RNNCell(self._num_hidden,
-                                                            activation='relu',
-                                                            prefix=cell_prefix),
-                    'rnn_tanh': lambda cell_prefix: RNNCell(self._num_hidden,
-                                                            activation='tanh',
-                                                            prefix=cell_prefix),
-                    'lstm': lambda cell_prefix: LSTMCell(self._num_hidden,
-                                                         prefix=cell_prefix),
-                    'gru': lambda cell_prefix: GRUCell(self._num_hidden,
-                                                       prefix=cell_prefix)}[self._mode]
+        get_vanilla_cell = {'rnn_relu': lambda cell_prefix: RNNCell(self._num_hidden,
+                                                                    activation='relu',
+                                                                    prefix=cell_prefix),
+                            'rnn_tanh': lambda cell_prefix: RNNCell(self._num_hidden,
+                                                                    activation='tanh',
+                                                                    prefix=cell_prefix),
+                            'lstm': lambda cell_prefix: LSTMCell(self._num_hidden,
+                                                                 prefix=cell_prefix),
+                            'gru': lambda cell_prefix: GRUCell(self._num_hidden,
+                                                               prefix=cell_prefix)}[self._mode]
+        if self._dropout != 0:
+            get_cell = lambda cell_prefix: DropoutCell(get_vanilla_cell(cell_prefix),
+                                                       dropout_outputs=self._dropout)
+        else:
+            get_cell = get_vanilla_cell
+
         for i in range(self._num_layers):
             if self._bidirectional:
                 stack.add(BidirectionalCell(

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -381,7 +381,8 @@ def test_unfuse():
     for mode in ['rnn_tanh', 'rnn_relu', 'lstm', 'gru']:
         fused = mx.rnn.FusedRNNCell(100, num_layers=2, mode=mode,
                 prefix='test_%s'%mode,
-                bidirectional=True)
+                bidirectional=True,
+                dropout=0.000001)
 
         stack = fused.unfuse()
 


### PR DESCRIPTION
@piiswrong this pr adds dropout parity for FusedRNNCell. It would be good if nvidia people could help verify whether function-wise this is aligned (i.e. dropout on output). Also, for testing, since the dropout control is a bit hard, I set the dropout rate to be small to make sure at least the logical branch is tested.