### PR TITLE
Add test for pip installations

### DIFF
--- a/tests/ci_build/install/install_julia.sh
+++ b/tests/ci_build/install/install_julia.sh
@@ -5,5 +5,7 @@ set -e
 wget https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-linux-x86_64.tar.gz
 mv julia-0.5.0-linux-x86_64.tar.gz /tmp/
 tar xfvz /tmp/julia-0.5.0-linux-x86_64.tar.gz
+rm -f /tmp/julia-0.5.0-linux-x86_64.tar.gz
+
+# tar extracted in current directory
 ln -s -f ${PWD}/julia-3c9d75391c/bin/julia /usr/bin/julia
-echo $PWD ''pwd

--- a/tests/ci_build/pip_tests/Dockerfile.in.pip_cpu
+++ b/tests/ci_build/pip_tests/Dockerfile.in.pip_cpu
@@ -1,0 +1,4 @@
+# -*- mode: dockerfile -*-
+# dockerfile to test pip installation on CPU
+
+FROM ubuntu:14.04

--- a/tests/ci_build/pip_tests/Dockerfile.in.pip_cu75
+++ b/tests/ci_build/pip_tests/Dockerfile.in.pip_cu75
@@ -1,0 +1,4 @@
+# -*- mode: dockerfile -*-
+# dockerfile to test pip installation on GPU with CUDA 7.5 CuDNN 5.1
+
+FROM nvidia/cuda:7.5-cudnn5-devel

--- a/tests/ci_build/pip_tests/Dockerfile.in.pip_cu80
+++ b/tests/ci_build/pip_tests/Dockerfile.in.pip_cu80
@@ -1,0 +1,4 @@
+# -*- mode: dockerfile -*-
+# dockerfile to test pip installation on GPU with CUDA 8.0 CuDNN 5.1
+
+FROM nvidia/cuda:8.0-cudnn5-devel

--- a/tests/ci_build/pip_tests/Dockerfile.pip_dependencies
+++ b/tests/ci_build/pip_tests/Dockerfile.pip_dependencies
@@ -1,0 +1,13 @@
+# -*- mode: dockerfile -*-
+# part of the dockerfile to test pip installations
+
+# add repo to install different Python versions
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:fkrull/deadsnakes && apt-get update
+RUN apt-get install -y python python2.7 python3.4 python3.5 python3.6
+
+# install other dependencies
+RUN apt-get install -y wget git unzip gcc
+
+# install virtualenv
+RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && pip install virtualenv && rm -rf get-pip.py

