### PR TITLE
Fix concat.cc documentation

### DIFF
--- a/src/operator/concat.cc
+++ b/src/operator/concat.cc
@@ -64,7 +64,7 @@ For example::
                          [ 3.,  3.],
                          [ 3.,  3.]]
 
-  Concat(x,y,z,dim=1) = [[ 1.,  1.,  2.,  2.],
+  Concat(x,y,dim=1) = [[ 1.,  1.,  2.,  2.],
                          [ 1.,  1.,  2.,  2.]]
 
 )code" ADD_FILELINE)


### PR DESCRIPTION
The dimension sizes of the input arrays on the given axis should be the same. However z does not have the same size as x, y on dimension 1.