### PR TITLE
Fix for invalid numpy float indexing

### DIFF
--- a/example/dec/dec.py
+++ b/example/dec/dec.py
@@ -21,7 +21,7 @@ def cluster_acc(Y_pred, Y):
   D = max(Y_pred.max(), Y.max())+1
   w = np.zeros((D,D), dtype=np.int64)
   for i in range(Y_pred.size):
-    w[Y_pred[i], Y[i]] += 1
+    w[Y_pred[i], int(Y[i])] += 1
   ind = linear_assignment(w.max() - w)
   return sum([w[i,j] for i,j in ind])*1.0/Y_pred.size, w
 


### PR DESCRIPTION
Being able to index a numpy array using a float value has long since been deprecated and as of numpy 1.12 it is has been removed. It throws:
```
TypeError: 'numpy.float64' object cannot be interpreted as an index
```

Unfortunately, due to dynamic typing this will be a difficult bug to find all uses of.