### PR TITLE
Add norm_clipping and summary to module.

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -4,6 +4,7 @@
 """Online evaluation metric module."""
 from __future__ import absolute_import
 
+import math
 import numpy
 from . import ndarray
 

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -193,6 +193,58 @@ class BaseModule(object):
         self.forward(data_batch, is_train=True)
         self.backward()
 
+    def clip_by_global_norm(self, max_norm=1.0):
+        """Clips gradient norm.
+
+        The norm is computed over all gradients together, as if they were
+         concatenated into a single vector. Gradients are modified in-place.
+        The method is first used in
+         `[ICML2013] On the difficulty of training recurrent neural networks`
+
+        Parameters
+        ----------
+        max_norm : float or int
+            The maximum clipping threshold of the gradient norm.
+
+        Returns
+        -------
+        norm_val : float
+            The computed norm of the gradients.
+
+        Examples
+        --------
+        An example of using clip_grad_norm to clip the gradient before updating the parameters::
+            >>> #Get the gradient via back-propagation
+            >>> net.forward_backward(data_batch=data_batch)
+            >>> norm_val = net.clip_grad_norm(max_norm=1.0)
+            >>> net.update()
+        """
+        raise NotImplementedError()
+
+    def global_norm(self):
+        """Calculate global gradient norm.
+
+        The L2 norm is computed over all gradients together, as if they were
+         concatenated into a single vector.
+
+        Could be used to debug the optimization process.
+         See http://videolectures.net/deeplearning2015_goodfellow_network_optimization/
+
+        Returns
+        -------
+        norm_val : float
+            The computed norm of the gradients.
+
+        Examples
+        --------
+        An example of using global_norm to calculate the gradient norm after back-propgation::
+            >>> #Get the gradient via back-propagation
+            >>> net.forward_backward(data_batch=data_batch)
+            >>> norm_val = net.global_norm()
+            >>> print(norm_val)
+        """
+        raise NotImplementedError()
+
     def score(self, eval_data, eval_metric, num_batch=None, batch_end_callback=None,
               score_end_callback=None,
               reset=True, epoch=0):
@@ -369,7 +421,7 @@ class BaseModule(object):
             epoch_end_callback=None, batch_end_callback=None, kvstore='local',
             optimizer='sgd', optimizer_params=(('learning_rate', 0.01),),
             eval_end_callback=None,
-            eval_batch_end_callback=None, initializer=Uniform(0.01),
+            eval_batch_end_callback=None, initializer=Uniform(0.01), max_norm=None,
             arg_params=None, aux_params=None, allow_missing=False,
             force_rebind=False, force_init=False, begin_epoch=0, num_epoch=None,
             validation_metric=None, monitor=None):
@@ -407,6 +459,9 @@ class BaseModule(object):
         initializer : Initializer
             The initializer is called to initialize the module parameters when they are
             not already initialized.
+        max_norm : float or None
+            The max_norm for global L2 norm clipping. Norm clip will not be triggered
+             if setting to zero
         arg_params : dict
             Defaults to ``None``, if not ``None``, should be existing parameters from a trained
             model or loaded from a checkpoint (previously saved model). In this case,
@@ -470,6 +525,8 @@ class BaseModule(object):
                 if monitor is not None:
                     monitor.tic()
                 self.forward_backward(data_batch)
+                if max_norm is not None:
+                    self.clip_by_global_norm(max_norm=max_norm)
                 self.update()
                 try:
                     # pre fetch next batch
