### PR TITLE
Debug kill-mxnet.py command can't kill remote processes

### DIFF
--- a/tools/kill-mxnet.py
+++ b/tools/kill-mxnet.py
@@ -25,12 +25,12 @@ with open(host_file, "r") as f:
   for host in f:
     if ':' in host:
       host = host[:host.index(':')]
-      print host
-      subprocess.Popen(["ssh", "%s" % host, kill_cmd],
-              shell=False,
-              stdout=subprocess.PIPE,
-              stderr=subprocess.PIPE)
-      print "Done killing"
+    print host
+    subprocess.Popen(["ssh", "-oStrictHostKeyChecking=no", "%s" % host, kill_cmd],
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+    print "Done killing"
 
 # Kill program on local machine
 os.system(kill_cmd)


### PR DESCRIPTION
Fixed host parameter bug, when the remote host has no phrase ":".
And also fixed un-controlable SSL verification message using "-oStrincHostKeyChecking=no".
It prevents the message  "Are you sure you want to continue connecting? (yes/no)" and in this case you can't type yes.