### PR TITLE
update doc for math, concat, slice/crop functions

### DIFF
--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -877,7 +877,8 @@ _init_ndarray_module(NDArray, "mxnet")
 def onehot_encode(indices, out):
     """One-hot encoding indices into matrix out.
 
-    Deprecated, use ``one_hot`` instead.
+    .. note:: `onehot_encode` is deprecated. Use `one_hot` instead.
+
     """
     # pylint: disable= no-member, protected-access
     return _internal._onehot_encode(indices, out, out=out)

--- a/python/mxnet/ndarray_doc.py
+++ b/python/mxnet/ndarray_doc.py
@@ -16,8 +16,13 @@ class ReshapeDoc(NDArrayDoc):
     --------
     Reshapes the input array into a new shape.
 
+<<<<<<< HEAD
     >>> x = mx.nd.array([1, 2, 3, 4])
     >>> y = mx.nd.reshape(x,shape=(2, 2))
+=======
+    >>> x = mx.nd.array([1,2,3,4])
+    >>> y = mx.nd.reshape(x,shape=(2,2))
+>>>>>>> fix formatting issues with Reshape documentation
     >>> x.shape
     (4L,)
     >>> y.shape

--- a/python/mxnet/ndarray_doc.py
+++ b/python/mxnet/ndarray_doc.py
@@ -16,13 +16,8 @@ class ReshapeDoc(NDArrayDoc):
     --------
     Reshapes the input array into a new shape.
 
-<<<<<<< HEAD
     >>> x = mx.nd.array([1, 2, 3, 4])
     >>> y = mx.nd.reshape(x,shape=(2, 2))
-=======
-    >>> x = mx.nd.array([1,2,3,4])
-    >>> y = mx.nd.reshape(x,shape=(2,2))
->>>>>>> fix formatting issues with Reshape documentation
     >>> x.shape
     (4L,)
     >>> y.shape

--- a/src/operator/concat.cc
+++ b/src/operator/concat.cc
@@ -46,29 +46,39 @@ Operator* ConcatProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shap
 DMLC_REGISTER_PARAMETER(ConcatParam);
 
 MXNET_REGISTER_OP_PROPERTY(Concat, ConcatProp)
