### PR TITLE
Adds GetDType() signature to mxnet-cpp's ndarray.h and fixes typo in implementation.

### DIFF
--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -384,6 +384,10 @@ class NDArray {
   */
   std::vector<mx_uint> GetShape() const;
   /*!
+  * \return the data type of current NDArray
+  */
+  int GetDType() const;
+  /*!
   * \return the data pointer to the current NDArray
   */
   const mx_float *GetData() const;

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -315,7 +315,7 @@ inline std::vector<mx_uint> NDArray::GetShape() const {
 
 inline int NDArray::GetDType() const {
   int ret;
-  MXNDArrayGetDType(blob_ptr_->handle, &ret);
+  MXNDArrayGetDType(blob_ptr_->handle_, &ret);
   return ret;
 }
 


### PR DESCRIPTION
Minor typo fix for mxnet-cpp.