### PR TITLE
[example]Debug error caused by missplaced import find_mxnet in googlenet

### DIFF
--- a/example/image-classification/symbols/googlenet.py
+++ b/example/image-classification/symbols/googlenet.py
@@ -6,7 +6,6 @@ with convolutions." arXiv preprint arXiv:1409.4842 (2014).
 
 """
 
-import find_mxnet
 import mxnet as mx
 
 def ConvFactory(data, num_filter, kernel, stride=(1,1), pad=(0, 0), name=None, suffix=''):


### PR DESCRIPTION
When test the googlenet symbol stuck into the error caused by missplaced "import find_mxnet"
which is already called in file train_mnist.py(from common import find_mxnet...). So I deleted the import line which can not be called.