### PR TITLE
Fix slicechannel type check

### DIFF
--- a/src/operator/slice_channel-inl.h
+++ b/src/operator/slice_channel-inl.h
@@ -155,7 +155,7 @@ class SliceChannelProp : public OperatorProperty {
 
   bool InferType(std::vector<int> *in_type,
                  std::vector<int> *out_type,
-                 std::vector<int> *aux_type) const override{
+                 std::vector<int> *aux_type) const override {
     CHECK_EQ(in_type->size(), 1U);
     int dtype = (*in_type)[0];
     CHECK_NE(dtype, -1) << "First input must have specified type";
@@ -202,34 +202,30 @@ class SliceChannelProp : public OperatorProperty {
       }
       dshape = TShape(&dshape[0], &dshape[dshape.ndim()-1]);
     }
-    if (out_shape->empty()) {
-      out_shape->resize(param_.num_outputs, dshape);
-    } else {
-      CHECK_EQ(static_cast<int>((*out_shape).size()), param_.num_outputs)
-        << "Size of output shape mismatch!";
-      for (int i = 0; i < param_.num_outputs; ++i) {
-        SHAPE_ASSIGN_CHECK(*out_shape, i, dshape);
-        // Perform incomplete shape inference.
-        // We can back-calculate the inshape based on the out_shape.
-        TShape back_calculate_dshape = ishape;
-        if (param_.squeeze_axis && (dshape.ndim() == ishape.ndim() - 1)) {
-          for (int d = 0; d < real_axis; ++d) {
-            back_calculate_dshape[d] = (*out_shape)[i][d];
-          }
-          back_calculate_dshape[real_axis] = param_.num_outputs;
-          for (int d = real_axis + 1; d < static_cast<int>(ishape.ndim()); ++d) {
-            back_calculate_dshape[d] = (*out_shape)[i][d - 1];
-          }
-        } else {
-          for (int d = 0; d < static_cast<int>(ishape.ndim()); ++d) {
-            back_calculate_dshape[d] = (*out_shape)[i][d];
-            if (d == real_axis) {
-              back_calculate_dshape[d] *= param_.num_outputs;
-            }
+    CHECK_EQ(static_cast<int>((*out_shape).size()), param_.num_outputs)
+      << "Size of output shape mismatch!";
+    for (int i = 0; i < param_.num_outputs; ++i) {
+      SHAPE_ASSIGN_CHECK(*out_shape, i, dshape);
+      // Perform incomplete shape inference.
+      // We can back-calculate the inshape based on the out_shape.
+      TShape back_calculate_dshape = ishape;
+      if (param_.squeeze_axis && (dshape.ndim() == ishape.ndim() - 1)) {
+        for (int d = 0; d < real_axis; ++d) {
+          back_calculate_dshape[d] = (*out_shape)[i][d];
+        }
+        back_calculate_dshape[real_axis] = param_.num_outputs;
+        for (int d = real_axis + 1; d < static_cast<int>(ishape.ndim()); ++d) {
+          back_calculate_dshape[d] = (*out_shape)[i][d - 1];
+        }
+      } else {
+        for (int d = 0; d < static_cast<int>(ishape.ndim()); ++d) {
+          back_calculate_dshape[d] = (*out_shape)[i][d];
+          if (d == real_axis) {
+            back_calculate_dshape[d] *= param_.num_outputs;
           }
         }
-        SHAPE_ASSIGN_CHECK(*in_shape, slice_enum::kData, back_calculate_dshape);
       }
+      SHAPE_ASSIGN_CHECK(*in_shape, slice_enum::kData, back_calculate_dshape);
     }
     return true;
   }

--- a/src/operator/slice_channel.cc
+++ b/src/operator/slice_channel.cc
@@ -21,10 +21,6 @@ Operator* CreateOp<cpu>(SliceChannelParam param, int dtype) {
 Operator* SliceChannelProp::CreateOperatorEx(Context ctx,
                                              std::vector<TShape>* in_shape,
                                              std::vector<int>* in_type) const {
-  std::vector<TShape> out_shape, aux_shape;
-  std::vector<int> out_type, aux_type;
-  CHECK(InferType(in_type, &out_type, &aux_type));
-  CHECK(InferShape(in_shape, &out_shape, &aux_shape));
   DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0]);
 }
 

--- a/src/operator/slice_channel.cc
+++ b/src/operator/slice_channel.cc
@@ -10,8 +10,10 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator* CreateOp<cpu>(SliceChannelParam param) {
-  return new SliceChannelOp<cpu>(param);
+Operator* CreateOp<cpu>(SliceChannelParam param, int dtype) {
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    return new SliceChannelOp<cpu, DType>(param);
+  })
 }
 
 Operator* SliceChannelProp::CreateOperator(Context ctx) const {

--- a/src/operator/slice_channel.cc
+++ b/src/operator/slice_channel.cc
@@ -11,13 +11,19 @@ namespace mxnet {
 namespace op {
 template<>
 Operator* CreateOp<cpu>(SliceChannelParam param, int dtype) {
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+  MSHADOW_TYPE_SWITCH(dtype, DType, {
     return new SliceChannelOp<cpu, DType>(param);
   })
 }
 
-Operator* SliceChannelProp::CreateOperator(Context ctx) const {
-  DO_BIND_DISPATCH(CreateOp, param_);
+Operator* SliceChannelProp::CreateOperatorEx(Context ctx,
+                                             std::vector<TShape>* in_shape,
+                                             std::vector<int>* in_type) const {
+  std::vector<TShape> out_shape, aux_shape;
+  std::vector<int> out_type, aux_type;
+  CHECK(InferType(in_type, &out_type, &aux_type));
+  CHECK(InferShape(in_shape, &out_shape, &aux_shape));
+  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0]);
 }
 
 DMLC_REGISTER_PARAMETER(SliceChannelParam);

--- a/src/operator/slice_channel.cc
+++ b/src/operator/slice_channel.cc
@@ -11,9 +11,11 @@ namespace mxnet {
 namespace op {
 template<>
 Operator* CreateOp<cpu>(SliceChannelParam param, int dtype) {
+  Operator* op = nullptr;
   MSHADOW_TYPE_SWITCH(dtype, DType, {
-    return new SliceChannelOp<cpu, DType>(param);
+    op = new SliceChannelOp<cpu, DType>(param);
   })
+  return op;
 }
 
 Operator* SliceChannelProp::CreateOperatorEx(Context ctx,

--- a/src/operator/slice_channel.cu
+++ b/src/operator/slice_channel.cu
@@ -11,9 +11,11 @@ namespace mxnet {
 namespace op {
 template<>
 Operator* CreateOp<gpu>(SliceChannelParam param, int dtype) {
+  Operator* op = nullptr;
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
-    return new SliceChannelOp<gpu>(param);
+    op = new SliceChannelOp<gpu, DType>(param);
   })
+  return op;
 }
 
 }  // namespace op

--- a/src/operator/slice_channel.cu
+++ b/src/operator/slice_channel.cu
@@ -10,8 +10,10 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator* CreateOp<gpu>(SliceChannelParam param) {
-  return new SliceChannelOp<gpu>(param);
+Operator* CreateOp<gpu>(SliceChannelParam param, int dtype) {
+  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+    return new SliceChannelOp<gpu>(param);
+  })
 }
 
 }  // namespace op


### PR DESCRIPTION
This PR fixes the problem of SliceChannel operator only accepting data type float32. It should support any data types supported in MXNet.

https://github.com/dmlc/mxnet/issues/5504

Test script:

```python
import mxnet as mx
import numpy as np


def test_slicechannel(dtype):
    data = mx.sym.Variable('data')
    target = mx.sym.SliceChannel(data, num_outputs=3)
    executor = target.bind(mx.cpu(),
                              {
                                  'data': mx.nd.array([[0, 1, 0], [1, 1, 0]], dtype=dtype)
                              })
    outputs = executor.forward()
    print outputs[0].asnumpy()


test_slicechannel(np.int32)
test_slicechannel(np.float16)
test_slicechannel(np.float32)
test_slicechannel(np.float64)
```