### PR TITLE
Support different batch size for forward input

### DIFF
--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -543,11 +543,11 @@ class Module(BaseModule):
         if new_batch_size != self.data_shapes[0][major_axis]:
             data_shape = getattr(data_batch, 'provide_data', None)
             label_shape = getattr(data_batch, 'provide_label', None)
-            if data_shape is None:
+            if not data_shape:
                 data_shape = [DataDesc(dname, data.shape) for dname, data in \
 		              zip(self._data_names, data_batch.data)]
                 data_label = getattr(data_batch, 'label', None)
-                if data_label is not None and len(data_label) > 0:
+                if data_label and len(data_label) > 0:
                     label_shape = [DataDesc(lname, label.shape) for lname, label in \
                                    zip(self._label_names, data_label)]
                 else:

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -15,6 +15,7 @@ from .executor_group import DataParallelExecutorGroup
 from ..model import _create_kvstore, _initialize_kvstore, _update_params, _update_params_on_kvstore
 from ..model import load_checkpoint
 from ..initializer import Uniform, InitDesc
+from ..io import DataDesc
 
 from .base_module import BaseModule, _check_input_names, _parse_data_desc
 
@@ -535,6 +536,29 @@ class Module(BaseModule):
             Default is `None`, which means `is_train` takes the value of `self.for_training`.
         """
         assert self.binded and self.params_initialized
+
+        major_axis = self._data_shapes[0].get_batch_axis(self._data_shapes[0].layout)
+        new_batch_size = data_batch.data[0].shape[major_axis]
+
+        if new_batch_size != self.data_shapes[0][major_axis]:
+            data_shape = data_batch.provide_data
+            label_shape = data_batch.provide_label
+            if data_shape is None:
+                data_shape = [DataDesc(dname, data.shape) for dname, data in \
+		              zip(self._data_names, data_batch.data)]
+                if data_batch.label is not None and len(data_batch.label) > 0:
+                    label_shape = [DataDesc(lname, label.shape) for lname, label in \
+                                   zip(self._label_names, data_batch.label)]
+                else:
+	        #If predicting, make the label shape the same as module label shape
+                    if self._label_shapes is not None:
+                        label_shape = []
+                        for lshape, lname in zip(self._label_shapes, self._label_names):
+                            new_lshape = list(lshape.shape)
+                            new_lshape[major_axis] = new_batch_size
+                            label_shape.append(DataDesc(lname, tuple(new_lshape)))
+            self.reshape(data_shape, label_shape)
+
         self._exec_group.forward(data_batch, is_train)
 
     def backward(self, out_grads=None):

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -541,16 +541,15 @@ class Module(BaseModule):
         new_batch_size = data_batch.data[0].shape[major_axis]
 
         if new_batch_size != self.data_shapes[0][major_axis]:
-            data_shape = data_batch.provide_data if hasattr(data_batch, 'provide_data') \
-                         else None
-            label_shape = data_batch.provide_label if hasattr(data_batch, 'provide_label') \
-                          else None
+            data_shape = getattr(data_batch, 'provide_data', None)
+            label_shape = getattr(data_batch, 'provide_label', None)
             if data_shape is None:
                 data_shape = [DataDesc(dname, data.shape) for dname, data in \
 		              zip(self._data_names, data_batch.data)]
-                if data_batch.label is not None and len(data_batch.label) > 0:
+                data_label = getattr(data_batch, 'label', None)
+                if data_label is not None and len(data_label) > 0:
                     label_shape = [DataDesc(lname, label.shape) for lname, label in \
-                                   zip(self._label_names, data_batch.label)]
+                                   zip(self._label_names, data_label)]
                 else:
 	        #If predicting, make the label shape the same as module label shape
                     if self._label_shapes is not None:
@@ -560,7 +559,6 @@ class Module(BaseModule):
                             new_lshape[major_axis] = new_batch_size
                             label_shape.append(DataDesc(lname, tuple(new_lshape)))
             self.reshape(data_shape, label_shape)
-
         self._exec_group.forward(data_batch, is_train)
 
     def backward(self, out_grads=None):

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -526,7 +526,7 @@ class Module(BaseModule):
         self.optimizer_initialized = True
 
     def forward(self, data_batch, is_train=None):
-        """Forward computation.
+        """Forward computation. It supports different batch_size inputs.
 
         Parameters
         ----------

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -541,8 +541,10 @@ class Module(BaseModule):
         new_batch_size = data_batch.data[0].shape[major_axis]
 
         if new_batch_size != self.data_shapes[0][major_axis]:
-            data_shape = data_batch.provide_data
-            label_shape = data_batch.provide_label
+            data_shape = data_batch.provide_data if hasattr(data_batch, 'provide_data') \
+                         else None
+            label_shape = data_batch.provide_label if hasattr(data_batch, 'provide_label') \
+                          else None
             if data_shape is None:
                 data_shape = [DataDesc(dname, data.shape) for dname, data in \
 		              zip(self._data_names, data_batch.data)]

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -162,9 +162,90 @@ def test_module_switch_bucket():
     #the default bucket is expected to reuse the bytes allocated
     assert total_bytes_after == total_bytes_before
 
+def test_forward_reshape():
+    data = mx.sym.Variable('data')
+    sym = mx.sym.FullyConnected(data, num_hidden=20, name='fc')
+
+    dshape = (10, 20)
+    mod = mx.mod.Module(sym, ('data',), None)
+    mod.bind(data_shapes=[('data', dshape)])
+    mod.init_params()
+    mod.init_optimizer(optimizer_params={'learning_rate': 1})
+
+    #Forward for the same batch_size input
+    mod.forward(mx.io.DataBatch(data=[mx.nd.ones(dshape)],
+                                label=None))
+    assert mod.get_outputs()[0].shape == dshape
+
+    #Forward for smaller batch_size input
+    dshape_1 = (1, 20)
+    mod.forward(mx.io.DataBatch(data=[mx.nd.ones(dshape_1)],
+                                label=None))
+    assert mod.get_outputs()[0].shape == dshape_1    
+
+    #Forward for larger batch_size input
+    dshape_2 = (100, 20)
+    mod.forward(mx.io.DataBatch(data=[mx.nd.ones(dshape_2)],
+                                label=None))
+    assert mod.get_outputs()[0].shape == dshape_2
+
+    #Forward for multiple device
+    mod = mx.mod.Module(sym, ('data',), None, context=[mx.cpu(0), mx.cpu(1)])
+    mod.bind(data_shapes=[('data', dshape)])
+    mod.init_params()
+    mod.init_optimizer(optimizer_params={'learning_rate': 1})
+
+    mod.forward(mx.io.DataBatch(data=[mx.nd.ones(dshape)],
+                                label=None))
+    assert mod.get_outputs()[0].shape == dshape
+
+    mod.forward(mx.io.DataBatch(data=[mx.nd.ones(dshape_2)],
+                                label=None))
+    assert mod.get_outputs()[0].shape == dshape_2
+
+def test_module_predict():
+    data = mx.sym.Variable('data')
+    fc = mx.sym.FullyConnected(data, num_hidden=20, name='fc')
+    mlp =  mx.sym.SoftmaxOutput(fc, name='softmax')
+    mod = mx.mod.Module(mlp)
+    
+    dshape = (100, 15)
+    lshape = (100,)
+    batch_size = 20
+    train_data = mx.io.NDArrayIter(mx.nd.ones(dshape), mx.nd.ones(lshape),
+                                   batch_size, shuffle=True)
+    
+    mod.fit(train_data=train_data,
+            num_epoch=1, optimizer='sgd',
+            optimizer_params={'learning_rate':0.1})
+
+    #Predict single sample
+    pshape_1 = (1, 15)
+    oshape_1 = (1, 20)
+    prob = mod.predict(mx.io.NDArrayIter(mx.nd.ones(pshape_1)))
+    assert prob.shape == oshape_1
+
+    #Predict multiple samples
+    pshape_2 = (10, 15)
+    oshape_2 = (10, 20)
+    prob = mod.predict(mx.io.NDArrayIter(mx.nd.ones(pshape_2)))
+    assert prob.shape == oshape_2
+
+    pshape_3 = (100, 15)
+    oshape_3 = (100, 20)
+    prob = mod.predict(mx.io.NDArrayIter(mx.nd.ones(pshape_3)))
+    assert prob.shape == oshape_3
+
+    pshape_4 = (200, 15)
+    oshape_4 = (200, 20)
+    prob = mod.predict(mx.io.NDArrayIter(mx.nd.ones(pshape_4)))
+    assert prob.shape == oshape_4
+
 if __name__ == '__main__':
     test_module_states()
     test_module_reshape()
     test_save_load()
     test_module_layout()
     test_module_switch_bucket()
+    test_forward_reshape()
+    test_module_predict()


### PR DESCRIPTION
Add support for different batch_size data for forward. 
One major use case is predicting single input, or any data of which batch size is different from training data.