### PR TITLE
Solved toy_ctc example error by debugging input data shape

### DIFF
--- a/example/warpctc/toy_ctc.py
+++ b/example/warpctc/toy_ctc.py
@@ -36,10 +36,10 @@ def gen_rand():
     buf = str(num)
     while len(buf) < 4:
         buf = "0" + buf
-    ret = np.array([])
+    ret = []
     for i in range(80):
         c = int(buf[i // 20])
-        ret = np.concatenate([ret, gen_feature(c)])
+        ret.append(gen_feature(c))
     return buf, ret
 
 def get_label(buf):
@@ -56,7 +56,7 @@ class DataIter(mx.io.DataIter):
         self.num_label = num_label
         self.init_states = init_states
         self.init_state_arrays = [mx.nd.zeros(x[1]) for x in init_states]
-        self.provide_data = [('data', (batch_size, 10 * 80))] + init_states
+        self.provide_data = [('data', (batch_size, 80, 10))] + init_states
         self.provide_label = [('label', (self.batch_size, 4))]
 
     def __iter__(self):


### PR DESCRIPTION
Solved related issue #5435 which happened
because data shape of symbol(seq_len=80) and real data shape(seq_len=800) doesn't met.
I modified data_iter's provide_data and gen_rand to support lstm_unroll's symbol(seq_len=80),
and confirmed it works well.
Below is the training log.

2017-04-15 16:27:06,025 Start training with [gpu(0)]
2017-04-15 16:28:11,823 Epoch[0] Batch [50]	Speed: 1257.73 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:13,122 Epoch[0] Batch [100]	Speed: 1231.47 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:14,348 Epoch[0] Batch [150]	Speed: 1305.72 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:15,595 Epoch[0] Batch [200]	Speed: 1283.31 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:16,912 Epoch[0] Batch [250]	Speed: 1215.02 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:18,191 Epoch[0] Batch [300]	Speed: 1251.47 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:19,430 Epoch[0] Batch [350]	Speed: 1291.18 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:20,736 Epoch[0] Batch [400]	Speed: 1225.21 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:22,045 Epoch[0] Batch [450]	Speed: 1222.62 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:23,342 Epoch[0] Batch [500]	Speed: 1233.66 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:24,615 Epoch[0] Batch [550]	Speed: 1257.35 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:25,893 Epoch[0] Batch [600]	Speed: 1252.21 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:27,153 Epoch[0] Batch [650]	Speed: 1269.36 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:28,392 Epoch[0] Batch [700]	Speed: 1291.39 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:29,692 Epoch[0] Batch [750]	Speed: 1231.25 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:30,935 Epoch[0] Batch [800]	Speed: 1287.14 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:32,168 Epoch[0] Batch [850]	Speed: 1297.67 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:33,460 Epoch[0] Batch [900]	Speed: 1239.32 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:34,744 Epoch[0] Batch [950]	Speed: 1246.30 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:36,027 Epoch[0] Batch [1000]	Speed: 1246.97 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:37,325 Epoch[0] Batch [1050]	Speed: 1233.15 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:38,567 Epoch[0] Batch [1100]	Speed: 1287.80 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:39,782 Epoch[0] Batch [1150]	Speed: 1317.17 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:40,994 Epoch[0] Batch [1200]	Speed: 1320.13 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:42,213 Epoch[0] Batch [1250]	Speed: 1313.24 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:43,451 Epoch[0] Batch [1300]	Speed: 1292.53 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:44,686 Epoch[0] Batch [1350]	Speed: 1295.47 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:46,028 Epoch[0] Batch [1400]	Speed: 1192.42 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:47,366 Epoch[0] Batch [1450]	Speed: 1196.41 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:48,595 Epoch[0] Batch [1500]	Speed: 1301.52 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:49,823 Epoch[0] Batch [1550]	Speed: 1303.15 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:51,119 Epoch[0] Batch [1600]	Speed: 1234.43 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:52,353 Epoch[0] Batch [1650]	Speed: 1297.16 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:53,619 Epoch[0] Batch [1700]	Speed: 1264.41 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:54,920 Epoch[0] Batch [1750]	Speed: 1229.41 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:56,172 Epoch[0] Batch [1800]	Speed: 1278.26 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:57,424 Epoch[0] Batch [1850]	Speed: 1278.35 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:58,635 Epoch[0] Batch [1900]	Speed: 1321.37 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:28:59,862 Epoch[0] Batch [1950]	Speed: 1304.36 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:01,146 Epoch[0] Batch [2000]	Speed: 1245.59 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:02,449 Epoch[0] Batch [2050]	Speed: 1228.02 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:03,660 Epoch[0] Batch [2100]	Speed: 1322.37 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:04,930 Epoch[0] Batch [2150]	Speed: 1259.39 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:06,205 Epoch[0] Batch [2200]	Speed: 1255.53 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:07,429 Epoch[0] Batch [2250]	Speed: 1306.73 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:08,753 Epoch[0] Batch [2300]	Speed: 1208.87 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:09,988 Epoch[0] Batch [2350]	Speed: 1295.36 samples/sec	Train-Accuracy=0.000000
2017-04-15 16:29:11,220 Epoch[0] Batch [2400]	Speed: 1299.24 samples/sec	Train-Accuracy=0.017500
2017-04-15 16:29:12,540 Epoch[0] Batch [2450]	Speed: 1212.11 samples/sec	Train-Accuracy=0.103750
2017-04-15 16:29:13,785 Epoch[0] Batch [2500]	Speed: 1286.16 samples/sec	Train-Accuracy=0.468750
2017-04-15 16:29:15,019 Epoch[0] Batch [2550]	Speed: 1296.61 samples/sec	Train-Accuracy=0.635625
2017-04-15 16:29:16,245 Epoch[0] Batch [2600]	Speed: 1304.37 samples/sec	Train-Accuracy=0.824375
2017-04-15 16:29:17,482 Epoch[0] Batch [2650]	Speed: 1294.61 samples/sec	Train-Accuracy=0.968125
2017-04-15 16:29:18,708 Epoch[0] Batch [2700]	Speed: 1305.09 samples/sec	Train-Accuracy=0.998750
2017-04-15 16:29:19,963 Epoch[0] Batch [2750]	Speed: 1274.84 samples/sec	Train-Accuracy=0.999375
2017-04-15 16:29:21,220 Epoch[0] Batch [2800]	Speed: 1272.97 samples/sec	Train-Accuracy=0.998125
2017-04-15 16:29:22,493 Epoch[0] Batch [2850]	Speed: 1257.39 samples/sec	Train-Accuracy=1.000000