@@ -950,3 +1007,20 @@ class BaseModule(object):
         not even be associated with any symbols.
         """
         return self._symbol
+
+    def summary(self, level=2):
+        """Summarize the network parameters.
+
+        Parameters
+        ----------
+        level : int, optional
+            Level of the summarization logs to print.
+            The log becomes more verbose with higher summary level.
+            - Level = 0
+                Print the total param number + aux param number
+            - Level = 1
+                Print the shape of all parameters + The total number of paremter numbers
+            - Level = 2
+                Print the shape of the data and other available information in Level 1
+        """
+        raise NotImplementedError()

--- a/python/mxnet/module/bucketing_module.py
+++ b/python/mxnet/module/bucketing_module.py
@@ -402,6 +402,58 @@ class BucketingModule(BaseModule):
         self._params_dirty = True
         self._curr_module.update()
 
+    def clip_by_global_norm(self, max_norm=1.0):
+        """Clips gradient norm.
+
+        The norm is computed over all gradients together, as if they were
+         concatenated into a single vector. Gradients are modified in-place.
+        The method is first used in
+         `[ICML2013] On the difficulty of training recurrent neural networks`
+
+        Parameters
+        ----------
+        max_norm : float or int
+            The maximum clipping threshold of the gradient norm.
+
+        Returns
+        -------
+        norm_val : float
+            The computed norm of the gradients.
+
+        Examples
+        --------
+        An example of using clip_grad_norm to clip the gradient before updating the parameters::
+            >>> #Get the gradient via back-propagation
+            >>> net.forward_backward(data_batch=data_batch)
+            >>> norm_val = net.clip_grad_norm(max_norm=1.0)
+            >>> net.update()
+        """
+        return self._curr_module.clip_by_global_norm(max_norm=max_norm)
+
+    def global_norm(self):
+        """Calculate global gradient norm.
+
+        The L2 norm is computed over all gradients together, as if they were
+         concatenated into a single vector.
+
+        Could be used to debug the optimization process.
+         See http://videolectures.net/deeplearning2015_goodfellow_network_optimization/
+
+        Returns
+        -------
+        norm_val : float
+            The computed norm of the gradients.
+
+        Examples
+        --------
+        An example of using global_norm to calculate the gradient norm after back-propgation::
+            >>> #Get the gradient via back-propagation
+            >>> net.forward_backward(data_batch=data_batch)
+            >>> norm_val = net.global_norm()
+            >>> print(norm_val)
+        """
+        return self._curr_module.global_norm()
+
     def get_outputs(self, merge_multi_context=True):
         """Get outputs from a previous forward computation.
 
@@ -465,3 +517,21 @@ class BucketingModule(BaseModule):
         assert self.binded
         for mod in self._buckets.values():
             mod.install_monitor(mon)
+
+    def summary(self, level=2):
+        """Summarize the network parameters.
+
+        Parameters
+        ----------
+        level : int, optional
+            Level of the summarization logs to print.
+            The log becomes more verbose with higher summary level.
+            - Level = 0
+                Print the total param number + aux param number
+            - Level = 1
+                Print the shape of all parameters + The total number of paremter numbers
+            - Level = 2
+                Print the shape of the data and other available information in Level 1
+        """
+        assert self.binded and self.params_initialized
+        self._curr_module.summary(level=level)

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -6,6 +6,7 @@ more `Executor` for data parallelization.
 
 import logging
 import warnings
+import numpy as np
 
 from .. import context as ctx
 from .. import ndarray as nd
@@ -568,6 +569,71 @@ class Module(BaseModule):
                            num_device=len(self._context),
                            kvstore=self._kvstore)
 
