### PR TITLE
Fixed imdecode crash bug when flag=0

### DIFF
--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -123,7 +123,7 @@ void Imdecode(const nnvm::NodeAttrs& attrs,
                 param.flag == 0 ? CV_8U : CV_8UC3,
                 ndout.data().dptr_);
     res.copyTo(dst);
-    if (param.to_rgb) {
+    if (param.to_rgb && param.flag != 0) {
       cv::cvtColor(dst, dst, CV_BGR2RGB);
     }
     (*outputs)[0] = ndout;
@@ -145,7 +145,7 @@ void Imdecode(const nnvm::NodeAttrs& attrs,
 #endif
       CHECK(!dst.empty());
       CHECK_EQ(static_cast<void*>(dst.ptr()), ndout.data().dptr_);
-      if (param.to_rgb) {
+      if (param.to_rgb && param.flag != 0) {
         cv::cvtColor(dst, dst, CV_BGR2RGB);
       }
     }, ndout.ctx(), {ndin.var()}, {ndout.var()},


### PR DESCRIPTION
Fixed by checking for flag before cvtColor - issue https://github.com/dmlc/mxnet/issues/5793

Compiled and checked on my local machine. Do I need to run any tests?