### PR TITLE
Disable MKL's fully connected layer for the convergence issue

### DIFF
--- a/src/operator/fully_connected.cc
+++ b/src/operator/fully_connected.cc
@@ -4,11 +4,6 @@
  * \brief fully connect operator
 */
 #include "./fully_connected-inl.h"
-#if MXNET_USE_MKL2017 == 1
-#include <mkl_memory.h>
-#include "./mkl/mkl_memory-inl.h"
-#include "./mkl/mkl_fully_connected-inl.h"
-#endif  // MXNET_USE_MKL2017
 #if MXNET_USE_NNPACK == 1
 #include "./nnpack/nnpack_fully_connected-inl.h"
 #endif  // MXNET_USE_NNPACK
@@ -21,17 +16,6 @@ Operator* CreateOp<cpu>(FullyConnectedParam param, int dtype,
                         std::vector<TShape> *out_shape,
                         Context ctx) {
   Operator *op = NULL;
-#if MXNET_USE_MKL2017 == 1
-  switch (dtype) {
-  case mshadow::kFloat32:
-    return new MKLFullyConnectedOp<cpu, float>(param, *in_shape, *out_shape);
-  case mshadow::kFloat64:
-    return new MKLFullyConnectedOp<cpu, double>(param, *in_shape, *out_shape);
-  default:
-    LOG(INFO) << MKLFullyConnectedOp<cpu, float>::getName() << " Skip MKL optimization";
-    break;
-  }
-#endif
 #if MXNET_USE_NNPACK == 1
   const size_t batch_size = (*in_shape)[0][0];
   // nnp_fully_connected_inference will do optimization for batch-size = 1


### PR DESCRIPTION
This change doesn't affect the performance. So, we can use atlas or openblas, instead. We will add MKL's sgemms instead of MKL's DNN primitive. This will resolve #5650 .