+    def clip_by_global_norm(self, max_norm=1.0):
+        """Clips gradient norm.
+
+        The norm is computed over all gradients together, as if they were
+         concatenated into a single vector. Gradients are modified in-place.
+        The method is first used in
+         `[ICML2013] On the difficulty of training recurrent neural networks`
+
+        Parameters
+        ----------
+        max_norm : float or int
+            The maximum clipping threshold of the gradient norm.
+
+        Returns
+        -------
+        norm_val : float
+            The computed norm of the gradients.
+
+        Examples
+        --------
+        An example of using clip_grad_norm to clip the gradient before updating the parameters::
+            >>> #Get the gradient via back-propagation
+            >>> net.forward_backward(data_batch=data_batch)
+            >>> norm_val = net.clip_grad_norm(max_norm=1.0)
+            >>> net.update()
+        """
+        assert self.binded and self.params_initialized
+        norm_val = self.global_norm()
+        if norm_val > max_norm:
+            ratio = max_norm / float(norm_val)
+            for grads in self._exec_group.grad_arrays:
+                for grad in grads:
+                    grad *= ratio
+        return norm_val
+
+    def global_norm(self):
+        """Calculate global gradient norm.
+
+        The L2 norm is computed over all gradients together, as if they were
+         concatenated into a single vector.
+
+        Could be used to debug the optimization process.
+         See http://videolectures.net/deeplearning2015_goodfellow_network_optimization/
+
+        Returns
+        -------
+        norm_val : float
+            The computed norm of the gradients.
+
+        Examples
+        --------
+        An example of using global_norm to calculate the gradient norm after back-propgation::
+            >>> #Get the gradient via back-propagation
+            >>> net.forward_backward(data_batch=data_batch)
+            >>> norm_val = net.global_norm()
+            >>> print(norm_val)
+        """
+        assert self.binded and self.params_initialized
+        # The code in the following will cause the estimated norm to be different for multiple gpus
+        norm_val = 0.0
+        for exe in self._exec_group.execs:
+            norm_val += nd.global_norm(exe.grad_arrays).asscalar()
+        norm_val /= float(len(self._exec_group.execs))
+        return norm_val
+
     def get_outputs(self, merge_multi_context=True):
         """Get outputs of the previous forward computation.
 
@@ -706,3 +772,83 @@ class Module(BaseModule):
         """ Install monitor on all executors """
         assert self.binded
         self._exec_group.install_monitor(mon)
+
+    # pylint: disable=invalid-name
+    def summary(self, level=2):
+        """Summarize the network parameters.
+
+        Parameters
+        ----------
+        level : int, optional
+            Level of the summarization logs to print.
+            The log becomes more verbose with higher summary level.
+            - Level = 0
+                Print the total param number + aux param number
+            - Level = 1
+                Print the shape of all parameters + The total number of paremter numbers
+            - Level = 2
+                Print the shape of the data and other available information in Level 1
+        """
+        assert self.binded and self.params_initialized
+        assert 0 <= level <= 2,\
+            "Level must be between 0 and 2, level=%d is not supported" % level
+        def _log_var(key, value, typ="param"):
+            if typ == "param":
+                if k in self._fixed_param_names:
+                    self.logger.info("   %s: %s, %d, req = %s, fixed"
+                                     %(key,
+                                       str(value.shape),
+                                       np.prod(value.shape),
+                                       self._exec_group.grad_req[k]))
+                else:
+                    self.logger.info("   %s: %s, %d, req = %s"
+                                     % (key,
+                                        str(value.shape),
+                                        np.prod(value.shape),
+                                        self._exec_group.grad_req[k]))
+            elif typ == "data" or typ == "aux":
+                self.logger.info("   %s: %s, %d"
+                                 % (key,
+                                    str(value.shape),
+                                    np.prod(value.shape)))
+        total_param_num = 0
+        total_fixed_param_num = 0
+        total_aux_param_num = 0
+        if level >= 2:
+            if len(self.data_names) == 0:
+                self.logger.info("Data: None")
+            else:
+                self.logger.info("Data:")
+                for k, v in zip(self.data_names, self.data_shapes):
+                    _log_var(k, v, typ="data")
+        if level >= 1:
+            if len(self._param_names) == 0:
+                self.logger.info("Param: None")
+            else:
+                self.logger.info("Params:")
+                for k in self._param_names:
+                    v = self._arg_params[k]
+                    _log_var(k, v)
+                    if k in self._fixed_param_names:
+                        total_fixed_param_num += np.prod(v.shape)
+                    else:
+                        total_param_num += np.prod(v.shape)
+            if len(self._aux_names) == 0:
+                self.logger.info("Aux States: None")
+            else:
+                self.logger.info("Aux States: ")
+                for k in self._aux_names:
+                    v = self._aux_params[k]
+                    _log_var(k, v, typ="aux")
+                    total_aux_param_num += np.prod(v.shape)
+        else:
+            for k in self._param_names:
+                v = self._arg_params[k]
+                total_param_num += np.prod(v.shape)
+            for k in self._aux_names:
+                v = self._aux_params[k]
+                total_aux_param_num += np.prod(v.shape)
+        self.logger.info("Total Param Num (exclude fixed ones): " + str(total_param_num))
+        self.logger.info("Total Fixed Param Num: " + str(total_fixed_param_num))
+        self.logger.info("Total Aux Param Num: " + str(total_aux_param_num))
+    # pylint: enable=invalid-name

--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -2206,5 +2206,48 @@ def imdecode(str_img, clip_rect=(0, 0, 0, 0), out=None, index=0, channels=3, mea
                                    str_img=str_img,
                                    out=out)
 
+
+def global_norm(t_list):
+    """Computes the global norm of multiple tensors.
+
+    Given a tuple or list of tensors t_list, this operation returns the global norm of the elements
+     in all tensors in t_list. The global norm is computed as:
+
+    ``global_norm = sqrt(sum([l2norm(t)**2 for t in t_list]))``
+
+    Any entries in t_list that are of type None are ignored.
+
+    Parameters
+    ----------
+    t_list: list or tuple
+        The NDArray list
+
+    Returns
+    -------
+    ret: NDArray
+        The global norm. The shape of the NDArray will be (1,)
+
+    Examples
+    --------
+    >>> x = mx.nd.ones((2, 3))
+    >>> y = mx.nd.ones((5, 6))
+    >>> z = mx.nd.ones((4, 2, 3))
+    >>> print(mx.nd.global_norm([x, y, z]).asscalar())
+    7.74597
+    >>> xnone = None
+    >>> ret = mx.nd.global_norm([x, y, z, xnone])
+    >>> print(ret.asscalar())
+    7.74597
+    """
+    ret = None
+    for arr in t_list:
+        if arr is not None:
+            if ret is None:
+                ret = square(norm(arr))
+            else:
+                ret += square(norm(arr))
+    ret = sqrt(ret)
+    return ret
+
 # from .base import add_fileline_to_docstring
 # add_fileline_to_docstring(__name__)

--- a/python/mxnet/symbol.py
+++ b/python/mxnet/symbol.py
@@ -1424,3 +1424,46 @@ def arange(start, stop=None, step=1.0, repeat=1, name=None, dtype=None):
         dtype = _numpy.float32
     return _internal._arange(start=start, stop=stop, step=step, repeat=repeat,
                              name=name, dtype=dtype)
+
+# pylint: disable=undefined-variable
+def global_norm(t_list, name=None):
+    """Computes the global norm of multiple tensors.
+
+    Given a tuple or list of tensors t_list, this operation returns the global norm of the elements
+     in all tensors in t_list. The global norm is computed as:
+
+    ``global_norm = sqrt(sum([l2norm(t)**2 for t in t_list]))``
+
+    Any entries in t_list that are of type None are ignored.
+
+    Parameters
+    ----------
+    t_list: list or tuple
+        The symbol list
+    name: str, optional
+        Name of the global norm symbol
+
+    Returns
+    -------
+    ret: Symbol
+        The global norm. The shape of the resulting symbols will be (1,)
+
+    Examples
+    --------
+    >>> x = mx.sym.ones((2, 3))
+    >>> y = mx.sym.ones((5, 6))
+    >>> z = mx.sym.ones((4, 2, 3))
+    >>> ret = mx.sym.global_norm([x, y, z])
+    >>> ret.eval()[0].asscalar()
+    7.74597
+    """
+    ret = None
+    for t in t_list:
+        if t is not None:
+            if ret is None:
+                ret = square(norm(t))
+            else:
+                ret += square(norm(t))
+    ret = sqrt(ret, name=name)
+    return ret
+# pylint: enable=undefined-variable

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -616,6 +616,17 @@ def test_iter():
     for i in range(x.size):
         assert same(y[i].asnumpy(), x[i].asnumpy())
 
+def test_global_norm():
+    nd_list = []
+    npy_norm = 0.0
+    for i in range(5):
+        data_npy = np.random.normal(loc=0, scale=1, size=(np.random.randint(1, 4),
+                                                          np.random.randint(1, 4)))
+        npy_norm += np.square(data_npy).sum()
+        nd_list.append(mx.nd.array(data_npy))
+    npy_norm = np.sqrt(npy_norm)
+    nd_val = mx.nd.global_norm(nd_list).asscalar()
+    assert_allclose(nd_val, npy_norm)
 
 if __name__ == '__main__':
     test_broadcast_binary()
@@ -642,3 +653,4 @@ if __name__ == '__main__':
     test_ndarray_equal()
     test_take()
     test_iter()
+    test_global_norm()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3005,6 +3005,20 @@ def test_custom_op():
     x = mx.nd.array(np.random.uniform(-1, 1, size=(4, 10)))
     check_numeric_gradient(op, [x])
 
+def test_global_norm():
+    a = mx.sym.var('a')
+    b = mx.sym.var('b')
+    c = mx.sym.var('c')
+    d = mx.sym.global_norm([a, b, c])
+    a_npy = np.random.normal(0, 1, (2, 4))
+    b_npy = np.random.normal(0, 1, (3, 3))
+    c_npy = np.random.normal(0, 1, (3, 1, 2, 3))
+    res = d.eval(ctx=default_context(),
+                 a=mx.nd.array(a_npy),
+                 b=mx.nd.array(b_npy),
+                 c=mx.nd.array(c_npy))[0].asscalar()
+    npy_res = np.sqrt((a_npy ** 2).sum() + (b_npy ** 2).sum() + (c_npy ** 2).sum())
+    assert_allclose(res, npy_res)
 
 if __name__ == '__main__':
     test_custom_op()
@@ -3071,3 +3085,4 @@ if __name__ == '__main__':
     test_tile()
     test_one_hot()
     test_where()
+    test_global_norm()


### PR DESCRIPTION
Add `nd.global_norm` and `sym.global_norm`
Add `mod.clip_by_global_norm()`
Add `mod.summary(level=...)`
Add norm clipping to the RNN examples

The log of running `cudnn_lstm_bucketing.py`
```log
WARNING: discarded 0 sentences longer than the largest bucket.
WARNING: discarded 0 sentences longer than the largest bucket.
WARNING: discarded 0 sentences longer than the largest bucket.
2017-04-16 18:27:02,240 Data:
2017-04-16 18:27:02,240    data: (85, 32), 2720
2017-04-16 18:27:02,241 Params:
2017-04-16 18:27:02,241    embed_weight: (10000, 200), 2000000, req = write
2017-04-16 18:27:02,241    lstm_parameters: (643200,), 643200, req = write
2017-04-16 18:27:02,241    pred_weight: (10000, 200), 2000000, req = write
2017-04-16 18:27:02,241    pred_bias: (10000,), 10000, req = write
2017-04-16 18:27:02,241 Aux States: None
2017-04-16 18:27:02,241 Total Param Num (exclude fixed ones): 4653200
2017-04-16 18:27:02,242 Total Fixed Param Num: 0
2017-04-16 18:27:02,242 Total Aux Param Num: 0
2017-04-16 18:27:02,242 Already bound, ignoring bind()
2017-04-16 18:27:02,242 optimizer already initialized, ignoring.
2017-04-16 18:27:03,534 Epoch[0] Batch [50]     Speed: 2344.07 samples/sec
Train-Perplexity=31611031.156206
2017-04-16 18:27:04,184 Epoch[0] Batch [100]    Speed: 2462.54 samples/sec
Train-Perplexity=6431.935574
2017-04-16 18:27:04,944 Epoch[0] Batch [150]    Speed: 2104.33 samples/sec
Train-Perplexity=1356.168854
2017-04-16 18:27:05,562 Epoch[0] Batch [200]    Speed: 2588.53 samples/sec
Train-Perplexity=1087.850005
2017-04-16 18:27:06,151 Epoch[0] Batch [250]    Speed: 2716.99 samples/sec
Train-Perplexity=1006.468296
2017-04-16 18:27:06,804 Epoch[0] Batch [300]    Speed: 2450.49 samples/sec
Train-Perplexity=923.301520
2017-04-16 18:27:07,456 Epoch[0] Batch [350]    Speed: 2454.61 samples/sec
Train-Perplexity=860.213869
2017-04-16 18:27:08,158 Epoch[0] Batch [400]    Speed: 2278.51 samples/sec
Train-Perplexity=774.597794
2017-04-16 18:27:08,773 Epoch[0] Batch [450]    Speed: 2601.98 samples/sec
Train-Perplexity=745.054633
2017-04-16 18:27:09,580 Epoch[0] Batch [500]    Speed: 1984.01 samples/sec
Train-Perplexity=693.528633
```