### PR TITLE
Fix memory error in threaded engine

### DIFF
--- a/src/engine/threaded_engine.cc
+++ b/src/engine/threaded_engine.cc
@@ -349,6 +349,7 @@ void ThreadedEngine::WaitForAll() {
 }
 
 inline void ThreadedEngine::OnComplete(ThreadedOpr* threaded_opr) {
+  bool is_temporary_opr = threaded_opr->temporary;
   // Mark complete for read variables
   for (auto&& i : threaded_opr->const_vars) {
     i->CompleteReadDependency([this](OprBlock* opr) {
@@ -376,6 +377,10 @@ inline void ThreadedEngine::OnComplete(ThreadedOpr* threaded_opr) {
       ThreadedVar::Delete(i);
     }
   }
+  // The function been pushed from `ThreadedEngine::DeleteOperator`
+  // could execute right after we mark all vars as complete, so if
+  // threaded_opr is not temporary, its value is not reliable
+  // anymore start from here.
   int npending;
   {
     std::unique_lock<std::mutex> lock{finished_m_};
@@ -388,7 +393,7 @@ inline void ThreadedEngine::OnComplete(ThreadedOpr* threaded_opr) {
   }
 
   // delte operator if it is temperory
-  if (threaded_opr->temporary) {
+  if (is_temporary_opr) {
     ThreadedOpr::Delete(threaded_opr);
   }
 }


### PR DESCRIPTION
This bug make mxnet frequently get segfault on my machine, after some debugging and code tracing I realized it happens in the following condition:
1. Executor calls [`DeleteOperator`](https://github.com/dmlc/mxnet/blob/a3045e2e9ea59da39236f65b4c687bbcdf7fa2cd/src/engine/threaded_engine.cc#L241-L256)
2. `DeleteOperator` pushes `ThreadedOpr::Delete(threaded_opr);` into the threaded engine.
3. But the write dependency of `ThreadedOpr::Delete(threaded_opr);` is not satisfied because operation `A` is using a dependent variable of `ThreadedOpr::Delete(threaded_opr);`, so `ThreadedOpr::Delete(threaded_opr)` waits `A`.
4. Operation `A` finishes and calls [`ThreadedEngine::OnComplete(A)`](https://github.com/dmlc/mxnet/blob/a3045e2e9ea59da39236f65b4c687bbcdf7fa2cd/src/engine/threaded_engine.cc#L351-L394).
5. We mark write dependencies of `A` as complete [(these code)](https://github.com/dmlc/mxnet/blob/a3045e2e9ea59da39236f65b4c687bbcdf7fa2cd/src/engine/threaded_engine.cc#L358-L378).
6. After step 5 [(this line)](https://github.com/dmlc/mxnet/blob/a3045e2e9ea59da39236f65b4c687bbcdf7fa2cd/src/engine/threaded_engine.cc#L378), the function pushed in step 2 may immediately execute, thus the object which `threaded_opr` points to is destroyed and the memory address may be occupied by other objects.
6. We read `threaded_opr->temporary` in [this line](https://github.com/dmlc/mxnet/blob/a3045e2e9ea59da39236f65b4c687bbcdf7fa2cd/src/engine/threaded_engine.cc#L391), and get a non-zero garbage value, then executes [ThreadedOpr::Delete(threaded_opr);](https://github.com/dmlc/mxnet/blob/a3045e2e9ea59da39236f65b4c687bbcdf7fa2cd/src/engine/threaded_engine.cc#L392) and destroy an innocent object `threaded_opr` points to. (Probably also a `threaded_opr` because object pool being used)

This patch fixes the issue.

cc original author @tqchen 