### PR TITLE
reverse previous change on script/edit markdown

### DIFF
--- a/docs/get_started/ubuntu_setup.md
+++ b/docs/get_started/ubuntu_setup.md
@@ -78,6 +78,16 @@ MXNet requires R-version to be 3.2.0 and above. If you are running an earlier ve
 To install MXNet for R:
 
 ```bash
+    # Clone mxnet repository. In terminal, run the commands WITHOUT "sudo"
+    git clone https://github.com/dmlc/mxnet.git ~/mxnet --recursive
+
+    cd ~/mxnet
+    cp make/config.mk .
+    # If building with GPU, add configurations to config.mk file:
+    echo "USE_CUDA=1" >>config.mk
+    echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk
+    echo "USE_CUDNN=1" >>config.mk
+
     cd ~/mxnet/setup-utils
     bash install-mxnet-ubuntu-r.sh
 ```

--- a/setup-utils/install-mxnet-ubuntu-python.sh
+++ b/setup-utils/install-mxnet-ubuntu-python.sh
@@ -14,7 +14,6 @@ sudo apt-get install -y build-essential libatlas-base-dev libopencv-dev graphviz
 
 echo "Building MXNet core. This can take few minutes..."
 cd "$MXNET_HOME"
-cp make/config.mk .
 make -j$(nproc)
 
 echo "Installing Numpy..."

--- a/setup-utils/install-mxnet-ubuntu-r.sh
+++ b/setup-utils/install-mxnet-ubuntu-r.sh
@@ -13,7 +13,6 @@ echo "MXNet root folder: $MXNET_HOME"
 
 echo "Building MXNet core. This can take few minutes..."
 cd "$MXNET_HOME"
-cp make/config.mk .
 make -j$(nproc)
 
 echo "Installing R dependencies. This can take few minutes..."


### PR DESCRIPTION
According to recent user feedback, the previous added `cp make/config.mk .` in ubuntu install python && r scripts will overrides the config.mk that user has edited to enable GPU, by following http://mxnet.io/get_started/ubuntu_setup.html#install-mxnet-for-python.

I should not edit the script itself, instead I should edit the http://mxnet.io/get_started/ubuntu_setup.html#install-mxnet-for-r by adding 
```
    # Clone mxnet repository. In terminal, run the commands WITHOUT "sudo"
    git clone https://github.com/dmlc/mxnet.git ~/mxnet --recursive

    # If building with GPU, add configurations to config.mk file:
    cd ~/mxnet
    cp make/config.mk .
    echo "USE_CUDA=1" >>config.mk
    echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk
    echo "USE_CUDNN=1" >>config.mk
```
in the *To install MXNet for R:* section, so that R user would not skip this part.

(I think the get_start instruction assumes people install install-mxnet-ubuntu-python.sh before they run install-mxnet-ubuntu-r.sh, but R use might jump to *To install MXNet for R* section and ignores the content in *Install MXNet for Python*)