### PR TITLE
Fixed argparse usage for --exts

### DIFF
--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -198,7 +198,7 @@ def parse_args():
                         help='If this is set im2rec will create image list(s) by traversing root folder\
         and output to <prefix>.lst.\
         Otherwise im2rec will read <prefix>.lst and create a database at <prefix>.rec')
-    cgroup.add_argument('--exts', type=list, default=['.jpeg', '.jpg'],
+    cgroup.add_argument('--exts', nargs='+', default=['.jpeg', '.jpg'],
                         help='list of acceptable image extensions.')
     cgroup.add_argument('--chunks', type=int, default=1, help='number of chunks.')
     cgroup.add_argument('--train-ratio', type=float, default=1.0,


### PR DESCRIPTION
Currently, the type for --exts is specified as type=list.
If one tries to change the extension to .png (for example) with:
 
     python tools/im2rec.py --exts .png
 
Then, internally, args.exts = ['.', 'p', 'n', 'g'] and this is not what is needed.
This is because specifying type=list stores the variable as a list of lists.
Instead, we specify that the number of arguments exts receives is one-or-more.
So, type=list becomes nargs='+'.