--- a/tests/jenkins/run_test_pip_installations.sh
+++ b/tests/jenkins/run_test_pip_installations.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+if (( $# < 1 )); then
+    echo "no!"
+    exit -1
+fi
+WORKSPACE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
+
+PYTHON_VERSIONS=('2.7' '3.4' '3.5' '3.6')
+DEVICES=('pip_cu80') #'pip_cpu' 'pip_cu75' 'pip_cu80')
+
+# build Docker images and test pip installation for each device
+for DEV in "${DEVICES[@]}"; do
+
+    # get Docker binary
+    if [[ "${DEV}" == *"cpu"* ]]; then
+        DOCKER_BINARY="docker"
+    else
+        DOCKER_BINARY="nvidia-docker"
+    fi
+
+    # concatenate the Dockerfile with dependencies into the device file
+    DOCKERFILE="Dockerfile.${DEV}"
+    DOCKERFILE_DEVICE="Dockerfile.in.${DEV}"
+    rm -rf ${DOCKERFILE}
+    cp ${DOCKERFILE_DEVICE} ${DOCKERFILE}
+    cat Dockerfile.pip_dependencies >> ${DOCKERFILE}
+
+    # build Docker image
+    DOCKER_TAG="mxnet/${DEV}"
+    ${DOCKER_BINARY} build -t ${DOCKER_TAG} -f ${DOCKERFILE} .
+
+    # test each python version of mxnet
+    for VERSION in "${PYTHON_VERSIONS[@]}"; do
+        PYTHON="python${VERSION}"
+        echo "Testing ${PYTHON} ${DOCKER_TAG}"
+        DOCKER_CMD="virtualenv -p \"/usr/bin/${PYTHON}\" ${PYTHON}; source \"${PYTHON}/bin/activate\"; cd ${WORKSPACE};"
+        if [[ "${DEV}" == *"cpu"* ]]; then
+            DOCKER_CMD="${DOCKER_CMD} pip install mxnet; python tests/python/train/test_conv.py"
+        elif [[ "${DEV}" == *"cu75"* ]]; then
+            DOCKER_CMD="${DOCKER_CMD} pip install mxnet-cu75; python tests/python/train/test_conv.py --gpu"
+        elif [[ "${DEV}" == *"cu80"* ]]; then
+            DOCKER_CMD="${DOCKER_CMD} pip install mxnet-cu80; python tests/python/train/test_conv.py --gpu"
+        fi
+	
+        ${DOCKER_BINARY} run --rm -v ${WORKSPACE}:${WORKSPACE} ${DOCKER_TAG} bash -c "${DOCKER_CMD}"
+	#${DOCKER_BINARY} run --rm -v ${WORKSPACE}:${WORKSPACE} ${DOCKER_TAG} bash -c "virtualenv -p \"/usr/bin/${PYTHON}\" ${PYTHON}; source \"${PYTHON}/bin/activate\"; cd ${WORKSPACE}; echo ${PWD} ${WORKSPACE}; pip install mxnet; python tests/python/train/test_conv.py"
+    done
+
+done

--- a/tests/jenkins/run_test_pip_installations.sh
+++ b/tests/jenkins/run_test_pip_installations.sh
@@ -3,13 +3,16 @@
 set -e
 
 if (( $# < 1 )); then
-    echo "no!"
-    exit -1
+    echo ""
+    echo "Usage: $(basename $0) WORKSPACE_PATH"
+    echo ""
+    exit 1
 fi
+
 WORKSPACE=$( echo "$1" | tr '[:upper:]' '[:lower:]' )
 
 PYTHON_VERSIONS=('2.7' '3.4' '3.5' '3.6')
-DEVICES=('pip_cu80') #'pip_cpu' 'pip_cu75' 'pip_cu80')
+DEVICES=('pip_cpu' 'pip_cu75' 'pip_cu80')
 
 # build Docker images and test pip installation for each device
 for DEV in "${DEVICES[@]}"; do
@@ -35,7 +38,7 @@ for DEV in "${DEVICES[@]}"; do
     # test each python version of mxnet
     for VERSION in "${PYTHON_VERSIONS[@]}"; do
         PYTHON="python${VERSION}"
-        echo "Testing ${PYTHON} ${DOCKER_TAG}"
+        echo "Testing ${PYTHON}"
         DOCKER_CMD="virtualenv -p \"/usr/bin/${PYTHON}\" ${PYTHON}; source \"${PYTHON}/bin/activate\"; cd ${WORKSPACE};"
         if [[ "${DEV}" == *"cpu"* ]]; then
             DOCKER_CMD="${DOCKER_CMD} pip install mxnet; python tests/python/train/test_conv.py"
@@ -46,7 +49,6 @@ for DEV in "${DEVICES[@]}"; do
         fi
 	
         ${DOCKER_BINARY} run --rm -v ${WORKSPACE}:${WORKSPACE} ${DOCKER_TAG} bash -c "${DOCKER_CMD}"
-	#${DOCKER_BINARY} run --rm -v ${WORKSPACE}:${WORKSPACE} ${DOCKER_TAG} bash -c "virtualenv -p \"/usr/bin/${PYTHON}\" ${PYTHON}; source \"${PYTHON}/bin/activate\"; cd ${WORKSPACE}; echo ${PWD} ${WORKSPACE}; pip install mxnet; python tests/python/train/test_conv.py"
     done
 
 done

--- a/tests/python/train/test_conv.py
+++ b/tests/python/train/test_conv.py
@@ -7,52 +7,57 @@ import os, pickle, gzip, argparse
 import logging
 from common import get_data
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--gpu', action='store_true', help='use gpu to train')
-args = parser.parse_args()
+def get_model(use_gpu):
+    # symbol net
+    data = mx.symbol.Variable('data')
+    conv1= mx.symbol.Convolution(data = data, name='conv1', num_filter=32, kernel=(3,3), stride=(2,2))
+    bn1 = mx.symbol.BatchNorm(data = conv1, name="bn1")
+    act1 = mx.symbol.Activation(data = bn1, name='relu1', act_type="relu")
+    mp1 = mx.symbol.Pooling(data = act1, name = 'mp1', kernel=(2,2), stride=(2,2), pool_type='max')
 
-# symbol net
-batch_size = 100
-
-data = mx.symbol.Variable('data')
-conv1= mx.symbol.Convolution(data = data, name='conv1', num_filter=32, kernel=(3,3), stride=(2,2))
-bn1 = mx.symbol.BatchNorm(data = conv1, name="bn1")
-act1 = mx.symbol.Activation(data = bn1, name='relu1', act_type="relu")
-mp1 = mx.symbol.Pooling(data = act1, name = 'mp1', kernel=(2,2), stride=(2,2), pool_type='max')
-
-conv2= mx.symbol.Convolution(data = mp1, name='conv2', num_filter=32, kernel=(3,3), stride=(2,2))
-bn2 = mx.symbol.BatchNorm(data = conv2, name="bn2")
-act2 = mx.symbol.Activation(data = bn2, name='relu2', act_type="relu")
-mp2 = mx.symbol.Pooling(data = act2, name = 'mp2', kernel=(2,2), stride=(2,2), pool_type='max')
+    conv2= mx.symbol.Convolution(data = mp1, name='conv2', num_filter=32, kernel=(3,3), stride=(2,2))
+    bn2 = mx.symbol.BatchNorm(data = conv2, name="bn2")
+    act2 = mx.symbol.Activation(data = bn2, name='relu2', act_type="relu")
+    mp2 = mx.symbol.Pooling(data = act2, name = 'mp2', kernel=(2,2), stride=(2,2), pool_type='max')
 
 
-fl = mx.symbol.Flatten(data = mp2, name="flatten")
-fc2 = mx.symbol.FullyConnected(data = fl, name='fc2', num_hidden=10)
-softmax = mx.symbol.SoftmaxOutput(data = fc2, name = 'sm')
+    fl = mx.symbol.Flatten(data = mp2, name="flatten")
+    fc2 = mx.symbol.FullyConnected(data = fl, name='fc2', num_hidden=10)
+    softmax = mx.symbol.SoftmaxOutput(data = fc2, name = 'sm')
 
-num_epoch = 1
-ctx=mx.gpu() if args.gpu else mx.cpu()
-model = mx.model.FeedForward(softmax, ctx,
-                             num_epoch=num_epoch,
-                             learning_rate=0.1, wd=0.0001,
-                             momentum=0.9)
-# check data
-get_data.GetMNIST_ubyte()
+    num_epoch = 1
+    ctx=mx.gpu() if use_gpu else mx.cpu()
+    model = mx.model.FeedForward(softmax, ctx,
+                                 num_epoch=num_epoch,
+                                 learning_rate=0.1, wd=0.0001,
+                                 momentum=0.9)
+    return model
 
-train_dataiter = mx.io.MNISTIter(
-        image="data/train-images-idx3-ubyte",
-        label="data/train-labels-idx1-ubyte",
-        data_shape=(1, 28, 28),
-        label_name='sm_label',
-        batch_size=batch_size, shuffle=True, flat=False, silent=False, seed=10)
-val_dataiter = mx.io.MNISTIter(
-        image="data/t10k-images-idx3-ubyte",
-        label="data/t10k-labels-idx1-ubyte",
-        data_shape=(1, 28, 28),
-        label_name='sm_label',
-        batch_size=batch_size, shuffle=True, flat=False, silent=False)
+def get_iters():
+    # check data
+    get_data.GetMNIST_ubyte()
 
+    batch_size = 100
+    train_dataiter = mx.io.MNISTIter(
+            image="data/train-images-idx3-ubyte",
+            label="data/train-labels-idx1-ubyte",
+            data_shape=(1, 28, 28),
+            label_name='sm_label',
+            batch_size=batch_size, shuffle=True, flat=False, silent=False, seed=10)
+    val_dataiter = mx.io.MNISTIter(
+            image="data/t10k-images-idx3-ubyte",
+            label="data/t10k-labels-idx1-ubyte",
+            data_shape=(1, 28, 28),
+            label_name='sm_label',
+            batch_size=batch_size, shuffle=True, flat=False, silent=False)
+    return  train_dataiter, val_dataiter
+
+# run default with unit test framework
 def test_mnist():
+    iters = get_iters()
+    exec_mnist(get_model(False), iters[0], iters[1])
+
+def exec_mnist(model, train_dataiter, val_dataiter):
     # print logging by default
     logging.basicConfig(level=logging.DEBUG)
     console = logging.StreamHandler()
@@ -71,7 +76,11 @@ def test_mnist():
     logging.info('final accuracy = %f', acc1)
     assert(acc1 > 0.94)
 
-
+# run as a script
 if __name__ == "__main__":
-    test_mnist()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--gpu', action='store_true', help='use gpu to train')
+    args = parser.parse_args()
+    iters = get_iters()
+    exec_mnist(get_model(args.gpu), iters[0], iters[1])
 

--- a/tests/python/train/test_conv.py
+++ b/tests/python/train/test_conv.py
@@ -3,9 +3,13 @@ import sys
 sys.path.insert(0, '../../python')
 import mxnet as mx
 import numpy as np
-import os, pickle, gzip
+import os, pickle, gzip, argparse
 import logging
 from common import get_data
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--gpu', action='store_true', help='use gpu to train')
+args = parser.parse_args()
 
 # symbol net
 batch_size = 100
@@ -27,7 +31,8 @@ fc2 = mx.symbol.FullyConnected(data = fl, name='fc2', num_hidden=10)
 softmax = mx.symbol.SoftmaxOutput(data = fc2, name = 'sm')
 
 num_epoch = 1
-model = mx.model.FeedForward(softmax, mx.cpu(),
+ctx=mx.gpu() if args.gpu else mx.cpu()
+model = mx.model.FeedForward(softmax, ctx,
                              num_epoch=num_epoch,
                              learning_rate=0.1, wd=0.0001,
                              momentum=0.9)


### PR DESCRIPTION
This commit adds Dockerfiles and test script to test all variants of MXNet pip packages. I've tested this on a copy of the Jenkins slave host with an updated NVIDIA driver (375.26) with the following command:

`tests/jenkins/run_test_pip_installations.sh ${WORKSPACE}` where WORKSPACE was set to /home/ec2-user/mxnet, the Jenkins workspace.

Currently the test will fail after testing `mxnet` with Python 3.6 as the accuracy is lower than expected. We can either put that case at the very end or change the script to not fail until all cases have been tested.

@sandeep-krishnamurthy 