### PR TITLE
Avoids running unneeded backprop kernels.

### DIFF
--- a/src/operator/cudnn_convolution-inl.h
+++ b/src/operator/cudnn_convolution-inl.h
@@ -209,8 +209,7 @@ class CuDNNConvolutionOp : public Operator {
       typename DataType<DType>::ScaleType alpha = 1.0f;
       typename DataType<DType>::ScaleType beta = 0.0f;
       typename DataType<DType>::ScaleType beta_add = 1.0f;
-      if (!param_.no_bias) {
-        CHECK_NE(req[conv::kBias], kNullOp);
+      if (!param_.no_bias && (req[conv::kBias] != kNullOp)) {
         Tensor<gpu, 1, DType> gbias = in_grad[conv::kBias].get<gpu, 1, DType>(s);
         CUDNN_CALL(cudnnConvolutionBackwardBias(s->dnn_handle_,
                                               &alpha,

--- a/src/operator/cudnn_convolution-inl.h
+++ b/src/operator/cudnn_convolution-inl.h
@@ -210,6 +210,7 @@ class CuDNNConvolutionOp : public Operator {
       typename DataType<DType>::ScaleType beta = 0.0f;
       typename DataType<DType>::ScaleType beta_add = 1.0f;
       if (!param_.no_bias) {
+        CHECK_NE(req[conv::kBias], kNullOp);
         Tensor<gpu, 1, DType> gbias = in_grad[conv::kBias].get<gpu, 1, DType>(s);
         CUDNN_CALL(cudnnConvolutionBackwardBias(s->dnn_handle_,
                                               &alpha,
@@ -219,8 +220,9 @@ class CuDNNConvolutionOp : public Operator {
                                               bias_desc_,
                                               gbias.dptr_ + bias_offset_ * g));
       }
-      #if CUDNN_MAJOR <= 4
-      CUDNN_CALL(cudnnConvolutionBackwardFilter_v3(s->dnn_handle_,
+      if (req[conv::kWeight] != kNullOp) {
+        #if CUDNN_MAJOR <= 4
+          CUDNN_CALL(cudnnConvolutionBackwardFilter_v3(s->dnn_handle_,
                &alpha,
                in_desc_,
                data_ptr + data_offset_ * g,
@@ -233,8 +235,8 @@ class CuDNNConvolutionOp : public Operator {
                req[conv::kWeight] == kAddTo? &beta_add : &beta,
                filter_desc_,
                gwmat_ptr + weight_offset_ * g));
-      #elif CUDNN_MAJOR >= 5
-      CUDNN_CALL(cudnnConvolutionBackwardFilter(s->dnn_handle_,
+        #elif CUDNN_MAJOR >= 5
+          CUDNN_CALL(cudnnConvolutionBackwardFilter(s->dnn_handle_,
                &alpha,
                in_desc_,
                data_ptr + data_offset_ * g,
@@ -247,9 +249,11 @@ class CuDNNConvolutionOp : public Operator {
                req[conv::kWeight] == kAddTo? &beta_add : &beta,
                filter_desc_,
                gwmat_ptr + weight_offset_ * g));
-      #endif
-      #if CUDNN_MAJOR <= 4
-      CUDNN_CALL(cudnnConvolutionBackwardData_v3(s->dnn_handle_,
+        #endif
+      }
+      if (req[conv::kData] != kNullOp) {
+        #if CUDNN_MAJOR <= 4
+          CUDNN_CALL(cudnnConvolutionBackwardData_v3(s->dnn_handle_,
                &alpha,
                filter_desc_,
                wmat_ptr + weight_offset_ * g,
@@ -262,8 +266,8 @@ class CuDNNConvolutionOp : public Operator {
                req[conv::kData] == kAddTo? &beta_add : &beta,
                in_desc_,
                gdata_ptr + data_offset_ * g));
-      #elif CUDNN_MAJOR >= 5
-      CUDNN_CALL(cudnnConvolutionBackwardData(s->dnn_handle_,
+        #elif CUDNN_MAJOR >= 5
+          CUDNN_CALL(cudnnConvolutionBackwardData(s->dnn_handle_,
                &alpha,
                filter_desc_,
                wmat_ptr + weight_offset_ * g,
@@ -276,7 +280,8 @@ class CuDNNConvolutionOp : public Operator {
                req[conv::kData] == kAddTo? &beta_add : &beta,
                in_desc_,
                gdata_ptr + data_offset_ * g));
-      #endif
+        #endif
+      }
     }
   }
 

--- a/src/operator/cudnn_deconvolution-inl.h
+++ b/src/operator/cudnn_deconvolution-inl.h
@@ -230,8 +230,7 @@ class CuDNNDeconvolutionOp : public Operator {
         req[deconv::kData] == kAddTo ? 1.0f : 0.0f;
       typename DataType<DType>::ScaleType weight_beta =
         req[deconv::kWeight] == kAddTo ? 1.0f : 0.0f;
-      if (!param_.no_bias) {
-        CHECK_NE(req[deconv::kBias], kNullOp);
+      if (!param_.no_bias && (req[deconv::kBias] != kNullOp)) {
         Tensor<gpu, 1, DType> gbias = in_grad[deconv::kBias].get<gpu, 1, DType>(s);
         CHECK_EQ(cudnnConvolutionBackwardBias(s->dnn_handle_,
                                               &alpha,

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -274,7 +274,8 @@ def test_convolution_with_type():
                np.dtype(np.uint8): 0,
                np.dtype(np.int32): 0}
     check_consistency(sym, ctx_list, tol=tol)
-
+    # test ability to turn off training on bias
+    check_consistency(sym, ctx_list, grad_req={'conv_data': 'write', 'conv_weight': 'write', 'conv_bias': 'null'}, tol=tol)
 
 # Apply N symbols against each of M contexts, checking that all NxM combinations match.
 def check_consistency_NxM(sym_list, ctx_list):


### PR DESCRIPTION
Within CuDNNConvolutionOp.Backward(), this adds checks to avoid launching backprop kernels unnecessarily (i.e. when req[] == kNullOp).  This would result typically in avoiding the L1 dgrad kernel launch in CNN's.