### PR TITLE
Fix python3 compatibilities

### DIFF
--- a/example/autoencoder/autoencoder.py
+++ b/example/autoencoder/autoencoder.py
@@ -143,8 +143,8 @@ class AutoEncoderModel(model.MXModel):
             if i == 0:
                 data_iter_i = data_iter
             else:
-                X_i = model.extract_feature(self.internals[i-1], self.args, self.auxs,
-                                            data_iter, X.shape[0], self.xpu).values()[0]
+                X_i = list(model.extract_feature(self.internals[i-1], self.args, self.auxs,
+                                            data_iter, X.shape[0], self.xpu).values())[0]
                 data_iter_i = mx.io.NDArrayIter({'data': X_i}, batch_size=batch_size,
                                                 last_batch_handle='roll_over')
             logging.info('Pre-training layer %d...'%i)
@@ -167,6 +167,6 @@ class AutoEncoderModel(model.MXModel):
         batch_size = 100
         data_iter = mx.io.NDArrayIter({'data': X}, batch_size=batch_size, shuffle=False,
                                       last_batch_handle='pad')
-        Y = model.extract_feature(self.loss, self.args, self.auxs, data_iter,
-                                 X.shape[0], self.xpu).values()[0]
+        Y = list(model.extract_feature(self.loss, self.args, self.auxs, data_iter,
+                                 X.shape[0], self.xpu).values())[0]
         return np.mean(np.square(Y-X))/2.0

--- a/example/autoencoder/model.py
+++ b/example/autoencoder/model.py
@@ -46,11 +46,11 @@ class MXModel(object):
 
     def save(self, fname):
         args_save = {key: v.asnumpy() for key, v in self.args.items()}
-        with open(fname, 'w') as fout:
+        with open(fname, 'wb') as fout:
             pickle.dump(args_save, fout)
 
     def load(self, fname):
-        with open(fname) as fin:
+        with open(fname, 'rb') as fin:
             args_save = pickle.load(fin)
             for key, v in args_save.items():
                 if key in self.args:

--- a/example/dec/dec.py
+++ b/example/dec/dec.py
@@ -98,7 +98,7 @@ class DECModel(model.MXModel):
         test_iter = mx.io.NDArrayIter({'data': X}, batch_size=batch_size, shuffle=False,
                                       last_batch_handle='pad')
         args = {k: mx.nd.array(v.asnumpy(), ctx=self.xpu) for k, v in self.args.items()}
-        z = model.extract_feature(self.feature, args, None, test_iter, N, self.xpu).values()[0]
+        z = list(model.extract_feature(self.feature, args, None, test_iter, N, self.xpu).values())[0]
         kmeans = KMeans(self.num_centers, n_init=20)
         kmeans.fit(z)
         args['dec_mu'][:] = kmeans.cluster_centers_
@@ -113,7 +113,7 @@ class DECModel(model.MXModel):
         self.y_pred = np.zeros((X.shape[0]))
         def refresh(i):
             if i%update_interval == 0:
-                z = model.extract_feature(self.feature, args, None, test_iter, N, self.xpu).values()[0]
+                z = list(model.extract_feature(self.feature, args, None, test_iter, N, self.xpu).values())[0]
                 p = np.zeros((z.shape[0], self.num_centers))
                 self.dec_op.forward([z, args['dec_mu'].asnumpy()], [p])
                 y_pred = p.argmax(axis=1)

--- a/example/rcnn/rcnn/dataset/coco.py
+++ b/example/rcnn/rcnn/dataset/coco.py
@@ -190,7 +190,7 @@ class coco(IMDB):
         self._print_detection_metrics(coco_eval)
 
         eval_file = os.path.join(res_folder, 'detections_%s_results.pkl' % self.image_set)
-        with open(eval_file, 'w') as f:
+        with open(eval_file, 'wb') as f:
             cPickle.dump(coco_eval, f, cPickle.HIGHEST_PROTOCOL)
         print('coco eval results saved to %s' % eval_file)
 

--- a/example/rcnn/rcnn/dataset/pascal_voc_eval.py
+++ b/example/rcnn/rcnn/dataset/pascal_voc_eval.py
@@ -88,10 +88,10 @@ def voc_eval(detpath, annopath, imageset_file, classname, annocache, ovthresh=0.
             if ind % 100 == 0:
                 print('reading annotations for {:d}/{:d}'.format(ind + 1, len(image_filenames)))
         print('saving annotations cache to {:s}'.format(annocache))
-        with open(annocache, 'w') as f:
+        with open(annocache, 'wb') as f:
             cPickle.dump(recs, f, protocol=cPickle.HIGHEST_PROTOCOL)
     else:
-        with open(annocache, 'r') as f:
+        with open(annocache, 'rb') as f:
             recs = cPickle.load(f)
 
     # extract objects in :param classname:

--- a/example/reinforcement-learning/dqn/base.py
+++ b/example/reinforcement-learning/dqn/base.py
@@ -125,7 +125,7 @@ class Base(object):
         data_inputs = {k: mx.nd.empty(data_shapes[k], ctx=self.ctx)
                        for k in set(data_shapes.keys()) - set(self.learn_init_keys)}
         if len(self._buckets) > 0:
-            shared_exe = self._buckets.values()[0]['exe'].values()[0]
+            shared_exe = list(list(self._buckets.values())[0]['exe'].values())[0]
         else:
             shared_exe = None
         self._buckets[self.curr_bucket_key] = {

--- a/example/ssd/evaluate/eval_voc.py
+++ b/example/ssd/evaluate/eval_voc.py
@@ -93,10 +93,10 @@ def voc_eval(detpath, annopath, imageset_file, classname, cache_dir, ovthresh=0.
             if ind % 100 == 0:
                 print('reading annotations for {:d}/{:d}'.format(ind + 1, len(image_filenames)))
         print('saving annotations cache to {:s}'.format(cache_file))
-        with open(cache_file, 'w') as f:
+        with open(cache_file, 'wb') as f:
             pickle.dump(recs, f)
     else:
-        with open(cache_file, 'r') as f:
+        with open(cache_file, 'rb') as f:
             recs = pickle.load(f)
 
     # extract objects in :param classname:


### PR DESCRIPTION
**Two fixes for python3 compatibility:**

In python3 dict.values() yields a `dict_values` object which does not support indexing. It will throw
```
TypeError: 'dict_values' object does not support indexing
```

<br><br>
Python pickle file has always been a byte stream, but python3's strict separation of strings and bytes means files must be opened in binary mode. See python docs for examples:
http://docs.python.org/release/3.2/library/pickle.html#examples

Otherwise when pickling it will throw:
```
TypeError: must be str, not bytes
```

Which is a rather confusing error. See:
https://pythonconquerstheuniverse.wordpress.com/category/moving-to-python-3/
http://stackoverflow.com/questions/4980292/programming-python-for-absolute-beginners-chapter-7-storing-complex-data


