### PR TITLE
reverse previous change on the install-mxnet-ubuntu script

### DIFF
--- a/setup-utils/install-mxnet-ubuntu-python.sh
+++ b/setup-utils/install-mxnet-ubuntu-python.sh
@@ -14,7 +14,6 @@ sudo apt-get install -y build-essential libatlas-base-dev libopencv-dev graphviz
 
 echo "Building MXNet core. This can take few minutes..."
 cd "$MXNET_HOME"
-cp make/config.mk .
 make -j$(nproc)
 
 echo "Installing Numpy..."

--- a/setup-utils/install-mxnet-ubuntu-r.sh
+++ b/setup-utils/install-mxnet-ubuntu-r.sh
@@ -13,7 +13,6 @@ echo "MXNet root folder: $MXNET_HOME"
 
 echo "Building MXNet core. This can take few minutes..."
 cd "$MXNET_HOME"
-cp make/config.mk .
 make -j$(nproc)
 
 echo "Installing R dependencies. This can take few minutes..."


### PR DESCRIPTION
According to user feedback, the previous added `cp make/config.mk .` in ubuntu install python/r script will overrides the config.mk that user has edited by following  http://mxnet.io/get_started/ubuntu_setup.html. 

I should not edit the script itself, instead I should edit the http://mxnet.io/get_started/ubuntu_setup.html#install-mxnet-for-r by adding `cp make/config.mk .` in the first line of `To install MXNet for R:` section.



