### PR TITLE
fix NDArrayGetData to return to use the right datatype

### DIFF
--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -313,12 +313,22 @@ inline std::vector<mx_uint> NDArray::GetShape() const {
   return ret;
 }
 
-inline const mx_float *NDArray::GetData() const {
-  mx_float *ret;
-  CHECK_NE(GetContext().GetDeviceType(), DeviceType::kGPU);
-  MXNDArrayGetData(blob_ptr_->handle_, &ret);
+inline int NDArray::GetDType() const {
+  int ret;
+  MXNDArrayGetDType(blob_ptr_->handle, &ret);
   return ret;
 }
+
+inline const mx_float *NDArray::GetData() const {
+  void *ret;
+  CHECK_NE(GetContext().GetDeviceType(), DeviceType::kGPU);
+  MXNDArrayGetData(blob_ptr_->handle_, &ret);
+  if (GetDType() != 0) {
+    return NULL;
+  }
+  return static_cast<mx_float*>(ret);
+}
+
 inline Context NDArray::GetContext() const {
   int out_dev_type;
   int out_dev_id;

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -392,7 +392,7 @@ MXNET_DLL int MXNDArrayGetShape(NDArrayHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayGetData(NDArrayHandle handle,
-                               mx_float **out_pdata);
+                               void **out_pdata);
 /*!
  * \brief get the type of the data in NDArray
  * \param handle the handle to the narray

--- a/perl-package/AI-MXNetCAPI/mxnet.i
+++ b/perl-package/AI-MXNetCAPI/mxnet.i
@@ -435,7 +435,7 @@ int MXNDArrayGetShape(NDArrayHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 int MXNDArrayGetData(NDArrayHandle handle,
-                               mx_float **out_pdata);
+                                void **out_pdata);
 /*!
  * \brief get the type of the data in NDArray
  * \param handle the handle to the narray

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -318,7 +318,7 @@ int MXNDArrayGetShape(NDArrayHandle handle,
 }
 
 int MXNDArrayGetData(NDArrayHandle handle,
-                     mx_float **out_pdata) {
+                     void **out_pdata) {
   API_BEGIN();
   NDArray *arr = static_cast<NDArray*>(handle);
   if (!arr->is_none()) {
@@ -326,7 +326,9 @@ int MXNDArrayGetData(NDArrayHandle handle,
         << "MXNDArrayGetData can only be called for NDArray on CPU";
     const TBlob &b = arr->data();
     CHECK(b.CheckContiguous());
-    *out_pdata = b.FlatTo2D<cpu, mx_float>().dptr_;
+    MSHADOW_REAL_TYPE_SWITCH(arr->dtype(), DType, {
+      *out_pdata = b.FlatTo2D<cpu, DType>().dptr_;
+    });
   } else {
     *out_pdata = nullptr;
   }


### PR DESCRIPTION
This failed if one tried to get the underlying data pointer for a NDArray with a dtype other then `Float32`.
I don't know if any of the other packages need to be adapted. I discovered this while working on the Julia package.

cc: @pluskid 