### PR TITLE
Implement 3D deconvolution (cuDNN)

### DIFF
--- a/src/operator/cudnn_algoreg-inl.h
+++ b/src/operator/cudnn_algoreg-inl.h
@@ -1,0 +1,89 @@
+/*!
+ * Copyright (c) 2015 by Contributors
+ * \file cudnn_algoreg-inl.h
+ * \brief
+ * \author Bing Xu
+ */
+#ifndef MXNET_OPERATOR_CUDNN_ALGOREG_INL_H_
+#define MXNET_OPERATOR_CUDNN_ALGOREG_INL_H_
+
+#include <algorithm>
+#include <mutex>
+#include <string>
+#include <vector>
+#include "../common/cuda_utils.h"
+#include "./convolution-inl.h"
+#include "./deconvolution-inl.h"
+
+namespace mxnet {
+namespace op {
+#if MXNET_USE_CUDNN == 1
+
+class CuDNNAlgoReg {
+ public:
+  template <typename Param>
+  std::string GetKey(const Param &param, const std::vector<TShape> &in_shape,
+                     const std::vector<TShape> &out_shape) {
+    std::ostringstream oss;
+    for (auto &i : in_shape)
+      oss << i << ";";
+    for (auto &i : out_shape)
+      oss << i << ";";
+    auto dict = param.__DICT__();
+    for (auto &k : dict)
+      oss << k.first << "=" << k.second << ";";
+    return oss.str();
+  }
+
+  bool Find(std::string key, cudnnConvolutionFwdAlgo_t *fwd,
+            cudnnConvolutionBwdDataAlgo_t *bwd,
+            cudnnConvolutionBwdFilterAlgo_t *flt) {
+    std::lock_guard<std::mutex> guard(lock_);
+    auto i = reg_.find(key);
+    if (i != reg_.end()) {
+      *fwd = i->second.fwd;
+      *bwd = i->second.bwd;
+      *flt = i->second.flt;
+      return true;
+    }
+    return false;
+  }
+
+  void Register(std::string key, cudnnConvolutionFwdAlgo_t fwd,
+                cudnnConvolutionBwdDataAlgo_t bwd,
+                cudnnConvolutionBwdFilterAlgo_t flt) {
+    std::lock_guard<std::mutex> guard(lock_);
+    if (reg_.size() % 50 == 0) {
+      LOG(INFO) << "Running performance tests to find the best convolution "
+                   "algorithm, "
+                   "this can take a while... (setting env variable "
+                   "MXNET_CUDNN_AUTOTUNE_DEFAULT to 0 to disable)";
+      if (reg_.size() >= 1000) {
+        LOG(INFO)
+            << "If you see this message in the middle of training, you are "
+               "probably using bucketing. Consider setting env variable "
+               "MXNET_CUDNN_AUTOTUNE_DEFAULT to 0 to disable cudnn tuning.";
+      }
+    }
+    reg_[key].fwd = fwd;
+    reg_[key].bwd = bwd;
+    reg_[key].flt = flt;
+  }
+
+  static CuDNNAlgoReg *Get();
+
+ private:
+  struct CudnnAlgorithms {
+    cudnnConvolutionFwdAlgo_t fwd;
+    cudnnConvolutionBwdDataAlgo_t bwd;
+    cudnnConvolutionBwdFilterAlgo_t flt;
+  };
+
+  std::mutex lock_;
+  std::unordered_map<std::string, CudnnAlgorithms> reg_;
+};
+#endif  // __CUDACC__ && CUDNN
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_CUDNN_ALGOREG_INL_H_

--- a/src/operator/cudnn_algoreg.cc
+++ b/src/operator/cudnn_algoreg.cc
@@ -1,10 +1,10 @@
 /*!
  * Copyright (c) 2015 by Contributors
- * \file cudnn_convolution.cc
+ * \file cudnn_algoreg.cc
  * \brief
  * \author Junyuan Xie
 */
-#include "./cudnn_convolution-inl.h"
+#include "./cudnn_algoreg-inl.h"
 #include <mxnet/base.h>
 #include <mxnet/ndarray.h>
 
@@ -14,8 +14,8 @@
 namespace mxnet {
 namespace op {
 #if MXNET_USE_CUDNN == 1
-CuDNNAlgoReg* CuDNNAlgoReg::Get() {
-  static CuDNNAlgoReg* ptr = new CuDNNAlgoReg();
+CuDNNAlgoReg *CuDNNAlgoReg::Get() {
+  static CuDNNAlgoReg *ptr = new CuDNNAlgoReg();
   return ptr;
 }
 #endif  // CUDNN

--- a/src/operator/cudnn_convolution-inl.h
+++ b/src/operator/cudnn_convolution-inl.h
@@ -12,74 +12,12 @@
 #include <mutex>
 #include <string>
 #include "./convolution-inl.h"
+#include "./cudnn_algoreg-inl.h"
 #include "../common/cuda_utils.h"
 
 namespace mxnet {
 namespace op {
 #if MXNET_USE_CUDNN == 1
-
-class CuDNNAlgoReg {
- public:
-  std::string GetKey(const ConvolutionParam& param,
-                     const std::vector<TShape>& in_shape,
-                     const std::vector<TShape>& out_shape) {
-    std::ostringstream oss;
-    for (auto& i : in_shape) oss << i << ";";
-    for (auto& i : out_shape) oss << i << ";";
-    auto dict = param.__DICT__();
-    for (auto& k : dict) oss << k.first << "=" << k.second << ";";
-    return oss.str();
-  }
-
-  bool Find(std::string key,
-            cudnnConvolutionFwdAlgo_t *fwd,
-            cudnnConvolutionBwdDataAlgo_t *bwd,
-            cudnnConvolutionBwdFilterAlgo_t *flt) {
-    std::lock_guard<std::mutex> guard(lock_);
-    auto i = reg_.find(key);
-    if (i != reg_.end()) {
-      *fwd = i->second.fwd;
-      *bwd = i->second.bwd;
-      *flt = i->second.flt;
-      return true;
-    }
-    return false;
-  }
-
-  void Register(std::string key,
-                cudnnConvolutionFwdAlgo_t fwd,
-                cudnnConvolutionBwdDataAlgo_t bwd,
-                cudnnConvolutionBwdFilterAlgo_t flt) {
-    std::lock_guard<std::mutex> guard(lock_);
-    if (reg_.size() % 50 == 0) {
-      LOG(INFO)
-        << "Running performance tests to find the best convolution algorithm, "
-           "this can take a while... (setting env variable "
-           "MXNET_CUDNN_AUTOTUNE_DEFAULT to 0 to disable)";
-      if (reg_.size() >= 1000) {
-        LOG(INFO)
-          << "If you see this message in the middle of training, you are "
-             "probably using bucketing. Consider setting env variable "
-             "MXNET_CUDNN_AUTOTUNE_DEFAULT to 0 to disable cudnn tuning.";
-      }
-    }
-    reg_[key].fwd = fwd;
-    reg_[key].bwd = bwd;
-    reg_[key].flt = flt;
-  }
-
-  static CuDNNAlgoReg* Get();
-
- private:
-  struct CudnnAlgorithms {
-    cudnnConvolutionFwdAlgo_t fwd;
-    cudnnConvolutionBwdDataAlgo_t bwd;
-    cudnnConvolutionBwdFilterAlgo_t flt;
-  };
-
-  std::mutex lock_;
-  std::unordered_map<std::string, CudnnAlgorithms> reg_;
-};
 
 template<typename DType>
 class CuDNNConvolutionOp : public Operator {

--- a/src/operator/cudnn_deconvolution-inl.h
+++ b/src/operator/cudnn_deconvolution-inl.h
@@ -1,29 +1,55 @@
 /*!
- * Copyright (c) 2015 by Contributors
+ * Copyright (c) 2017 by Contributors
  * \file cudnn_deconvolution-inl.h
  * \brief
- * \author Wei Wu
+ * \author Wei Wu, Leonard Lausen
 */
 #ifndef MXNET_OPERATOR_CUDNN_DECONVOLUTION_INL_H_
 #define MXNET_OPERATOR_CUDNN_DECONVOLUTION_INL_H_
 
 #include <algorithm>
 #include <vector>
+#include <mutex>
+#include <string>
 #include "./deconvolution-inl.h"
+#include "./cudnn_algoreg-inl.h"
+#include "../common/cuda_utils.h"
 
 namespace mxnet {
 namespace op {
-#if defined(__CUDACC__) && MXNET_USE_CUDNN == 1
+#if MXNET_USE_CUDNN == 1
+
 template<typename DType>
 class CuDNNDeconvolutionOp : public Operator {
  public:
-  explicit CuDNNDeconvolutionOp(DeconvolutionParam param) {
+  explicit CuDNNDeconvolutionOp(DeconvolutionParam param,
+                                const std::vector<TShape>& in_shape,
+                                const std::vector<TShape>& out_shape,
+                                const Context& ctx) {
+    using namespace mshadow;
     this->param_ = param;
+
     // convert MB to words
     param_.workspace = (param_.workspace << 20) / sizeof(DType);
     init_cudnn_ = false;
-    // TODO(xxx): fp16
+    init_temp_size_ = false;
     dtype_ = mshadow::DataType<DType>::kCudnnFlag;
+
+#if CUDNN_MAJOR >= 5
+    MSHADOW_LAYOUT_SWITCH(param_.layout.value(), Layout, {
+        format_ = LayoutType<Layout>::kCudnnFlag;
+      });
+#else
+    CHECK(param_.layout.value() == kNCHW || param_.layout.value() == kNCDHW)
+      << "Need CuDNN > 5.0 for layout support";
+#endif
+
+    InitDescriptors(ctx, in_shape, out_shape);
+
+    if (!param_.cudnn_tune) {
+      param_.cudnn_tune = dmlc::GetEnv("MXNET_CUDNN_AUTOTUNE_DEFAULT", 1);
+    }
+    SelectAlgo(ctx, in_shape, out_shape);
   }
 
   ~CuDNNDeconvolutionOp() {
@@ -43,22 +69,39 @@ class CuDNNDeconvolutionOp : public Operator {
                        const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     size_t expected = param_.no_bias ? 2 : 3;
+    DType *data_ptr = NULL;
+    DType *wmat_ptr = NULL;
+    DType *out_ptr = NULL;
     CHECK_EQ(in_data.size(), expected);
     CHECK_EQ(out_data.size(), 1U);
     Stream<gpu> *s = ctx.get_stream<gpu>();
-    Tensor<gpu, 4, DType> data = in_data[deconv::kData].get<gpu, 4, DType>(s);
-    Tensor<gpu, 4, DType> wmat = in_data[deconv::kWeight].get<gpu, 4, DType>(s);
-    Tensor<gpu, 4, DType> out = out_data[deconv::kOut].get<gpu, 4, DType>(s);
-
-    CHECK_EQ(data.CheckContiguous(), true);
-    CHECK_EQ(wmat.CheckContiguous(), true);
-    CHECK_EQ(out.CheckContiguous(), true);
-    if (!init_cudnn_) {
-      Init(s, in_data, out_data);
-    }
+    GetTempSize(ctx);
     Tensor<gpu, 1, DType> workspace =
-        ctx.requested[deconv::kTempSpace].get_space_typed<gpu, 1, DType>(
-                                 mshadow::Shape1(forward_workspace_), s);
+      ctx.requested[deconv::kTempSpace].get_space_typed<gpu, 1, DType>(
+        mshadow::Shape1(forward_workspace_), s);
+
+    if (param_.kernel.ndim() == 2) {
+      Tensor<gpu, 4, DType> data = in_data[deconv::kData].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> wmat = in_data[deconv::kWeight].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> out = out_data[deconv::kOut].get<gpu, 4, DType>(s);
+      CHECK_EQ(data.CheckContiguous(), true);
+      CHECK_EQ(wmat.CheckContiguous(), true);
+      CHECK_EQ(out.CheckContiguous(), true);
+      data_ptr = data.dptr_;
+      wmat_ptr = wmat.dptr_;
+      out_ptr = out.dptr_;
+    } else {
+      Tensor<gpu, 5, DType> data = in_data[deconv::kData].get<gpu, 5, DType>(s);
+      Tensor<gpu, 5, DType> wmat = in_data[deconv::kWeight].get<gpu, 5, DType>(s);
+      Tensor<gpu, 5, DType> out = out_data[deconv::kOut].get<gpu, 5, DType>(s);
+      CHECK_EQ(data.CheckContiguous(), true);
+      CHECK_EQ(wmat.CheckContiguous(), true);
+      CHECK_EQ(out.CheckContiguous(), true);
+      data_ptr = data.dptr_;
+      wmat_ptr = wmat.dptr_;
+      out_ptr = out.dptr_;
+    }
+
     for (uint32_t g = 0; g < param_.num_group; ++g) {
       typename DataType<DType>::ScaleType alpha = 1.0f;
       typename DataType<DType>::ScaleType beta  = 0.0f;
@@ -66,30 +109,30 @@ class CuDNNDeconvolutionOp : public Operator {
       CHECK_EQ(cudnnConvolutionBackwardData_v3(s->dnn_handle_,
                &alpha,
                filter_desc_,
-               wmat.dptr_ + weight_offset_ * g,
+               wmat_ptr + weight_offset_ * g,
                in_desc_,
-               data.dptr_ + data_offset_ * g,
+               data_ptr + data_offset_ * g,
                conv_desc_,
                back_algo_,
                workspace.dptr_,
                backward_workspace_byte_,
                &beta,
                out_desc_,
-               out.dptr_ + out_offset_ * g), CUDNN_STATUS_SUCCESS);
+               out_ptr + out_offset_ * g), CUDNN_STATUS_SUCCESS);
       #elif CUDNN_MAJOR == 5
       CHECK_EQ(cudnnConvolutionBackwardData(s->dnn_handle_,
                &alpha,
                filter_desc_,
-               wmat.dptr_ + weight_offset_ * g,
+               wmat_ptr + weight_offset_ * g,
                in_desc_,
-               data.dptr_ + data_offset_ * g,
+               data_ptr + data_offset_ * g,
                conv_desc_,
                back_algo_,
                workspace.dptr_,
                backward_workspace_byte_,
                &beta,
                out_desc_,
-               out.dptr_ + out_offset_ * g), CUDNN_STATUS_SUCCESS);
+               out_ptr + out_offset_ * g), CUDNN_STATUS_SUCCESS);
       #endif
       if (!param_.no_bias) {
         beta = 1.0f;
@@ -101,7 +144,7 @@ class CuDNNDeconvolutionOp : public Operator {
                                 bias.dptr_ + bias_offset_ * g,
                                 &beta,
                                 out_desc_,
-                                out.dptr_ + out_offset_ * g), CUDNN_STATUS_SUCCESS);
+                                out_ptr + out_offset_ * g), CUDNN_STATUS_SUCCESS);
 #endif
 #if CUDNN_MAJOR == 3
         CHECK_EQ(cudnnAddTensor(s->dnn_handle_,
@@ -111,7 +154,7 @@ class CuDNNDeconvolutionOp : public Operator {
                                 bias.dptr_ + bias_offset_ * g,
                                 &beta,
                                 out_desc_,
-                                out.dptr_ + out_offset_ * g), CUDNN_STATUS_SUCCESS);
+                                out_ptr + out_offset_ * g), CUDNN_STATUS_SUCCESS);
 #endif
       }
     }
@@ -127,17 +170,40 @@ class CuDNNDeconvolutionOp : public Operator {
     using namespace mshadow;
     using namespace mshadow::expr;
     size_t expected = param_.no_bias == 0 ? 3 : 2;
+    DType *grad_ptr = NULL;
+    DType *wmat_ptr = NULL;
+    DType *gwmat_ptr = NULL;
+    DType *data_ptr = NULL;
+    DType *gdata_ptr = NULL;
     CHECK_EQ(out_grad.size(), 1U);
     CHECK(in_data.size() == expected && in_grad.size() == expected);
+    Stream<gpu> *s = ctx.get_stream<gpu>();
+    if (param_.kernel.ndim() == 2) {
+      Tensor<gpu, 4, DType> grad = out_grad[deconv::kOut].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> wmat = in_data[deconv::kWeight].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> gwmat = in_grad[deconv::kWeight].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> data = in_data[deconv::kData].get<gpu, 4, DType>(s);
+      Tensor<gpu, 4, DType> gdata = in_grad[deconv::kData].get<gpu, 4, DType>(s);
+      grad_ptr = grad.dptr_;
+      wmat_ptr = wmat.dptr_;
+      gwmat_ptr = gwmat.dptr_;
+      data_ptr = data.dptr_;
+      gdata_ptr = gdata.dptr_;
+    } else {
+      Tensor<gpu, 5, DType> grad = out_grad[deconv::kOut].get<gpu, 5, DType>(s);
+      Tensor<gpu, 5, DType> wmat = in_data[deconv::kWeight].get<gpu, 5, DType>(s);
+      Tensor<gpu, 5, DType> gwmat = in_grad[deconv::kWeight].get<gpu, 5, DType>(s);
+      Tensor<gpu, 5, DType> data = in_data[deconv::kData].get<gpu, 5, DType>(s);
+      Tensor<gpu, 5, DType> gdata = in_grad[deconv::kData].get<gpu, 5, DType>(s);
+      grad_ptr = grad.dptr_;
+      wmat_ptr = wmat.dptr_;
+      gwmat_ptr = gwmat.dptr_;
+      data_ptr = data.dptr_;
+      gdata_ptr = gdata.dptr_;
+    }
     CHECK_NE(req[deconv::kWeight], kWriteInplace);
     CHECK_NE(req[deconv::kBias], kWriteInplace);
     CHECK_NE(req[deconv::kData], kWriteInplace);
-    Stream<gpu> *s = ctx.get_stream<gpu>();
-    Tensor<gpu, 4, DType> grad = out_grad[deconv::kOut].get<gpu, 4, DType>(s);
-    Tensor<gpu, 4, DType> wmat = in_data[deconv::kWeight].get<gpu, 4, DType>(s);
-    Tensor<gpu, 4, DType> gwmat = in_grad[deconv::kWeight].get<gpu, 4, DType>(s);
-    Tensor<gpu, 4, DType> data = in_data[deconv::kData].get<gpu, 4, DType>(s);
-    Tensor<gpu, 4, DType> gdata = in_grad[deconv::kData].get<gpu, 4, DType>(s);
     Tensor<gpu, 1, DType> workspace =
         ctx.requested[deconv::kTempSpace].get_space_typed<gpu, 1, DType>(
                                  mshadow::Shape1(backward_workspace_), s);
@@ -155,7 +221,7 @@ class CuDNNDeconvolutionOp : public Operator {
         CHECK_EQ(cudnnConvolutionBackwardBias(s->dnn_handle_,
                                               &alpha,
                                               out_desc_,
-                                              grad.dptr_ + out_offset_ * g,
+                                              grad_ptr + out_offset_ * g,
                                               &bias_beta,
                                               bias_desc_,
                                               gbias.dptr_ + bias_offset_ * g),
@@ -166,187 +232,341 @@ class CuDNNDeconvolutionOp : public Operator {
         CHECK_EQ(cudnnConvolutionBackwardFilter_v3(s->dnn_handle_,
                  &alpha,
                  out_desc_,
-                 grad.dptr_ + out_offset_ * g,
+                 grad_ptr + out_offset_ * g,
                  in_desc_,
-                 data.dptr_ + data_offset_ * g,
+                 data_ptr + data_offset_ * g,
                  conv_desc_,
                  back_algo_w_,
                  workspace.dptr_,
                  backward_workspace_byte_,
                  &weight_beta,
                  filter_desc_,
-                 gwmat.dptr_ + weight_offset_ * g), CUDNN_STATUS_SUCCESS);
+                 gwmat_ptr + weight_offset_ * g), CUDNN_STATUS_SUCCESS);
         #elif CUDNN_MAJOR == 5
         CHECK_EQ(cudnnConvolutionBackwardFilter(s->dnn_handle_,
                  &alpha,
                  out_desc_,
-                 grad.dptr_ + out_offset_ * g,
+                 grad_ptr + out_offset_ * g,
                  in_desc_,
-                 data.dptr_ + data_offset_ * g,
+                 data_ptr + data_offset_ * g,
                  conv_desc_,
                  back_algo_w_,
                  workspace.dptr_,
                  backward_workspace_byte_,
                  &weight_beta,
                  filter_desc_,
-                 gwmat.dptr_ + weight_offset_ * g), CUDNN_STATUS_SUCCESS);
+                 gwmat_ptr + weight_offset_ * g), CUDNN_STATUS_SUCCESS);
         #endif
       }
       if (req[deconv::kData] != kNullOp) {
         CHECK_EQ(cudnnConvolutionForward(s->dnn_handle_,
                                          &alpha,
                                          out_desc_,
-                                         grad.dptr_ + out_offset_ * g,
+                                         grad_ptr + out_offset_ * g,
                                          filter_desc_,
-                                         wmat.dptr_ + weight_offset_ * g,
+                                         wmat_ptr + weight_offset_ * g,
                                          conv_desc_,
                                          algo_,
                                          workspace.dptr_,
                                          forward_workspace_byte_,
                                          &data_beta,
                                          in_desc_,
-                                         gdata.dptr_ + data_offset_ * g), CUDNN_STATUS_SUCCESS);
+                                         gdata_ptr + data_offset_ * g), CUDNN_STATUS_SUCCESS);
       }
     }
   }
 
  private:
-  inline void Init(mshadow::Stream<gpu> *s,
-                   const std::vector<TBlob> &in_data,
-                   const std::vector<TBlob> &out_data) {
+  inline void InitDescriptors(const Context& ctx,
+                              const std::vector<TShape> &in_shape,
+                              const std::vector<TShape> &out_shape) {
     using namespace mshadow;
-    #if CUDNN_MAJOR == 5
-    format_ = CUDNN_TENSOR_NCHW;
-    #endif
     size_t expected = param_.no_bias ? 2 : 3;
-    CHECK_EQ(in_data.size(), expected);
-    CHECK_EQ(out_data.size(), 1U);
-    if (!init_cudnn_) {
-      init_cudnn_ = true;
-      size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
-      size_t back_size = 0;
-      size_t back_size_w = 0;
-      Tensor<gpu, 4, DType> data = in_data[deconv::kData].get<gpu, 4, DType>(s);
-      Tensor<gpu, 4, DType> out = out_data[deconv::kOut].get<gpu, 4, DType>(s);
-      index_t pad_y, pad_x, adj_y, adj_x;
-      param_.InferPad(data.size(2), data.size(3), &pad_y, &pad_x, &adj_y, &adj_x);
-      data_offset_ = data.shape_[1] / param_.num_group * data.shape_[2] * data.shape_[3];
-      out_offset_ = out.shape_[1] /param_.num_group * out.shape_[2] * out.shape_[3];
-      weight_offset_ = data.shape_[1] / param_.num_group * param_.num_filter / param_.num_group
-                       * param_.kernel[0] * param_.kernel[1];
-      CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc_), CUDNN_STATUS_SUCCESS);
-      #if CUDNN_MAJOR <=4
-      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
-                                          dtype_,
-                                          data.shape_[1] / param_.num_group,
-                                          param_.num_filter / param_.num_group,
-                                          param_.kernel[0],
-                                          param_.kernel[1]), CUDNN_STATUS_SUCCESS);
-      #elif CUDNN_MAJOR ==5
-      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
-                                          dtype_,
-                                          format_,
-                                          data.shape_[1] / param_.num_group,
-                                          param_.num_filter / param_.num_group,
-                                          param_.kernel[0],
-                                          param_.kernel[1]), CUDNN_STATUS_SUCCESS);
-      #endif
+    CHECK_EQ(in_shape.size(), expected);
+    CHECK_EQ(out_shape.size(), 1U);
+    CHECK_EQ(cudnnCreateTensorDescriptor(&in_desc_), CUDNN_STATUS_SUCCESS);
+    CHECK_EQ(cudnnCreateTensorDescriptor(&out_desc_), CUDNN_STATUS_SUCCESS);
+    CHECK_EQ(cudnnCreateTensorDescriptor(&bias_desc_), CUDNN_STATUS_SUCCESS);
+    CHECK_EQ(cudnnCreateFilterDescriptor(&filter_desc_), CUDNN_STATUS_SUCCESS);
+    CHECK_EQ(cudnnCreateConvolutionDescriptor(&conv_desc_), CUDNN_STATUS_SUCCESS);
+
+    TShape dshape = in_shape[deconv::kData];
+    TShape wshape = in_shape[deconv::kWeight];
+    TShape oshape = out_shape[deconv::kOut];
+    TShape dstride, ostride;
+    wshape[0] /= param_.num_group;
+
+    if (param_.kernel.ndim() == 2) {
+      // 2d conv
+      index_t o_pad[2];
+      index_t o_adj[2];
+      param_.InferPad(dshape, o_pad, o_adj);
+
       CHECK_EQ(cudnnSetConvolution2dDescriptor(conv_desc_,
-                                               pad_y,
-                                               pad_x,
+                                               o_pad[0],
+                                               o_pad[1],
                                                param_.stride[0],
                                                param_.stride[1],
                                                1,
                                                1,
                                                CUDNN_CROSS_CORRELATION), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnSetTensor4dDescriptorEx(in_desc_,
-                                            dtype_,
-                                            data.shape_[0],
-                                            data.shape_[1] / param_.num_group,
-                                            data.shape_[2],
-                                            data.shape_[3],
-                                            data.shape_[1] * data.shape_[2] * data.shape_[3],
-                                            data.shape_[2] * data.shape_[3],
-                                            data.shape_[3],
-                                            1), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnSetTensor4dDescriptorEx(out_desc_,
-                                            dtype_,
-                                            out.shape_[0],
-                                            out.shape_[1] / param_.num_group,
-                                            out.shape_[2],
-                                            out.shape_[3],
-                                            out.shape_[1] * out.shape_[2] * out.shape_[3],
-                                            out.shape_[2] * out.shape_[3],
-                                            out.shape_[3],
-                                            1), CUDNN_STATUS_SUCCESS);
-      if (!param_.no_bias) {
-        Tensor<gpu, 1, DType> bias = in_data[deconv::kBias].get<gpu, 1, DType>(s);
-        bias_offset_ = bias.shape_[0] / param_.num_group;
-        CHECK_EQ(cudnnSetTensor4dDescriptor(bias_desc_,
-                                            CUDNN_TENSOR_NCHW,
-                                            dtype_,
-                                            1,
-                                            bias.shape_[0] / param_.num_group,
-                                            1,
-                                            1), CUDNN_STATUS_SUCCESS);
+
+      #if CUDNN_MAJOR >= 5
+      wshape = ConvertLayout(wshape.get<4>(), param_.layout.value(), kNCHW);
+      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
+                                          dtype_,
+                                          format_,
+                                          wshape[0],
+                                          wshape[1],
+                                          wshape[2],
+                                          wshape[3]), CUDNN_STATUS_SUCCESS);
+      #else
+      CHECK_EQ(param_.layout.value(), kNCHW) << "CuDNN V4 only support NCHW layout";
+      CHECK_EQ(cudnnSetFilter4dDescriptor(filter_desc_,
+                                          dtype_,
+                                          wshape[0],
+                                          wshape[1],
+                                          wshape[2],
+                                          wshape[3]), CUDNN_STATUS_SUCCESS);
+      #endif
+
+      dstride = ConvertLayout(Shape4(dshape[1] * dshape[2] * dshape[3],
+                                     dshape[2] * dshape[3],
+                                     dshape[3],
+                                     1),
+                              param_.layout.value(), kNCHW);
+      dshape = ConvertLayout(dshape.get<4>(), param_.layout.value(), kNCHW);
+
+      ostride = ConvertLayout(Shape4(oshape[1] * oshape[2] * oshape[3],
+                                     oshape[2] * oshape[3],
+                                     oshape[3],
+                                     1),
+                              param_.layout.value(), kNCHW);
+      oshape = ConvertLayout(oshape.get<4>(), param_.layout.value(), kNCHW);
+    } else if (param_.kernel.ndim() == 3) {
+      // 3d conv
+      std::vector<int> upscale_vec = {1, 1, 1};
+
+      index_t o_pad[3];
+      index_t o_adj[3];
+      param_.InferPad(dshape, o_pad, o_adj);
+
+      #if CUDNN_MAJOR >= 5
+      CHECK_EQ(param_.layout.value(), kNCDHW) << "CuDNN only support 3D conv with NCDHW layout";
+      CHECK_EQ(cudnnSetFilterNdDescriptor(filter_desc_,
+                                          dtype_,
+                                          CUDNN_TENSOR_NCHW,
+                                          static_cast<int>(wshape.ndim()),
+                                          reinterpret_cast<int*>(&wshape[0])),
+               CUDNN_STATUS_SUCCESS);
+      #else
+      LOG(FATAL) << "Only support CUDNN V5 for 3D convolution";
+      #endif
+      CHECK_EQ(cudnnSetConvolutionNdDescriptor(conv_desc_,
+                                               3,
+                                               reinterpret_cast<int*>(&o_pad[0]),
+                                               reinterpret_cast<int*>(&param_.stride[0]),
+                                               &upscale_vec[0],
+                                               CUDNN_CROSS_CORRELATION,
+                                               dtype_), CUDNN_STATUS_SUCCESS);
+
+      dstride = ConvertLayout(Shape5(dshape[1] * dshape[2] * dshape[3] * dshape[4],
+                                     dshape[2] * dshape[3] * dshape[4],
+                                     dshape[3] * dshape[4],
+                                     dshape[4],
+                                     1),
+                              param_.layout.value(), kNCDHW);
+      dshape = ConvertLayout(dshape.get<5>(), param_.layout.value(), kNCDHW);
+
+      ostride = ConvertLayout(Shape5(oshape[1] * oshape[2] * oshape[3] * oshape[4],
+                                     oshape[2] * oshape[3] * oshape[4],
+                                     oshape[3] * oshape[4],
+                                     oshape[4],
+                                     1),
+                              param_.layout.value(), kNCDHW);
+      oshape = ConvertLayout(oshape.get<5>(), param_.layout.value(), kNCDHW);
+    }
+    dshape[1] /= param_.num_group;
+    oshape[1] /= param_.num_group;
+    weight_offset_ = wshape.Size();
+    data_offset_ = dstride[1] * dshape[1];
+    out_offset_ = ostride[1] * oshape[1];
+
+    CHECK_EQ(cudnnSetTensorNdDescriptor(in_desc_,
+                                        dtype_,
+                                        static_cast<int>(dshape.ndim()),
+                                        reinterpret_cast<int*>(&dshape[0]),
+                                        reinterpret_cast<int*>(&dstride[0])),
+             CUDNN_STATUS_SUCCESS);
+
+    CHECK_EQ(cudnnSetTensorNdDescriptor(out_desc_,
+                                        dtype_,
+                                        static_cast<int>(oshape.ndim()),
+                                        reinterpret_cast<int*>(&oshape[0]),
+                                        reinterpret_cast<int*>(&ostride[0])),
+             CUDNN_STATUS_SUCCESS);
+
+    if (!param_.no_bias) {
+      TShape bias = in_shape[deconv::kBias];
+      bias_offset_ = bias[0] / param_.num_group;
+      std::vector<int> bias_shape = {1,
+                                     static_cast<int>(bias[0] / param_.num_group),
+                                     1, 1};
+      std::vector<int> bias_stride = {static_cast<int>(bias_offset_), 1, 1, 1};
+      if (param_.kernel.ndim() == 3) {
+        bias_shape.push_back(1);
+        bias_stride.push_back(1);
       }
+      CHECK_EQ(cudnnSetTensorNdDescriptor(bias_desc_,
+                                          dtype_,
+                                          static_cast<int>(bias_shape.size()),
+                                          &bias_shape[0],
+                                          &bias_stride[0]), CUDNN_STATUS_SUCCESS);
+    }
+    init_cudnn_ = true;
+  }
+
+  void SelectAlgo(const Context& ctx,
+                  const std::vector<TShape>& in_shape,
+                  const std::vector<TShape>& out_shape) {
+    std::string key = CuDNNAlgoReg::Get()->GetKey(param_, in_shape, out_shape);
+    if (CuDNNAlgoReg::Get()->Find(key, &algo_, &back_algo_, &back_algo_w_)) return;
+
+    Engine::VarHandle var = Engine::Get()->NewVariable();
+    Engine::Get()->PushSync([=](RunContext rctx) {
+      mshadow::Stream<gpu> *s = rctx.get_stream<gpu>();
       CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
-      CHECK_EQ(cudnnGetConvolutionForwardAlgorithm(s->dnn_handle_,
-               out_desc_,
-               filter_desc_,
-               conv_desc_,
-               in_desc_,
-               CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &algo_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
-               out_desc_,
-               in_desc_,
-               conv_desc_,
-               filter_desc_,
-               CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &back_algo_w_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardDataAlgorithm(s->dnn_handle_,
-               filter_desc_,
-               in_desc_,
-               conv_desc_,
-               out_desc_,
-               CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-               workspace_byte,
-               &back_algo_), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardDataWorkspaceSize(s->dnn_handle_,
+      size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
+      if (!param_.cudnn_tune.value()) {
+        CHECK_EQ(cudnnGetConvolutionForwardAlgorithm(s->dnn_handle_,
+                 out_desc_,
+                 filter_desc_,
+                 conv_desc_,
+                 in_desc_,
+                 CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
+                 workspace_byte,
+                 &(this->algo_)), CUDNN_STATUS_SUCCESS);
+        CHECK_EQ(cudnnGetConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
+                 out_desc_,
+                 in_desc_,
+                 conv_desc_,
+                 filter_desc_,
+                 CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+                 workspace_byte,
+                 &(this->back_algo_w_)), CUDNN_STATUS_SUCCESS);
+        CHECK_EQ(cudnnGetConvolutionBackwardDataAlgorithm(s->dnn_handle_,
+                 filter_desc_,
+                 in_desc_,
+                 conv_desc_,
+                 out_desc_,
+                 CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
+                 workspace_byte,
+                 &(this->back_algo_)), CUDNN_STATUS_SUCCESS);
+      } else {
+        const int kMaxAlgos = 10;
+        int nalgo = kMaxAlgos;
+        int i;
+
+        cudnnConvolutionFwdAlgoPerf_t fwd_algo[kMaxAlgos];
+        CHECK_EQ(cudnnFindConvolutionForwardAlgorithm(s->dnn_handle_,
+                 out_desc_,
+                 filter_desc_,
+                 conv_desc_,
+                 in_desc_,
+                 kMaxAlgos,
+                 &nalgo,
+                 fwd_algo), CUDNN_STATUS_SUCCESS);
+        i = 0;
+        while (i < nalgo
+               && (fwd_algo[i].status != CUDNN_STATUS_SUCCESS
+               || (param_.cudnn_tune.value() == deconv::kLimited
+               && fwd_algo[i].memory > workspace_byte))) ++i;
+        if (i == nalgo) {
+          LOG(FATAL) << "Failed to find an convolution algorithm.";
+        } else {
+          this->algo_ = fwd_algo[i].algo;
+        }
+
+        cudnnConvolutionBwdFilterAlgoPerf_t bwd_filter_algo[kMaxAlgos];
+        CHECK_EQ(cudnnFindConvolutionBackwardFilterAlgorithm(s->dnn_handle_,
+                 out_desc_,
+                 in_desc_,
+                 conv_desc_,
+                 filter_desc_,
+                 kMaxAlgos,
+                 &nalgo,
+                 bwd_filter_algo), CUDNN_STATUS_SUCCESS);
+        i = 0;
+        while (i < nalgo
+               && (bwd_filter_algo[i].status != CUDNN_STATUS_SUCCESS
+               || (param_.cudnn_tune.value() == deconv::kLimited
+               && bwd_filter_algo[i].memory > workspace_byte))) ++i;
+        if (i == nalgo) {
+          LOG(FATAL) << "Failed to find an convolution algorithm.";
+        } else {
+          this->back_algo_w_ = bwd_filter_algo[i].algo;
+        }
+
+        cudnnConvolutionBwdDataAlgoPerf_t bwd_data_algo[kMaxAlgos];
+        CHECK_EQ(cudnnFindConvolutionBackwardDataAlgorithm(s->dnn_handle_,
+                 filter_desc_,
+                 in_desc_,
+                 conv_desc_,
+                 out_desc_,
+                 kMaxAlgos,
+                 &nalgo,
+                 bwd_data_algo), CUDNN_STATUS_SUCCESS);
+        i = 0;
+        while (i < nalgo
+               && (bwd_data_algo[i].status != CUDNN_STATUS_SUCCESS
+               || (param_.cudnn_tune.value() == deconv::kLimited
+               && bwd_data_algo[i].memory > workspace_byte))) ++i;
+        if (i == nalgo) {
+          LOG(FATAL) << "Failed to find an convolution algorithm.";
+        } else {
+          this->back_algo_ = bwd_data_algo[i].algo;
+        }
+        CuDNNAlgoReg::Get()->Register(key, this->algo_, this->back_algo_, this->back_algo_w_);
+      }
+    }, ctx, {}, {var});
+    Engine::Get()->WaitForVar(var);
+    Engine::Get()->DeleteVariable([](RunContext s) {}, ctx, var);
+  }
+
+  void GetTempSize(const OpContext& ctx) {
+    if (init_temp_size_) return;
+    mshadow::Stream<gpu> *s = ctx.get_stream<gpu>();
+    size_t back_size = 0, back_size_w = 0;
+    CHECK_EQ(cudnnGetConvolutionBackwardDataWorkspaceSize(s->dnn_handle_,
                filter_desc_,
                in_desc_,
                conv_desc_,
                out_desc_,
                back_algo_,
                &back_size), CUDNN_STATUS_SUCCESS);
-      CHECK_EQ(cudnnGetConvolutionBackwardFilterWorkspaceSize(s->dnn_handle_,
+    CHECK_EQ(cudnnGetConvolutionBackwardFilterWorkspaceSize(s->dnn_handle_,
                out_desc_,
                in_desc_,
                conv_desc_,
                filter_desc_,
                back_algo_w_,
                &back_size_w), CUDNN_STATUS_SUCCESS);
-      backward_workspace_byte_ = std::max(back_size, back_size_w);
-      CHECK_EQ(cudnnGetConvolutionForwardWorkspaceSize(s->dnn_handle_,
+    backward_workspace_byte_ = std::max(back_size, back_size_w);
+    CHECK_EQ(cudnnGetConvolutionForwardWorkspaceSize(s->dnn_handle_,
                out_desc_,
                filter_desc_,
                conv_desc_,
                in_desc_,
                algo_,
                &forward_workspace_byte_), CUDNN_STATUS_SUCCESS);
-      forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
-      backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
-    }
+
+    forward_workspace_ = forward_workspace_byte_ / sizeof(DType) + 1;
+    backward_workspace_ = backward_workspace_byte_ / sizeof(DType) + 1;
+    init_temp_size_ = true;
   }
 
   bool init_cudnn_;
+  bool init_temp_size_;
   size_t forward_workspace_;
   size_t backward_workspace_;
   size_t forward_workspace_byte_;
@@ -364,12 +584,10 @@ class CuDNNDeconvolutionOp : public Operator {
   cudnnConvolutionFwdAlgo_t algo_;
   cudnnConvolutionBwdDataAlgo_t back_algo_;
   cudnnConvolutionBwdFilterAlgo_t back_algo_w_;
-  #if CUDNN_MAJOR == 5
   cudnnTensorFormat_t format_;
-  #endif
   DeconvolutionParam param_;
 };
-#endif  // __CUDACC__ && CUDNN
+#endif  // CUDNN
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/deconvolution.cc
+++ b/src/operator/deconvolution.cc
@@ -10,7 +10,10 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator* CreateOp<cpu>(DeconvolutionParam param, int dtype) {
+Operator* CreateOp<cpu>(DeconvolutionParam param, int dtype,
+                        std::vector<TShape> *in_shape,
+                        std::vector<TShape> *out_shape,
+                        Context ctx) {
   Operator *op = NULL;
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
     op = new DeconvolutionOp<cpu, DType>(param);
@@ -24,7 +27,7 @@ Operator* DeconvolutionProp::CreateOperatorEx(Context ctx, std::vector<TShape> *
   std::vector<int> out_type, aux_type;
   CHECK(InferType(in_type, &out_type, &aux_type));
   CHECK(InferShape(in_shape, &out_shape, &aux_shape));
-  DO_BIND_DISPATCH(CreateOp, param_, in_type->at(0));
+  DO_BIND_DISPATCH(CreateOp, param_, in_type->at(0), in_shape, &out_shape, ctx);
 }
 
 DMLC_REGISTER_PARAMETER(DeconvolutionParam);

--- a/src/operator/deconvolution.cu
+++ b/src/operator/deconvolution.cu
@@ -13,11 +13,14 @@
 namespace mxnet {
 namespace op {
 template<>
-Operator* CreateOp<gpu>(DeconvolutionParam param, int dtype) {
+Operator* CreateOp<gpu>(DeconvolutionParam param, int dtype,
+                        std::vector<TShape> *in_shape,
+                        std::vector<TShape> *out_shape,
+                        Context ctx) {
   Operator *op = NULL;
 #if MXNET_USE_CUDNN == 1
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
-    op = new CuDNNDeconvolutionOp<DType>(param);
+    op = new CuDNNDeconvolutionOp<DType>(param, *in_shape, *out_shape, ctx);
   });
 #else
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {

--- a/src/operator/upsampling.cc
+++ b/src/operator/upsampling.cc
@@ -33,8 +33,6 @@ Operator *CreateOp<cpu>(UpSamplingParam param, int dtype) {
       p.stride = TShape(shape, shape + 2);
       shape[0] = shape[1] = pad;
       p.pad = TShape(shape, shape + 2);
-      shape[0] = shape[1] = 0;
-      p.target_shape = TShape(shape, shape + 2);
       op = new DeconvolutionOp<cpu, DType>(p);
     } else {
       LOG(FATAL) << "Unknown sample type";

--- a/src/operator/upsampling.cu
+++ b/src/operator/upsampling.cu
@@ -32,8 +32,6 @@ Operator *CreateOp<gpu>(UpSamplingParam param, int dtype) {
       p.stride = TShape(shape, shape + 2);
       shape[0] = shape[1] = pad;
       p.pad = TShape(shape, shape + 2);
-      shape[0] = shape[1] = 0;
-      p.target_shape = TShape(shape, shape + 2);
       op = new DeconvolutionOp<gpu, DType>(p);
     } else {
       LOG(FATAL) << "Unknown sample type";

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -704,9 +704,13 @@ def check_deconvolution_gradient(input_shape, num_filter, pad):
 
 def check_deconvolution_target_shape(input_shape, kernel, stride, pad, adj, target_shape=None):
     data = mx.sym.Variable(name="data")
-    deconv = mx.sym.Deconvolution(
-        data=data, kernel=kernel, stride=stride, pad=pad, adj=adj, num_filter=5,
-        target_shape = target_shape if target_shape is not None else (0, 0))
+    if target_shape:
+        deconv = mx.sym.Deconvolution(
+            data=data, kernel=kernel, stride=stride, pad=pad, adj=adj, num_filter=5,
+            target_shape = target_shape)
+    else:
+        deconv = mx.sym.Deconvolution(
+            data=data, kernel=kernel, stride=stride, pad=pad, adj=adj, num_filter=5)
     arg_names = deconv.list_arguments()
     arg_shapes, out_shapes, _ = deconv.infer_shape(data=input_shape)
     assert out_shapes[0] == (input_shape[0], 5, 8, 8)


### PR DESCRIPTION
This pull request adds support for 3D deconvolution when compiled with cudnn and run on GPU. It does not break the current 2D Deconvolution non-cudnn code and simply throws an error if the non-cudnn code is called with a 3D kernel.

As the non-gpu version does not support 3D deconvolution, this pull request does not add test cases to compare that their output is similar. Instead I manually compared the output to the PyTorch 3D Deconvolution implementation.

I have seen that the cudnn convolution code uses `DMLC_DECLARE_FIELD(workspace).set_default(1024).set_range(0, 8192)`. Shall the cudnn deconvolution code be adapted to use a default of 1024 for as well? Currently the default is 512.

The following code can be used to compare with PyTorch:
```
import mxnet as mx
import numpy as np
import torch

TEST = "3D_TM"

if TEST == "3D_TM":
    DATA_SHAPE = (1, 1, 3, 3, 3)

    weights = np.random.normal(scale=0.3, size=(1, 1, 3, 3, 3))
    weights[0][0][0][0] = 1
    data = np.random.normal(size=DATA_SHAPE)

    ### pytorch
    t_c = torch.nn.ConvTranspose3d(1, 1, 3, bias=None)

    t_weights = torch.from_numpy(weights)
    t_c.weight.data = t_weights

    t_data = torch.from_numpy(data)
    t_v_data = torch.autograd.Variable(t_data)

    t_v_out = t_c.forward(t_v_data)
    t_out = t_v_out.data.numpy()

    ### mxnet
    ctx = mx.gpu(0)
    rand = mx.sym.Variable('rand')
    d = mx.sym.Deconvolution(rand, name='d', kernel=(3, 3, 3), num_filter=1)

    modG = mx.mod.Module(
        symbol=d, data_names=('rand', ), label_names=None, context=ctx)
    modG.bind(data_shapes=[("rand", DATA_SHAPE)])

    m_weights = mx.ndarray.array(weights)
    modG.init_params(arg_params = {'d_weight' : m_weights})

    m_data = mx.ndarray.array(data)

    batch = mx.io.DataBatch([m_data], None)
    modG.forward(batch)

    m_out = modG.get_outputs()[0].asnumpy()


elif TEST == "2D_TMM":
    DATA_SHAPE = (1, 1, 3, 3)

    weights = np.random.normal(scale=0.3, size=(1, 1, 1, 1))
    weights[0][0][0][0] = 1
    data = np.random.normal(size=DATA_SHAPE)

    ### pytorch
    t_c = torch.nn.ConvTranspose2d(1, 1, 1, bias=None)

    t_weights = torch.from_numpy(weights)
    t_c.weight.data = t_weights

    t_data = torch.from_numpy(data)
    t_v_data = torch.autograd.Variable(t_data)

    t_v_out = t_c.forward(t_v_data)
    t_out = t_v_out.data.numpy()

    ### mxnet gpu
    ctx = mx.gpu(0)
    rand = mx.sym.Variable('rand')
    d = mx.sym.Deconvolution(rand, name='d', kernel=(1, 1), num_filter=1)

    modG = mx.mod.Module(
        symbol=d, data_names=('rand', ), label_names=None, context=ctx)
    modG.bind(data_shapes=[("rand", DATA_SHAPE)])

    m_weights = mx.ndarray.array(weights)
    modG.init_params(arg_params={'d_weight' : m_weights})

    m_data = mx.ndarray.array(data)

    batch = mx.io.DataBatch([m_data], None)
    modG.forward(batch)

    m_out = modG.get_outputs()[0].asnumpy()

    ### mxnet cpu
    ctx = mx.cpu()
    modG_cpu = mx.mod.Module(
        symbol=d, data_names=('rand', ), label_names=None, context=ctx)
    modG_cpu.bind(data_shapes=[("rand", DATA_SHAPE)])
    modG_cpu.init_params(mx.init.Normal(0.02))

    modG_cpu.set_params(arg_params={'d_weight' : m_weights}, aux_params={})

    modG_cpu.forward(batch)

    m_c_out = modG_cpu.get_outputs()[0].asnumpy()
```