### PR TITLE
Fix docstring test for symbol.py and ndarray.py examples.

### DIFF
--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -552,10 +552,10 @@ fixed-size items.
         >>> tic = time.time()
         >>> a = mx.nd.ones((1000,1000))
         >>> b = mx.nd.dot(a, a)
-        >>> print(time.time() - tic)
+        >>> print(time.time() - tic) # doctest: +SKIP
         0.003854036331176758
         >>> b.wait_to_read()
-        >>> print(time.time() - tic)
+        >>> print(time.time() - tic) # doctest: +SKIP
         0.0893700122833252
         """
         check_call(_LIB.MXNDArrayWaitToRead(self.handle))
@@ -958,7 +958,7 @@ def full(shape, val, ctx=None, dtype=mx_real_t):
     array([ 2.], dtype=float32)
     >>> mx.nd.full((1, 2), 2.0, mx.gpu(0))
     <NDArray 1x2 @gpu(0)>
-    >>> mx.nd.ones((1, 2), 2.0, dtype='float16').asnumpy()
+    >>> mx.nd.full((1, 2), 2.0, dtype='float16').asnumpy()
     array([[ 2.,  2.]], dtype=float16)
     """
     arr = empty(shape, ctx, dtype)

--- a/python/mxnet/symbol_doc.py
+++ b/python/mxnet/symbol_doc.py
@@ -157,7 +157,7 @@ class FlattenDoc(SymbolDoc):
     >>> for dims in test_dims:
     ...     x = test_utils.random_arrays(dims)
     ...     y = test_utils.simple_forward(op, flat_data=x)
-    ...     y_np = x.reshape((dims[0], np.prod(dims[1:])))
+    ...     y_np = x.reshape((dims[0], np.prod(dims[1:]).astype('int32')))
     ...     print('%s: %s' % (dims, test_utils.almost_equal(y, y_np)))
     (2, 3, 4, 5): True
     (2, 3): True

--- a/tests/python/doctest/test_docstring.py
+++ b/tests/python/doctest/test_docstring.py
@@ -32,12 +32,12 @@ def test_symbols():
 
     # make sure all the operators are available
     import_into(globs, mxnet.symbol)
-    doctest.testmod(mxnet.symbol_doc, globs=globs)
+    doctest.testmod(mxnet.symbol_doc, globs=globs, verbose=True)
 
 def test_ndarray():
     globs = {'np': numpy, 'mx': mxnet}
 
-    doctest.testmod(mxnet.ndarray, globs=globs)
+    doctest.testmod(mxnet.ndarray, globs=globs, verbose=True)
 
 
 if __name__ == '__main__':

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -106,10 +106,14 @@ if [ ${TASK} == "python_test" ]; then
         # export MXNET_ENFORCE_CYTHON=1
         # python3 -m nose tests/python/unittest || exit -1
         python3 -m nose tests/python/train || exit -1
+        python -m nose tests/python/doctest || exit -1
+        python3 -m nose tests/python/doctest || exit -1
     else
         nosetests tests/python/unittest || exit -1
         nosetests3 tests/python/unittest || exit -1
         nosetests3 tests/python/train || exit -1
+        nosetests tests/python/doctest || exit -1
+        nosetests3 tests/python/doctest || exit -1
     fi
     exit 0
 fi


### PR DESCRIPTION
Fix all the doc tests for symbol.py and ndarray.py examples.
Also add the doc test in Travis_CI test, passed on Mac and Ubuntu.

Testing:
...
191 tests in 230 items.
191 passed and 0 failed.
Test passed.