-.describe(R"code(Concate a list of array along a given axis.
+.describe(R"code(Join input arrays along the given dimension.
 
-The dimension sizes of the input arrays on the given axis should be the same.
+.. note:: `Concat` is deprecated. Use `concat` instead.
 
-For example::
+The dimensions of the input arrays should be the same except along the axis
+which they will concatenated.
+The dimension of the output array along the concatenated axis will be equal
+to the sum of the corresponding dimensions of the input arrays.
 
-  x = [[1,1],[1,1]]
-  y = [[2,2],[2,2]]
-  z = [[3,3],[3,3],[3,3]]
+Example::
 
-  Concat(x,y,z,dim=0) = [[ 1.,  1.],
-                         [ 1.,  1.],
-                         [ 2.,  2.],
-                         [ 2.,  2.],
-                         [ 3.,  3.],
-                         [ 3.,  3.],
-                         [ 3.,  3.]]
+   x = [[1,1],[2,2]]
+   y = [[3,3],[4,4],[5,5]]
+   z = [[6,6], [7,7],[8,8]]
 
-  Concat(x,y,z,dim=1) = [[ 1.,  1.,  2.,  2.],
-                         [ 1.,  1.,  2.,  2.]]
+   concat(x,y,z,dim=0) = [[ 1.,  1.],
+                          [ 2.,  2.],
+                          [ 3.,  3.],
+                          [ 4.,  4.],
+                          [ 5.,  5.],
+                          [ 6.,  6.],
+                          [ 7.,  7.],
+                          [ 8.,  8.]]
+
+   Note that you cannot concat x,y,z along dimension 1 since dimension
+   0 is not the same for all the input arrays.
+
+   concat(y,z,dim=1) = [[ 3.,  3.,  6.,  6.],
+                         [ 4.,  4.,  7.,  7.],
+                         [ 5.,  5.,  8.,  8.]]
 
 )code" ADD_FILELINE)
-.add_argument("data", "NDArray-or-Symbol[]", "List of tensors to concatenate")
+.add_argument("data", "NDArray-or-Symbol[]", "List of arrays to concatenate")
 .add_arguments(ConcatParam::__FIELDS__())
 .set_key_var_num_args("num_args");
 

--- a/src/operator/concat.cc
+++ b/src/operator/concat.cc
@@ -46,12 +46,12 @@ Operator* ConcatProp::CreateOperatorEx(Context ctx, std::vector<TShape> *in_shap
 DMLC_REGISTER_PARAMETER(ConcatParam);
 
 MXNET_REGISTER_OP_PROPERTY(Concat, ConcatProp)
-.describe(R"code(Join input arrays along the given dimension.
+.describe(R"code(Join input arrays along the given axis.
 
 .. note:: `Concat` is deprecated. Use `concat` instead.
 
-The dimensions of the input arrays should be the same except along the axis
-which they will concatenated.
+The dimensions of the input arrays should be the same except the axis along
+ which they will concatenated.
 The dimension of the output array along the concatenated axis will be equal
 to the sum of the corresponding dimensions of the input arrays.
 

--- a/src/operator/crop-inl.h
+++ b/src/operator/crop-inl.h
@@ -38,7 +38,7 @@ struct CropParam : public dmlc::Parameter<CropParam> {
     DMLC_DECLARE_FIELD(offset).set_default(TShape(shape, shape + 2))
     .describe("crop offset coordinate: (y, x)");
     DMLC_DECLARE_FIELD(h_w).set_default(TShape(shape, shape + 2))
-    .describe("crop height and weight: (h, w)");
+    .describe("crop height and width: (h, w)");
     DMLC_DECLARE_FIELD(center_crop).set_default(false)
     .describe("If set to true, then it will use be the center_crop,"
       "or it will crop using the shape of crop_like");

--- a/src/operator/crop.cc
+++ b/src/operator/crop.cc
@@ -21,9 +21,15 @@ Operator* CropProp::CreateOperator(Context ctx) const {
 DMLC_REGISTER_PARAMETER(CropParam);
 
 MXNET_REGISTER_OP_PROPERTY(Crop, CropProp)
-.describe("Crop the 2nd and 3rd dim of input data, with the corresponding size of h_w or "
-"with width and height of the second input symbol, i.e., with one input, we need h_w to "
-"specify the crop height and width, otherwise the second input symbol's size will be used")
+.describe(R"code(
+
+.. note:: `Crop` is deprecated. Use `slice` instead.
+
+Crop the 2nd and 3rd dim of input data, with the corresponding size of h_w or
+with width and height of the second input symbol, i.e., with one input, we need h_w to
+specify the crop height and width, otherwise the second input symbol's size will be used
+)code" ADD_FILELINE)
+
 .add_argument("data", "Symbol or Symbol[]", "Tensor or List of Tensors, the second input "
 "will be used as crop_like shape reference")
 .add_arguments(CropParam::__FIELDS__())

--- a/src/operator/nn/softmax-inl.h
+++ b/src/operator/nn/softmax-inl.h
@@ -207,8 +207,7 @@ struct SoftmaxParam : public dmlc::Parameter<SoftmaxParam> {
   int axis;
   DMLC_DECLARE_PARAMETER(SoftmaxParam) {
     DMLC_DECLARE_FIELD(axis).set_default(-1)
-      .describe("The axis along which to compute softmax. "
-                "By default use the last axis");
+      .describe("The axis along which to compute softmax.");
   }
 };
 

--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -12,6 +12,26 @@ namespace op {
 DMLC_REGISTER_PARAMETER(SoftmaxParam);
 
 MXNET_OPERATOR_REGISTER_UNARY(softmax)
+.describe(R"code(Applies the softmax function. The resulting array contains
+ elements in the range (0,1) and the elements along the given axis sum up to 1.
+
+.. math::
+   softmax(\mathbf{z})_j = \frac{e^{z_j}}{\sum_{k=1}^K e^{z_k}}
+  
+for :math:`j = 1, …, K`
+
+Example::
+
+  x = [[ 1.  1.  1.]
+       [ 1.  1.  1.]]
+
+  softmax(x,axis=0) = [[ 0.5  0.5  0.5]
+                       [ 0.5  0.5  0.5]]
+
+  softmax(x,axis=1) = [[ 0.33333334,  0.33333334,  0.33333334],
+                       [ 0.33333334,  0.33333334,  0.33333334]]
+ 
+)code" ADD_FILELINE)
 .set_attr_parser(ParamParser<SoftmaxParam>)
 .set_attr<FCompute>("FCompute<cpu>", SoftmaxCompute<cpu, mxnet_op::softmax_fwd>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{"_backward_softmax"})

--- a/src/operator/softmax_output.cc
+++ b/src/operator/softmax_output.cc
@@ -80,7 +80,8 @@ also supports various ways to normalize the gradient by ``normalization``:
 .add_arguments(SoftmaxOutputParam::__FIELDS__());
 
 MXNET_REGISTER_OP_PROPERTY(Softmax, DeprecatedSoftmaxProp)
-.describe("DEPRECATED: Perform a softmax transformation on input. Please use SoftmaxOutput")
+.describe("Perform a softmax transformation on input. Please use SoftmaxOutput"
+          ".. note::  `Softmax`` is deprecated. Use `softmax`")
 .add_argument("data", "NDArray-or-Symbol", "Input data to softmax.")
 .add_arguments(SoftmaxOutputParam::__FIELDS__());
 

--- a/src/operator/tensor/elemwise_unary_op.cc
+++ b/src/operator/tensor/elemwise_unary_op.cc
@@ -12,7 +12,7 @@ DMLC_REGISTER_PARAMETER(CastParam);
 
 // copy
 MXNET_OPERATOR_REGISTER_UNARY(_copy)
-.MXNET_DESCRIBE("Identity mapping, copy src to output")
+.MXNET_DESCRIBE("Returns a copy of the input.")
 .add_alias("identity")
 .set_attr<FCompute>("FCompute<cpu>", IdentityCompute<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_copy"});
@@ -75,7 +75,7 @@ NNVM_REGISTER_OP(Cast)
 .add_alias("cast")
 .describe(R"code(Casts all elements of the input to the new type.
 
-.. note:: ``Cast`` is deprecated, use ``cast``.
+.. note:: ``Cast`` is deprecated. Use ``cast`` instead.
 
 Example::
 
@@ -301,9 +301,9 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_log)
 
 // sin
 MXNET_OPERATOR_REGISTER_UNARY(sin)
-.describe(R"code(Returns element-wise trigonometric sine value of the input.
+.describe(R"code(Computes the element-wise sine of the input.
 
-The input is in radians (:math:`2\pi` rad equals 360 degrees).
+The should be in radians (:math:`2\pi` rad equals 360 degrees).
 
 .. math::
    sin([0, \pi/4, \pi/2]) = [0, 0.707, 1]
@@ -331,7 +331,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_log1p)
 
 // expm1
 MXNET_OPERATOR_REGISTER_UNARY(expm1)
-.describe(R"code(Calculate ``exp(x) - 1``
+.describe(R"code(Returns element-wise ``exp(x) - 1`` value of the input.
 
 This function provides greater precision than ``exp(x) - 1`` for small values of ``x``.
 
@@ -344,9 +344,9 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_expm1)
 
 // cos
 MXNET_OPERATOR_REGISTER_UNARY(cos)
-.describe(R"code(Cosine, element-wise.
+.describe(R"code(Computes the element-wise cosine of the input array.
 
-The input is in radians (:math:`2\pi` rad equals 360 degress).
+The input should be in radians (:math:`2\pi` rad equals 360 degrees).
 
 .. math::
    cos([0, \pi/4, \pi/2]) = [1, 0.707, 0]
@@ -360,9 +360,9 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_cos)
 
 // tan
 MXNET_OPERATOR_REGISTER_UNARY(tan)
-.describe(R"code(Tangent, element-wise.
+.describe(R"code(Computes the element-wise tangent of the input array.
 
-Then input is in radians (:math:`2\pi` rad equals 360 degress).
+The input should be in radians (:math:`2\pi` rad equals 360 degrees).
 
 .. math::
    tan([0, \pi/4, \pi/2]) = [0, 1, -inf]
@@ -376,10 +376,10 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_tan)
 
 // arcsin
 MXNET_OPERATOR_REGISTER_UNARY(arcsin)
-.describe(R"code(Inverse sine, element-wise.
+.describe(R"code(Returns element-wise inverse sine of the input array.
 
-The input should be in range :math:`[-1, 1]`.
-The output is in the closed interval :math:`[-\pi/2, \pi/2]`
+The input should be in the range `[-1, 1]`.
+The output is in the closed interval of [:math:`-\pi/2`, :math:`\pi/2`].
 
 .. math::
    arcsin([-1, -.707, 0, .707, 1]) = [-\pi/2, -\pi/4, 0, \pi/4, \pi/2]
@@ -393,9 +393,9 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_arcsin)
 
 // arccos
 MXNET_OPERATOR_REGISTER_UNARY(arccos)
-.describe(R"code(Inverse cosine, element-wise.
+.describe(R"code(Returns element-wise inverse cosine of the input array.
 
-The input should be in range :math:`[-1, 1]`.
+The input should be in range `[-1, 1]`.
 The output is in the closed interval :math:`[0, \pi]`
 
 .. math::
@@ -410,12 +410,12 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_arccos)
 
 // arctan
 MXNET_OPERATOR_REGISTER_UNARY(arctan)
-.describe(R"code(Inverse tangent, element-wise.
+.describe(R"code(Returns element-wise inverse tangent of the input array.
 
 The output is in the closed interval :math:`[-\pi/2, \pi/2]`
 
 .. math::
-   arccos([-1, 0, 1]) = [-\pi/4, 0, \pi/4]
+   arctan([-1, 0, 1]) = [-\pi/4, 0, \pi/4]
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", UnaryCompute<cpu, mshadow_op::arctan>)
@@ -426,7 +426,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_arctan)
 
 // degrees
 MXNET_OPERATOR_REGISTER_UNARY(degrees)
-.describe(R"code(Convert angles from radians to degrees.
+.describe(R"code(Converts each element of the input array from radians to degrees.
 
 .. math::
    degrees([0, \pi/2, \pi, 3\pi/2, 2\pi]) = [0, 90, 180, 270, 360]
@@ -440,7 +440,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_degrees)
 
 // radians
 MXNET_OPERATOR_REGISTER_UNARY(radians)
-.describe(R"code(Convert angles from degrees to radians.
+.describe(R"code(Converts each element of the input array from degrees to radians.
 
 .. math::
    radians([0, 90, 180, 270, 360]) = [0, \pi/2, \pi, 3\pi/2, 2\pi]
@@ -454,9 +454,9 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_radians)
 
 // sinh
 MXNET_OPERATOR_REGISTER_UNARY(sinh)
-.describe(R"code(Hyperbolic sine, element-wise.
+.describe(R"code(Returns the hyperbolic sine of the input array, computed element-wise.
 
-For example::
+.. math::
    sinh(x) = 0.5\times(exp(x) - exp(-x))
 
 )code" ADD_FILELINE)
@@ -468,9 +468,9 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_sinh)
 
 // cosh
 MXNET_OPERATOR_REGISTER_UNARY(cosh)
-.describe(R"code(Hyperbolic cosine, element-wise.
+.describe(R"code(Returns the hyperbolic cosine  of the input array, computed element-wise.
 
-For example::
+.. math::
    cosh(x) = 0.5\times(exp(x) + exp(-x))
 
 )code" ADD_FILELINE)
@@ -482,9 +482,9 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_cosh)
 
 // tanh
 MXNET_OPERATOR_REGISTER_UNARY(tanh)
-.describe(R"code(Hyperbolic tangent element-wise.
+.describe(R"code(Returns the hyperbolic tansgent of the input array, computed element-wise.
 
-For example::
+.. math::
    tanh(x) = sinh(x) / cosh(x)
 
 )code" ADD_FILELINE)
@@ -496,7 +496,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_tanh)
 
 // arcsinh
 MXNET_OPERATOR_REGISTER_UNARY(arcsinh)
-.describe(R"code(Inverse hyperbolic sine, element-wise.
+.describe(R"code(Returns the element-wise inverse hyperbolic sine of the input array, computed element-wise.
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", UnaryCompute<cpu, mshadow_op::arcsinh>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_arcsinh" });
@@ -506,7 +506,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_arcsinh)
 
 // arccosh
 MXNET_OPERATOR_REGISTER_UNARY(arccosh)
-.describe(R"code(Inverse hyperbolic cosine, element-wise.
+.describe(R"code(Returns the element-wise inverse hyperbolic cosine of the input array, computed element-wise.
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", UnaryCompute<cpu, mshadow_op::arccosh>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_arccosh" });
@@ -516,7 +516,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_arccosh)
 
 // arctanh
 MXNET_OPERATOR_REGISTER_UNARY(arctanh)
-.describe(R"code(Inverse hyperbolic tangent, element-wise.
+.describe(R"code(Returns the element-wise inverse hyperbolic tangent of the input array, computed element-wise.
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", UnaryCompute<cpu, mshadow_op::arctanh>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_arctanh" });
@@ -526,7 +526,8 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_arctanh)
 
 // gamma
 MXNET_OPERATOR_REGISTER_UNARY(gamma)
-.MXNET_DESCRIBE("The gamma function (extension of the factorial function), element-wise")
+.MXNET_DESCRIBE("Returns the gamma function (extension of the factorial function to the reals)"
+  " , computed element-wise on the input array.")
 .set_attr<FCompute>("FCompute<cpu>", UnaryCompute<cpu, mshadow_op::gamma>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_gamma"});
 
@@ -535,7 +536,8 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_gamma)
 
 // gammaln
 MXNET_OPERATOR_REGISTER_UNARY(gammaln)
-.MXNET_DESCRIBE("Log of the absolute value of the gamma function, element-wise")
+.MXNET_DESCRIBE("Returns element-wise log of the absolute value of the gamma function"
+  " of the input.")
 .set_attr<FCompute>("FCompute<cpu>", UnaryCompute<cpu, mshadow_op::gammaln>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_gammaln"});
 

--- a/src/operator/tensor/elemwise_unary_op.cc
+++ b/src/operator/tensor/elemwise_unary_op.cc
@@ -303,7 +303,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_log)
 MXNET_OPERATOR_REGISTER_UNARY(sin)
 .describe(R"code(Computes the element-wise sine of the input.
 
-The should be in radians (:math:`2\pi` rad equals 360 degrees).
+The input should be in radians (:math:`2\pi` rad equals 360 degrees).
 
 .. math::
    sin([0, \pi/4, \pi/2]) = [0, 0.707, 1]
@@ -331,7 +331,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_log1p)
 
 // expm1
 MXNET_OPERATOR_REGISTER_UNARY(expm1)
-.describe(R"code(Returns element-wise ``exp(x) - 1`` value of the input.
+.describe(R"code(Returns ``exp(x) - 1`` computed element-wise on the input.
 
 This function provides greater precision than ``exp(x) - 1`` for small values of ``x``.
 
@@ -482,7 +482,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_cosh)
 
 // tanh
 MXNET_OPERATOR_REGISTER_UNARY(tanh)
-.describe(R"code(Returns the hyperbolic tansgent of the input array, computed element-wise.
+.describe(R"code(Returns the hyperbolic tangent of the input array, computed element-wise.
 
 .. math::
    tanh(x) = sinh(x) / cosh(x)

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -149,11 +149,11 @@ Examples::
 NNVM_REGISTER_OP(one_hot)
 .describe(R"code(Returns a one-hot array.
 
-The locations represented by ``indices`` take value ``on_value``, while all
-other locations take value ``off_value``.
+The locations represented by `indices` take value `on_value`, while all
+other locations take value `off_value`.
 
-Assume ``indices`` has shape ``(i0, i1)``, then the output will have shape
-``(i0, i1, depth)`` and::
+`one_hot` operation with `indices` of shape ``(i0, i1)`` and `depth`  of ``d`` would result
+ in an output array of shape ``(i0, i1, d)`` with::
 
   output[i,j,:] = off_value
   output[i,j,indices[i,j]] = on_value

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -552,7 +552,7 @@ struct OneHotParam : public dmlc::Parameter<OneHotParam> {
   int dtype;
   DMLC_DECLARE_PARAMETER(OneHotParam) {
     DMLC_DECLARE_FIELD(depth)
-      .describe("The dimension size at dim = axis.");
+      .describe("Depth of the one hot dimension.");
     DMLC_DECLARE_FIELD(on_value)
       .set_default(1.0f)
       .describe("The value assigned to the locations represented by indices.");

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -673,9 +673,9 @@ struct SliceParam : public dmlc::Parameter<SliceParam> {
   nnvm::Tuple<dmlc::optional<int> > begin, end;
   DMLC_DECLARE_PARAMETER(SliceParam) {
     DMLC_DECLARE_FIELD(begin)
-    .describe("starting coordinates");
+    .describe("starting indices for the slice operation, Supports negative indices.");
     DMLC_DECLARE_FIELD(end)
-    .describe("ending coordinates");
+    .describe("ending indices for the slice operation, Supports negative indices.");
   }
 };
 
@@ -1005,15 +1005,13 @@ struct SliceAxisParam : public dmlc::Parameter<SliceAxisParam> {
   dmlc::optional<int> end;
   DMLC_DECLARE_PARAMETER(SliceAxisParam) {
     DMLC_DECLARE_FIELD(axis)
-      .describe("The axis to be sliced."
-                " Negative axis means to count from the last to the first axis.");
+      .describe("Axis along which to be sliced, supports negative indexes.");
     DMLC_DECLARE_FIELD(begin)
-      .describe("The beginning index to be sliced."
-                " Negative values are interpreted as counting from the backward.");
+      .describe("The beginning index along the axis to be sliced, "
+                " Supports negative indexes.");
     DMLC_DECLARE_FIELD(end)
-      .describe("The end index to be sliced."
-                " The end can be None, in which case all the rest elements are used."
-                " Also, negative values are interpreted as counting from the backward.");
+      .describe("The ending index along the axis to be sliced, "
+                " Supports negative indexes.");
   }
 };
 

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -673,9 +673,9 @@ struct SliceParam : public dmlc::Parameter<SliceParam> {
   nnvm::Tuple<dmlc::optional<int> > begin, end;
   DMLC_DECLARE_PARAMETER(SliceParam) {
     DMLC_DECLARE_FIELD(begin)
-    .describe("starting indices for the slice operation, Supports negative indices.");
+    .describe("starting indices for the slice operation, supports negative indices.");
     DMLC_DECLARE_FIELD(end)
-    .describe("ending indices for the slice operation, Supports negative indices.");
+    .describe("ending indices for the slice operation, supports negative indices.");
   }
 };
 
@@ -1008,10 +1008,10 @@ struct SliceAxisParam : public dmlc::Parameter<SliceAxisParam> {
       .describe("Axis along which to be sliced, supports negative indexes.");
     DMLC_DECLARE_FIELD(begin)
       .describe("The beginning index along the axis to be sliced, "
-                " Supports negative indexes.");
+                " supports negative indexes.");
     DMLC_DECLARE_FIELD(end)
       .describe("The ending index along the axis to be sliced, "
-                " Supports negative indexes.");
+                " supports negative indexes.");
   }
 };
 

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -220,7 +220,7 @@ NNVM_REGISTER_OP(slice)
 .add_alias("crop")
 .describe(R"code(Slice a continuous region of the array.
 
-.. note:: ``crop`` is Deprecated. Use ``slice`` instead.
+.. note:: ``crop`` is deprecated. Use ``slice`` instead.
 
 This function returns a sliced continous region of the array between the indices given 
 by `begin` and `end`.
@@ -302,7 +302,7 @@ NNVM_REGISTER_OP(_crop_assign_scalar)
 NNVM_REGISTER_OP(slice_axis)
 .describe(R"code(Slice along a given axis.
 
-Returns a Sliced array along a given `axis` starting from the `begin` index
+Returns an array slice along a given `axis` starting from the `begin` index
  to the `end` index.
 
 Examples::
@@ -427,7 +427,7 @@ NNVM_REGISTER_OP(clip)
 Given an interval, values outside the interval are clipped to the interval edges.
 Clipping ``x`` between `a_min` and `a_x` would be::
 
-   clip(x) = max(min(x, a_max), a_min))
+   clip(x, a_min, a_max) = max(min(x, a_max), a_min))
 
 Example::
 

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -1,4 +1,3 @@
-from Cython.Utility.MemoryView import shape
 /*!
  *  Copyright (c) 2015 by Contributors
  * \file matrix_op.cc
@@ -105,8 +104,25 @@ NNVM_REGISTER_OP(Flatten)
 .add_alias("flatten")
 .describe(R"code(Flattens the input array into a 2-D array by collapsing the higher dimensions.
 
-Assume the input array has shape ``(d1, d2, ..., dk)``, then ``flatten`` reshapes
-the input array into shape ``(d1, d2*...*dk)``.
+.. note:: `Flatten` is deprecated. Use `flatten` instead.
+
+For an input array with shape ``(d1, d2, ..., dk)``, `flatten` operation reshapes
+the input array into an output array of shape ``(d1, d2*...*dk)``.
+
+Example::
+
+    x = [[
+        [1,2,3],
+        [4,5,6],
+        [7,8,9]
+    ],
+    [    [1,2,3],
+        [4,5,6],
+        [7,8,9]
+    ]],
+
+    flatten(x) = [[ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.],
+       [ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.]]
 
 )code" ADD_FILELINE)
 .set_num_inputs(1)
@@ -119,7 +135,7 @@ the input array into shape ``(d1, d2*...*dk)``.
   [](const NodeAttrs& attrs) {
   return std::vector<std::pair<int, int> >{{0, 0}};
 })
-.add_argument("data", "NDArray-or-Symbol", "Input data to reshape.");
+.add_argument("data", "NDArray-or-Symbol", "Input array.");
 
 NNVM_REGISTER_OP(transpose)
 .describe(R"code(Permute the dimensions of an array.
@@ -406,12 +422,18 @@ NNVM_REGISTER_OP(_backward_batch_dot)
 .set_attr<FCompute>("FCompute<cpu>", BatchDotBackward_<cpu>);
 
 NNVM_REGISTER_OP(clip)
-.describe(R"code(Clip (limit) the values in an array, elementwise
+.describe(R"code(Clip (limit) the values in an array.
 
-Given an interval, values outside the interval are clipped to the interval
-edges. That is::
+Given an interval, values outside the interval are clipped to the interval edges.
+Clipping ``x`` between `a_min` and `a_x` would be::
 
-   clip(x) = max(min(x, a_max)), a_min)
+   clip(x) = max(min(x, a_max), a_min))
+
+Example::
+
+    x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    clip(x,1,8) = [ 1.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  8.]
 
 )code" ADD_FILELINE)
 .set_num_inputs(1)
@@ -421,7 +443,7 @@ edges. That is::
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
 .set_attr<FCompute>("FCompute<cpu>", Clip<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_clip" })
-.add_argument("data", "NDArray-or-Symbol", "Source input")
+.add_argument("data", "NDArray-or-Symbol", "Input array.")
 .add_arguments(ClipParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_clip)

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -1,3 +1,4 @@
+from Cython.Utility.MemoryView import shape
 /*!
  *  Copyright (c) 2015 by Contributors
  * \file matrix_op.cc
@@ -200,24 +201,31 @@ will return a new array with shape ``(2,1,3,4)``.
 .add_arguments(ExpandDimParam::__FIELDS__());
 
 NNVM_REGISTER_OP(slice)
-.describe(R"code(Crop a continuous region from the array.
+.add_alias("crop")
+.describe(R"code(Slice a continuous region of the array.
 
-Assume the input array has *n* dimensions, given ``begin=(b_1, ..., b_n)`` and
-``end=(e_1, ..., e_n)``, then ``crop`` will return a region with shape
-``(e_1-b_1, ..., e_n-b_n)``. The result's *k*-th dimension contains elements
-from the *k*-th dimension of the input array with the open range ``[b_k, e_k)``.
+.. note:: ``crop`` is Deprecated. Use ``slice`` instead.
 
-For example::
+This function returns a sliced continous region of the array between the indices given 
+by `begin` and `end`.
+
+For an input array of `n` dimensions, slice operation with ``begin=(b_0, b_1...b_n-1)`` indices
+and ``end=(e_1, e_2, ... e_n)`` indices will result in an array with the shape
+``(e_1-b_0, ..., e_n-b_n-1)``.
+
+The resulting array's *k*-th dimension contains elements
+ from the *k*-th dimension of the input array with the open range ``[b_k, e_k)``.
+
+Example::
 
   x = [[  1.,   2.,   3.,   4.],
        [  5.,   6.,   7.,   8.],
        [  9.,  10.,  11.,  12.]]
 
-  crop(x, begin=(0,1), end=(2,4)) = [[ 2.,  3.,  4.],
+  slice(x, begin=(0,1), end=(2,4)) = [[ 2.,  3.,  4.],
                                      [ 6.,  7.,  8.]]
 
 )code" ADD_FILELINE)
-.add_alias("crop")
 .set_attr_parser(ParamParser<SliceParam>)
 .set_attr<nnvm::FInferShape>("FInferShape", SliceShape)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
@@ -278,7 +286,10 @@ NNVM_REGISTER_OP(_crop_assign_scalar)
 NNVM_REGISTER_OP(slice_axis)
 .describe(R"code(Slice along a given axis.
 
-Examples:
+Returns a Sliced array along a given `axis` starting from the `begin` index
+ to the `end` index.
+
+Examples::
 
   x = [[  1.,   2.,   3.,   4.],
        [  5.,   6.,   7.,   8.],


### PR DESCRIPTION
The doc for the below math functions are modified
expm1,cos,tan,arcsin,arccos,arctan,degrees,radians,sinh,cosh,tanh,arcsinh,arccosh,arctanh,gamma,gammaln

@mli, @madjam @zackchase @Roshrini 

Please take a look and merge.