### PR TITLE
Fix in order to allow specifying more than one input shape for predict api

### DIFF
--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -150,8 +150,8 @@ int MXPredCreatePartialOut(const char* symbol_json_str,
   std::unordered_map<std::string, TShape> known_shape;
   for (mx_uint i = 0; i < num_input_nodes; ++i) {
     known_shape[std::string(input_keys[i])] =
-        TShape(input_shape_data + input_shape_indptr[i],
-               input_shape_data + input_shape_indptr[i + 1]);
+        TShape(input_shape_data + input_shape_indptr[2*i],
+               input_shape_data + input_shape_indptr[2*i + 1]);
   }
   std::vector<std::string> arg_names = sym.ListInputNames(Symbol::kReadOnlyArgs);
   std::vector<std::string> aux_names = sym.ListInputNames(Symbol::kAuxiliaryStates);


### PR DESCRIPTION
Needed for lstm examples that have Reshape op that depends on defined shape of the softmax_label.
@piiswrong The comments in the .h file for the MXPredCreate* are pretty confusing, and certainly need to be rewritten in the light of this change, I however a bit perplexed on what exactly these comments should say, can you suggest anything ?
I submitted a pull against Go interface that uses this code as well.
https://github.com/songtianyi/go-mxnet-predictor/pull/3