### PR TITLE
Cures SEGV seen in test_symbol.py:test_zero_prop2 when DEBUG=1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 
 # CFLAGS for debug
 ifeq ($(DEBUG), 1)
-	CFLAGS += -g -O0 -DDMLC_LOG_FATAL_THROW=0
+	CFLAGS += -g -O0
 else
 	CFLAGS += -O3
 endif


### PR DESCRIPTION
test_symbol.py:test_zero_prop2 triggers and checks for an exception.  The current behavior of having LOG(FATAL) call abort()  when DEBUG=1 prevents the regression tests from completing in this case.