### PR TITLE
Added ndim property to ndarray.

### DIFF
--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -601,7 +601,7 @@ fixed-size items.
         >>> x.ndim
         2
         """
-        return len(self.shape) 
+        return len(self.shape)
 
     @property
     def shape(self):

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -588,7 +588,7 @@ fixed-size items.
 
 
     @property
-    def ndim(self, shape):
+    def ndim(self):
         """Returns the number of dimensions of this array
 
         Examples

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -588,6 +588,22 @@ fixed-size items.
 
 
     @property
+    def ndim(self, shape):
+        """Returns the number of dimensions of this array
+
+        Examples
+        --------
+        >>> x = mx.nd.array([1, 2, 3, 4])
+        >>> x.ndim
+        1
+        >>> x = mx.nd.array([[1, 2],
+                             [3, 4]])
+        >>> x.ndim
+        2
+        """
+        return len(self.shape) 
+
+    @property
     def shape(self):
         """Tuple of array dimensions.
 


### PR DESCRIPTION
Making `mx.nd.array` more consistent with NumPy by adding an `ndim` property. 
Also useful to avoid having to write `len(array.shape)` every time.