### PR TITLE
Inference in ndarray Reshape.

### DIFF
--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -497,7 +497,7 @@ fixed-size items.
         for index, element in enumerate(shape):
             if element == -1:
                 remainder = list(self.shape)
-                for i, e in enumerate(shape):  # pylint: disable=C0321
+                for i, e in enumerate(shape):  # pylint: disable=invalid-name
                     if i != index and e == -1:
                         raise ValueError('Only one dimension can be inferred.')
                     try:

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -497,12 +497,12 @@ fixed-size items.
         for index, element in enumerate(shape):
             if element == -1:
                 remainder = list(self.shape)
-                for i, e in enumerate(shape):
+                for i, e in enumerate(shape):  # pylint: disable=C0321
                     if i != index and e == -1:
                         raise ValueError('Only one dimension can be inferred.')
                     try:
                         remainder.remove(e)
-                    except:
+                    except ValueError:
                         pass
                 shape[index] = np.product(remainder)
                 # We have already gone through the whole shape, break

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -460,7 +460,8 @@ fixed-size items.
         shape : tuple of int
             The new shape should not change the array size, namely
             ``np.prod(new_shape)`` should be equal to ``np.prod(self.shape)``.
-            One shape dimension can be -1. In this case, the value is inferred from the length of the array and remaining dimensions.
+            One shape dimension can be -1. In this case, the value is inferred
+            from the length of the array and remaining dimensions.
 
 
         Returns
@@ -513,7 +514,7 @@ fixed-size items.
                                          c_array(ctypes.c_int, shape),
                                          ctypes.byref(handle)))
         return NDArray(handle=handle, writable=self.writable)
-    
+
     # pylint: disable= undefined-variable
     def broadcast_to(self, shape):
         """Broadcasts an array to a new shape.

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -460,6 +460,8 @@ fixed-size items.
         shape : tuple of int
             The new shape should not change the array size, namely
             ``np.prod(new_shape)`` should be equal to ``np.prod(self.shape)``.
+            One shape dimension can be -1. In this case, the value is inferred from the length of the array and remaining dimensions.
+
 
         Returns
         -------
@@ -477,18 +479,41 @@ fixed-size items.
         array([[ 0.,  1.],
                [ 2.,  3.],
                [ 4.,  5.]], dtype=float32)
+        >>> y = x.reshape((3,-1))
+        >>> y.asnumpy()
+        array([[ 0.,  1.],
+               [ 2.,  3.],
+               [ 4.,  5.]], dtype=float32)
         >>> y[:] = -1
         >>> x.asnumpy()
         array([[-1., -1., -1.],
                [-1., -1., -1.]], dtype=float32)
         """
         handle = NDArrayHandle()
+
+        # Infer the correct size for dim == -1
+        shape = list(shape)
+        for index, element in enumerate(shape):
+            if element == -1:
+                remainder = list(self.shape)
+                for i, e in enumerate(shape):
+                    if i != index and e == -1:
+                        raise ValueError('Only one dimension can be inferred.')
+                    try:
+                        remainder.remove(e)
+                    except:
+                        pass
+                shape[index] = np.product(remainder)
+                # We have already gone through the whole shape, break
+                break
+
+        # Actual reshape
         check_call(_LIB.MXNDArrayReshape(self.handle,
                                          len(shape),
                                          c_array(ctypes.c_int, shape),
                                          ctypes.byref(handle)))
         return NDArray(handle=handle, writable=self.writable)
-
+    
     # pylint: disable= undefined-variable
     def broadcast_to(self, shape):
         """Broadcasts an array to a new shape.

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -29,13 +29,13 @@ struct ReshapeParam : public dmlc::Parameter<ReshapeParam> {
   bool reverse;
   DMLC_DECLARE_PARAMETER(ReshapeParam) {
     int tmp[] = {0, 0};
+    DMLC_DECLARE_FIELD(shape)
+    .set_default(nnvm::Tuple<int>())
+    .describe("The target shape");
     DMLC_DECLARE_FIELD(keep_highest).set_default(false)
     .describe("(Deprecated! Use ``shape`` instead.) Whether keep the highest dim unchanged."
               "If set to true, then the first dim in target_shape is ignored,"
               "and always fixed as input");
-    DMLC_DECLARE_FIELD(shape)
-    .set_default(nnvm::Tuple<int>())
-    .describe("The target shape");
     DMLC_DECLARE_FIELD(reverse)
     .set_default(false)
     .describe("If true then translating the input shape from right to left");

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -29,11 +29,6 @@ struct ReshapeParam : public dmlc::Parameter<ReshapeParam> {
   bool reverse;
   DMLC_DECLARE_PARAMETER(ReshapeParam) {
     int tmp[] = {0, 0};
-    DMLC_DECLARE_FIELD(target_shape)
-    .set_default(TShape(tmp, tmp + 2))
-    .describe("(Deprecated! Use ``shape`` instead.) "
-              "Target new shape. One and only one dim can be 0, "
-              "in which case it will be inferred from the rest of dims");
     DMLC_DECLARE_FIELD(keep_highest).set_default(false)
     .describe("(Deprecated! Use ``shape`` instead.) Whether keep the highest dim unchanged."
               "If set to true, then the first dim in target_shape is ignored,"
@@ -44,6 +39,11 @@ struct ReshapeParam : public dmlc::Parameter<ReshapeParam> {
     DMLC_DECLARE_FIELD(reverse)
     .set_default(false)
     .describe("If true then translating the input shape from right to left");
+    DMLC_DECLARE_FIELD(target_shape)
+    .set_default(TShape(tmp, tmp + 2))
+    .describe("(Deprecated! Use ``shape`` instead.) "
+              "Target new shape. One and only one dim can be 0, "
+              "in which case it will be inferred from the rest of dims");
   }
 };
 

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -116,6 +116,20 @@ def test_ndarray_negate():
     # we compute (-arr)
     assert_almost_equal(npy, arr.asnumpy())
 
+def test_ndarray_reshape():
+    tensor  = mx.nd.array([[[1, 2], [3, 4]],
+                           [[5, 6], [7, 8]]])
+    true_res = mx.nd.arange(8) + 1
+    assert same(tensor.reshape((-1, )), true_res)
+    true_res  = mx.nd.array([[1, 2, 3, 4],
+                             [5, 6, 7, 8]])
+    assert same(tensor.reshape((2, -1)), true_res)
+    true_res  = mx.nd.array([[1, 2],
+                             [3, 4],
+                             [5, 6],
+                             [7, 8]])
+    assert same(tensor.reshape((-1, 2)), true_res)
+
 
 def test_ndarray_choose():
     shape = (100, 20)


### PR DESCRIPTION
Makes `shape` the default parameter in nd.reshape (rather than the current deprecated `target_shape`) so that the function behaves as expected (e.g. `mx.nd.reshape(X, (1, -1))` works as expected).

Added support for shape inference (`-1`) on NDarray objects (i.e. for an array `X`, `X.reshape((-1, ))` works).