### PR TITLE
Fixing _normalize_sequence call in *RNNCell unroll to use valid l…

### DIFF
--- a/python/mxnet/rnn/rnn_cell.py
+++ b/python/mxnet/rnn/rnn_cell.py
@@ -292,7 +292,7 @@ class BaseRNNCell(object):
             output, states = self(inputs[i], states)
             outputs.append(output)
 
-        outputs, _ = _normalize_sequence(None, outputs, layout, merge_outputs)
+        outputs, _ = _normalize_sequence(length, outputs, layout, merge_outputs)
 
         return outputs, states
 
@@ -632,7 +632,7 @@ class FusedRNNCell(BaseRNNCell):
         if axis == 1:
             outputs = symbol.swapaxes(outputs, dim1=0, dim2=1)
 
-        outputs, _ = _normalize_sequence(None, outputs, layout, merge_outputs)
+        outputs, _ = _normalize_sequence(length, outputs, layout, merge_outputs)
 
         return outputs, states
 


### PR DESCRIPTION
This fix passes in the available argument length to _normalize_sequence for outputs in BaseRNNCell and FusedRNNCell unroll methods in place of length=None.
_normalize_sequence exists to check length == len(inputs) if inputs is a list. Thus, any mismatches will be caught anyway. Making this fix, solves this aforementioned issue.

In running cell.unroll() a new error that now comes up is:
```
MXNetErrorTraceback (most recent call last)
<ipython-input-15-46f86e184d7a> in <module>()
     16 word_char_embed_all, _ = model.char_rnn_encoder.encode(char_embed_forward,
     17                                                        7,
---> 18                                                        merge_outputs=False)

/ami_workplace/ranubhai/code/workplace/DeepEntities/deepentities/encoders.py in encode(self, inputs, sequence_length, merge_outputs)
    116                                                  inputs=inputs,
    117                                                  layout=Layout.TNC.name,
--> 118                                                  merge_outputs=merge_outputs)
    119 
    120 

/home/ubuntu/mxnet_master_feb21_9_41am/mxnet/python/mxnet/rnn/rnn_cell.pyc in unroll(self, length, inputs, begin_state, layout, merge_outputs)
    745             p += n
    746             inputs, states = cell.unroll(length, inputs=inputs, begin_state=states, layout=layout,
--> 747                                          merge_outputs=None if i < num_cells-1 else merge_outputs)
    748 
    749         return inputs, states

/home/ubuntu/mxnet_master_feb21_9_41am/mxnet/python/mxnet/rnn/rnn_cell.pyc in unroll(self, length, inputs, begin_state, layout, merge_outputs)
    636             outputs = symbol.swapaxes(outputs, dim1=0, dim2=1)
    637 
--> 638         outputs, _ = _normalize_sequence(None, outputs, layout, merge_outputs)
    639 
    640         return outputs, states

/home/ubuntu/mxnet_master_feb21_9_41am/mxnet/python/mxnet/rnn/rnn_cell.pyc in _normalize_sequence(length, inputs, layout, merge, in_layout)
     41                 "to list with list(inputs) first or let unroll handle splitting."
     42             inputs = list(symbol.split(inputs, axis=in_axis, num_outputs=length,
---> 43                                        squeeze_axis=1))
     44     else:
     45         assert length is None or len(inputs) == length

/home/ubuntu/mxnet_master_feb21_9_41am/mxnet/python/mxnet/_ctypes/symbol.pyc in creator(*args, **kwargs)
    179             mx_uint(len(param_keys)),
    180             param_keys, param_vals,
--> 181             ctypes.byref(sym_handle)))
    182 
    183         if len(args) != 0 and len(symbol_kwargs) != 0:

/home/ubuntu/mxnet_master_feb21_9_41am/mxnet/python/mxnet/base.pyc in check_call(ret)
     76     """
     77     if ret != 0:
---> 78         raise MXNetError(py_str(_LIB.MXGetLastError()))
     79 
     80 if sys.version_info[0] < 3:

MXNetError: Invalid Parameter format for num_outputs expect int but value='None', in operator SliceChannel(name="", axis="0", num_outputs="None", squeeze_axis="1")
```

