### PR TITLE
BatchNorm: Document CUDNN_BN_MIN_EPSILON

### DIFF
--- a/src/operator/batch_norm-inl.h
+++ b/src/operator/batch_norm-inl.h
@@ -35,7 +35,9 @@ struct BatchNormParam : public dmlc::Parameter<BatchNormParam> {
   bool output_mean_var;
   DMLC_DECLARE_PARAMETER(BatchNormParam) {
     DMLC_DECLARE_FIELD(eps).set_default(1e-3f)
-    .describe("Epsilon to prevent div 0");
+    .describe("Epsilon to prevent div 0. "
+              "Must be bigger than CUDNN_BN_MIN_EPSILON "
+              "defined in cudnn.h when using cudnn (usually 1e-5)");
     DMLC_DECLARE_FIELD(momentum).set_default(0.9f)
     .describe("Momentum for moving average");
     DMLC_DECLARE_FIELD(fix_gamma).set_default(true)

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -13,10 +13,6 @@
 #include <utility>
 #include "./batch_norm-inl.h"
 
-#if MXNET_USE_CUDNN == 1
-#include <cudnn.h>
-#endif  // MXNET_USE_CUDNN == 1
-
 namespace mxnet {
 namespace op {
 #if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 4

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -28,7 +28,7 @@ class CuDNNBatchNormOp : public Operator {
  public:
   explicit CuDNNBatchNormOp(BatchNormParam param) {
     using namespace mshadow;
-    CHECK_GT(param.eps, CUDNN_BN_MIN_EPSILON);
+    CHECK_GE(param.eps, CUDNN_BN_MIN_EPSILON);
     this->param_ = param;
     init_cudnn_ = false;
     dtype_ = DataType<DType>::kCudnnFlag;

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -13,6 +13,10 @@
 #include <utility>
 #include "./batch_norm-inl.h"
 
+#if MXNET_USE_CUDNN == 1
+#include <cudnn.h>
+#endif  // MXNET_USE_CUDNN == 1
+
 namespace mxnet {
 namespace op {
 #if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 4
@@ -28,6 +32,7 @@ class CuDNNBatchNormOp : public Operator {
  public:
   explicit CuDNNBatchNormOp(BatchNormParam param) {
     using namespace mshadow;
+    CHECK_GT(param.eps, CUDNN_BN_MIN_EPSILON);
     this->param_ = param;
     init_cudnn_ = false;
     dtype_ = DataType<DType>::kCudnnFlag;

--- a/src/operator/cudnn_batch_norm-inl.h
+++ b/src/operator/cudnn_batch_norm-inl.h
@@ -28,7 +28,8 @@ class CuDNNBatchNormOp : public Operator {
  public:
   explicit CuDNNBatchNormOp(BatchNormParam param) {
     using namespace mshadow;
-    CHECK_GE(param.eps, CUDNN_BN_MIN_EPSILON);
+    CHECK_GT(param.eps, CUDNN_BN_MIN_EPSILON)
+     << "CuDNN requires eps to be greater than " << CUDNN_BN_MIN_EPSILON;
     this->param_ = param;
     init_cudnn_ = false;
     dtype_ = DataType<DType>::kCudnnFlag;


### PR DESCRIPTION
When using an eps value <= CUDNN_BN_MIN_EPSILON cudnn will fail with CUDNN_STATUS_BAD_PARAM.