### PR TITLE
OpWrapperGenerator not Py3 compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,7 +488,7 @@ if(NOT MSVC)
   add_custom_command(TARGET mxnet
     POST_BUILD
     COMMAND cp $<TARGET_FILE:mxnet> .
-    COMMAND python OpWrapperGenerator.py $<TARGET_FILE_NAME:mxnet>
+    COMMAND python2 OpWrapperGenerator.py $<TARGET_FILE_NAME:mxnet>
     COMMAND rm $<TARGET_FILE_NAME:mxnet>
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/cpp-package/src/OpWrapperGenerator/
   )


### PR DESCRIPTION
The change introduced in 21b2da07f6ff10669b7649860b913e17e6184708 breaks the build if Python 3 is in the path. This forces Python 2 to be used until OpWrapperGenerator is fixed to support Python 3.