### PR TITLE
Skip the line in lst, if the format is incorrect

### DIFF
--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -83,7 +83,15 @@ def read_list(path_in):
             if not line:
                 break
             line = [i.strip() for i in line.strip().split('\t')]
-            item = [int(line[0])] + [line[-1]] + [float(i) for i in line[1:-1]]
+            line_len = len(line)
+            if line_len < 3:
+                print('lst should at least has three parts, but only has %s parts for %s' %(line_len, line))
+                continue
+            try:
+                item = [int(line[0])] + [line[-1]] + [float(i) for i in line[1:-1]]
+            except Exception, e:
+                print('Parsing lst met error for %s, detail: %s' %(line, e))
+                continue
             yield item
 
 def image_encode(args, i, item, q_out):


### PR DESCRIPTION
Currently, im2rec.py will block(not exit, not continue) if lst file contains some incorrect format while using multiple preprocessing. Do the validation, and add try catch to avoid this problem. 