### PR TITLE
Adding back all other OS install guide.

### DIFF
--- a/docs/get_started/amazonlinux_setup.md
+++ b/docs/get_started/amazonlinux_setup.md
@@ -1,0 +1,228 @@
+# Installing MXNet on Amazon Linux
+
+**NOTE:** For MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/get_started/install.html).
+
+Installing MXNet is a two-step process:
+
+1. Build the shared library from the MXNet C++ source code.
+2. Install the supported language-specific packages for MXNet.
+
+**Note:** To change the compilation options for your build, edit the ```make/config.mk``` file and submit a build request with the ```make``` command.
+
+## Build the Shared Library
+On Amazon Linux, you need the following dependencies:
+
+- Git (to pull code from GitHub)
+
+- libatlas-base-dev (for linear algebraic operations)
+
+- libopencv-dev (for computer vision operations)
+
+Install these dependencies using the following commands:
+
+```bash
+      # CMake is required for installing dependencies.
+      sudo yum install -y cmake
+
+      # Set appropriate library path env variables
+      echo 'export PATH=/usr/local/bin:$PATH' >> ~/.profile
+      echo 'export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH' >> ~/.profile
+      echo 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH' >> ~/.profile
+      echo '. ~/.profile' >> ~/.bashrc
+      source ~/.profile
+
+      # Install gcc-4.8/make and other development tools on Amazon Linux
+      # Reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/compile-software.html
+      # Install Python, Numpy, Scipy and set up tools.
+      sudo yum groupinstall -y "Development Tools"
+      sudo yum install -y python27 python27-setuptools python27-tools python-pip
+      sudo yum install -y python27-numpy python27-scipy python27-nose python27-matplotlib graphviz
+
+      # Install OpenBLAS at /usr/local/openblas
+      git clone https://github.com/xianyi/OpenBLAS
+      cd OpenBLAS
+      make FC=gfortran -j $(($(nproc) + 1))
+      sudo make PREFIX=/usr/local install
+      cd ..
+
+      # Install OpenCV at /usr/local/opencv
+      git clone https://github.com/opencv/opencv
+      cd opencv
+      mkdir -p build
+      cd build
+      cmake -D BUILD_opencv_gpu=OFF -D WITH_EIGEN=ON -D WITH_TBB=ON -D WITH_CUDA=OFF -D WITH_1394=OFF -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..
+      sudo make PREFIX=/usr/local install
+
+      # Install Graphviz for visualization and Jupyter notebook for running examples and tutorials
+      sudo pip install graphviz
+      sudo pip install jupyter
+
+      # Export env variables for pkg config
+      export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+```
+After installing the dependencies, use the following command to pull the MXNet source code from GitHub
+
+```bash
+    # Get MXNet source code
+    git clone https://github.com/dmlc/mxnet.git ~/mxnet --recursive
+    # Move to source code parent directory
+    cd ~/mxnet
+    cp make/config.mk .
+    echo "USE_BLAS=openblas" >>config.mk
+    echo "ADD_CFLAGS += -I/usr/include/openblas" >>config.mk
+    echo "ADD_LDFLAGS += -lopencv_core -lopencv_imgproc -lopencv_imgcodecs" >>config.mk
+```
+
+If building with ```GPU``` support, run below commands to add GPU dependency configurations to config.mk file:
+
+```bash
+    echo "USE_CUDA=1" >>config.mk
+    echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk
+    echo "USE_CUDNN=1" >>config.mk
+```
+
+Then build mxnet:
+
+```bash
+    make -j$(nproc)
+```
+
+Executing these commands creates a library called ```libmxnet.so```
+
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for the programming language of your choice:
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
+- [Perl](#install-the-mxnet-package-for-perl)
+
+## Install the MXNet Package for R
+Run the following commands to install the MXNet dependencies and build the MXNet R package.
+
+```r
+  Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')"
+```
+```bash
+  cd R-package
+  Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cran.rstudio.com')); install_deps(dependencies = TRUE)"
+  cd ..
+  make rpkg
+```
+
+**Note:** R-package is a folder in the MXNet source.
+
+These commands create the MXNet R package as a tar.gz file that you can install as an R package. To install the R package, run the following command, use your MXNet version number:
+
+```bash
+  R CMD INSTALL mxnet_current_r.tar.gz
+```
+
+## Install the MXNet Package for Julia
+The MXNet package for Julia is hosted in a separate repository, MXNet.jl, which is available on [GitHub](https://github.com/dmlc/MXNet.jl). To use Julia binding it with an existing libmxnet installation, set the ```MXNET_HOME``` environment variable by running the following command:
+
+```bash
+  export MXNET_HOME=/<path to>/libmxnet
+```
+
+The path to the existing libmxnet installation should be the root directory of libmxnet. In other words, you should be able to find the ```libmxnet.so``` file at ```$MXNET_HOME/lib```. For example, if the root directory of libmxnet is ```~```, you would run the following command:
+
+```bash
+  export MXNET_HOME=/~/libmxnet
+```
+
+You might want to add this command to your ```~/.bashrc``` file. If you do, you can install the Julia package in the Julia console using the following command:
+
+```julia
+  Pkg.add("MXNet")
+```
+
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+
+## Install the MXNet Package for Scala
+
+There are two ways to install the MXNet package for Scala:
+
+* Use the prebuilt binary package
+
+* Build the library from source code
+
+### Use the Prebuilt Binary Package
+For Linux users, MXNet provides prebuilt binary packages that support computers with either GPU or CPU processors. To download and build these packages using ```Maven```, change the ```artifactId``` in the following Maven dependency to match your architecture:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-full_<system architecture></artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+For example, to download and build the 64-bit CPU-only version for Linux, use:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-full_2.10-linux-x86_64-cpu</artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+If your native environment differs slightly from the assembly package, for example, if you use the openblas package instead of the atlas package, it's better to use the mxnet-core package and put the compiled Java native library in your load path:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-core_2.10</artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+### Build the Library from Source Code
+Before you build MXNet for Scala from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
+
+```bash
+  make scalapkg
+```
+
+This command creates the JAR files for the assembly, core, and example modules. It also creates the native library in the ```native/{your-architecture}/target directory```, which you can use to cooperate with the core module.
+
+To install the MXNet Scala package into your local Maven repository, run the following command from the MXNet source root directory:
+
+```bash
+  make scalainstall
+```
+
+## Install the MXNet Package for Perl
+
+Before you build MXNet for Scala from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
+
+```bash
+    ## install PDL, Graphviz, Mouse, App::cpanminus, swig via yum before running these commands
+    cpanm -q -L "${HOME}/perl5" Function::Parameters
+
+    MXNET_HOME=${PWD}
+    export LD_LIBRARY_PATH=${MXNET_HOME}/lib
+    export PERL5LIB=${HOME}/perl5/lib/perl5
+
+    cd ${MXNET_HOME}/perl-package/AI-MXNetCAPI/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make install
+
+    cd ${MXNET_HOME}/perl-package/AI-NNVMCAPI/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make install
+
+    cd ${MXNET_HOME}/perl-package/AI-MXNet/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make install
+```
+
+**Note -** You are more than welcome to contribute easy installation scripts for other operating systems and programming languages, see [community page](http://mxnet.io/community/index.html) for contributors guidelines.
+
+## Next Steps
+
+* [Tutorials](http://mxnet.io/tutorials/index.html)
+* [How To](http://mxnet.io/how_to/index.html)
+* [Architecture](http://mxnet.io/architecture/index.html)

--- a/docs/get_started/build_from_source.md
+++ b/docs/get_started/build_from_source.md
@@ -1,0 +1,425 @@
+# Build MXNet from Source
+
+**NOTE:** For MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/get_started/install.html).
+
+This document explains how to build MXNet from sources. Building MXNet from sources is a 2 step process.
+
+1. Build the MXNet shared library, `libmxnet.so`, from [C++ source files](#build-the-shared-library)
+2. Install the language binding for MXNet. MXNet supports -
+   [C++](#build-the-cpp-package),
+   [Scala](#build-the-scala-package), [R](#build-the-r-package), and
+   [Julia](#build-the-julia-package).
+
+## Build the shared library
+
+### Prerequisites
+
+You need C++ build tools and BLAS library to build MXNet shared library. If you want to run MXNet on GPUs, you need to install CUDA and CuDNN.
+
+#### C++ build tools
+
+1. A C++ compiler that supports C++ 11.
+[G++ (4.8 or later)](https://gcc.gnu.org/gcc-4.8/) or
+[Clang](http://clang.llvm.org/) is required.
+
+2. [Git](https://git-scm.com/downloads) for downloading the sources from Github repository.
+
+3. [GNU Make](https://www.gnu.org/software/make/) ([cmake](https://cmake.org/)
+   for Windows) to build the library.
+
+
+Select your preferences and follow the instructions to install MXNet from sources.
+<div class="btn-group opt-group" role="group">
+<button type="button" class="btn btn-default opt active">Linux</button>
+<button type="button" class="btn btn-default opt">macOS</button>
+<button type="button" class="btn btn-default opt">Windows</button>
+</div>
+<script type="text/javascript" src='../../_static/js/options.js'></script>
+
+<div class="linux">
+
+Then select the Linux distribution:
+<div class="btn-group opt-group" role="group">
+<button type="button" class="btn btn-default opt active">Ubuntu</button>
+<button type="button" class="btn btn-default opt">CentOS</button>
+<button type="button" class="btn btn-default opt">Others</button>
+</div>
+
+- **Ubuntu** for systems supporting the `apt-get`
+  package management program
+- **CentOS** for systems supporting the `yum` package
+  management program
+- **Others** for general Linux-like systems building dependencies from scratch.
+
+<div class="ubuntu">
+
+Install build tools and git on `Ubuntu >= 13.10` and `Debian >= 8`.
+
+```bash
+sudo apt-get update && sudo apt-get install build-essential git
+```
+
+</div>
+
+<div class="centos">
+
+Install build tools and git on `CentOS >= 7` and `Fedora >= 19`.
+
+```bash
+sudo yum groupinstall -y "Development Tools" && sudo yum install -y git
+```
+
+</div>
+
+<div class="others">
+
+Installing both `git` and `make` by following instructions on the websites is
+straightforward. Here we provide the instructions to build `gcc-4.8` from source codes.
+
+1. Install the 32-bit `libc` with one of the following system-specific commands:
+
+   ```bash
+   sudo apt-get install libc6-dev-i386 # In Ubuntu
+   sudo yum install glibc-devel.i686   # In RHEL (Red Hat Linux)
+   sudo yum install glibc-devel.i386   # In CentOS 5.8
+   sudo yum install glibc-devel.i686   # In CentOS 6/7
+   ```
+
+2. Download and extract the `gcc` source code with the prerequisites:
+
+   ```bash
+   wget http://mirrors.concertpass.com/gcc/releases/gcc-4.8.5/gcc-4.8.5.tar.gz
+   tar -zxf gcc-4.8.5.tar.gz
+   cd gcc-4.8.5
+   ./contrib/download_prerequisites
+   ```
+
+3. Build `gcc` by using 10 threads and then install to `/usr/local`
+
+   ```bash
+   mkdir release && cd release
+   ../configure --prefix=/usr/local --enable-languages=c,c++
+   make -j10
+   sudo make install
+   ```
+
+4. Add the lib path to your configure file such as `~/.bashrc`:
+
+   ```bash
+   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib64
+   ```
+
+</div>
+</div> <!-- linux -->
+
+<div class="windows">
+
+1. If [Microsoft Visual Studio 2015](https://www.visualstudio.com/downloads/) is not already installed, download and install it. You can download and install the free community edition.
+2. Download and Install [CMake](https://cmake.org/) if it is not already installed.
+
+</div>
+
+<div class="macos">
+
+Install [Xcode](https://developer.apple.com/xcode/).
+
+</div>
+
+#### BLAS library
+
+MXNet relies on the
+[BLAS](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) (Basic
+Linear Algebra Subprograms) library for numerical computations. You can install
+any one among [ATLAS](http://math-atlas.sourceforge.net/),
+[OpenBLAS](http://www.openblas.net/) and
+[MKL](https://software.intel.com/en-us/intel-mkl).
+
+<div class="linux">
+<div class="ubuntu">
+
+```bash
+sudo apt-get install libatlas-base-dev
+```
+
+</div>
+
+<div class="centos">
+
+```bash
+sudo yum install atlas-devel
+```
+
+</div>
+
+<div class="linux">
+
+You can follow this link to build
+[OpenBlas from source](https://github.com/xianyi/OpenBLAS#installation-from-source).
+
+</div>
+</div>
+
+<div class="macos">
+
+macOS users can skip this step as `xcode` ships with a BLAS library.
+
+</div>
+
+<div class="windows">
+
+1. Download pre-built binaries for [OpenBLAS](https://sourceforge.net/projects/openblas/files/)
+2. Set the environment variable `OpenBLAS_HOME` to point to the OpenBLAS
+   directory that contains the `include/` and `lib/` directories. Typically, you
+   can find the directory in `C:\Program files (x86)\OpenBLAS\`.
+
+</div>
+
+#### Optional: [OpenCV](http://opencv.org/) for Image Loading and Augmentation
+
+<div class="linux">
+<div class="ubuntu">
+
+```bash
+sudo apt-get install libopencv-dev
+```
+
+</div>
+
+<div class="centos">
+
+```bash
+sudo apt-get install opencv-devel
+```
+
+</div>
+
+<div class="others">
+
+To build OpenCV from source code, you need the [cmake](https://cmake.org) library.
+
+1. If you don't have cmake or if your version of cmake is earlier than 3.6.1, run the following commands to install a newer version of cmake:
+
+   ```bash
+   wget https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz
+   tar -zxvf cmake-3.6.1-Linux-x86_64.tar.gz
+   alias cmake="cmake-3.6.1-Linux-x86_64/bin/cmake"
+   ```
+
+2. To download and extract the OpenCV source code, run the following commands:
+
+   ```bash
+   wget https://codeload.github.com/opencv/opencv/zip/2.4.13
+   unzip 2.4.13
+   cd opencv-2.4.13
+   mkdir release
+   cd release/
+   ```
+
+3. Build OpenCV. The following commands build OpenCV with 10 threads. We
+   disabled GPU support, which might significantly slow down an MXNet program
+   running on a GPU processor. It also disables 1394 which might generate a
+   warning. Then install it on `/usr/local`.
+
+   ```bash
+   cmake -D BUILD_opencv_gpu=OFF -D WITH_CUDA=OFF -D WITH_1394=OFF -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..
+   make -j10
+   sudo make install
+   ```
+
+4. Add the lib path to your configuration such as `~/.bashrc`.
+
+   ```bash
+   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig/
+   ```
+
+</div>
+</div>
+
+<div class="windows">
+
+First download and install [OpenCV](http://opencv.org/releases.html), then set
+the environment variable `OpenCV_DIR` to point to the OpenCV build directory.
+
+</div>
+
+#### Optional: [CUDA](https://developer.nvidia.com/cuda-downloads)/[cuDNN](https://developer.nvidia.com/cudnn) for Nvidia GPUs
+
+MXNet is compatible with both CUDA 7.5 and 8.0. It is recommended to use cuDNN 5.
+
+<div class="linux">
+<div class="ubuntu">
+
+Install CUDA 7.5 and cuDNN 5 on Ubuntu 14.04
+
+```bash
+wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/cuda-repo-ubuntu1404_7.5-18_amd64.deb
+sudo dpkg -i cuda-repo-ubuntu1404_7.5-18_amd64.deb
+echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1404/x86_64 /" | sudo tee /etc/apt/sources.list.d/nvidia-ml.list
+sudo apt-get update
+sudo apt-get install -y linux-image-extra-`uname -r` linux-headers-`uname -r` linux-image-`uname -r`
+sudo apt-get install -y cuda libcudnn5-dev=5.0.5-1+cuda7.5
+```
+
+</div>
+</div>
+
+### Build
+
+<div class="linux macos">
+
+First clone the recent codes
+
+```bash
+git clone --recursive https://github.com/dmlc/mxnet
+cd mxnet
+```
+
+File
+[`make/config.mk`](https://github.com/dmlc/mxnet/blob/master/make/config.mk)
+contains all the compilation options. You can edit it and then `make`. There are
+some example build options
+
+If you want to build MXNet with C++ language binding, please make sure you read [Build the C++ package](#build-the-cpp-package) first.
+
+</div>
+
+<div class="linux">
+
+- Build without using OpenCV. `-j` runs multiple jobs against multi-core CPUs.
+
+  ```bash
+  make -j USE_OPENCV=0
+  ```
+
+- Build with both GPU and OpenCV support
+
+  ```bash
+  make -j USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1
+  ```
+
+</div>
+
+<div class="macos">
+
+- Build with the default BLAS library and clang installed with `xcode` (OPENMP
+  is disabled because it is not supported in default by clang).
+
+  ```bash
+  make -j USE_BLAS=apple USE_OPENCV=0 USE_OPENMP=0
+  ```
+
+</div>
+
+<div class="windows">
+
+Use [CMake](https://cmake.org/) to create a Visual Studio solution in ```./build```.
+
+In Visual Studio, open the solution file,```.sln```, and compile it.
+These commands produce a library called ```mxnet.dll``` in the ```./build/Release/``` or ```./build/Debug``` folder.
+
+</div>
+
+## Build the C++ package
+The C++ package has the same prerequisites as the MXNet library, you should also have `python` 2 installed. (`python` 3 is not supported currently)
+
+To enable C++ package, just add `USE_CPP_PACKAGE=1` in the build options when building the MXNet shared library.
+
+## Build the R package
+
+The R package requires `R` to be installed.
+
+<div class="ubuntu">
+
+Follow the below instructions to install the latest R on Ubuntu 14.04 (trusty) and also the libraries used
+to build other R package dependencies.
+
+```bash
+echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list
+gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
+gpg -a --export E084DAB9 | apt-key add -
+
+apt-get update
+apt-get install -y r-base r-base-dev libxml2-dev libxt-dev libssl-dev
+```
+
+</div>
+
+Install the required R package dependencies:
+
+```bash
+cd R-package
+Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')"
+Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cran.rstudio.com')); install_deps(dependencies = TRUE)"
+```
+
+Next, build and install the MXNet R package:
+
+```bash
+cd ..
+make rpkg
+R CMD INSTALL mxnet_current_r.tar.gz
+```
+
+## Build the Scala package
+
+Both JDK and Maven are required to build the Scala package.
+
+<div class="ubuntu">
+
+```bash
+sudo apt-get install -y maven default-jdk
+```
+
+</div>
+
+The following command builds the `.jar` package:
+
+```bash
+make scalapkg
+```
+
+which can be found by `ls scala-package/assembly/*/target/*SNAPSHOT.jar`.
+
+Optionally, we can install Scala for the interactive interface.
+
+<div class="ubuntu">
+
+```bash
+wget http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.deb
+dpkg -i scala-2.11.8.deb
+rm scala-2.11.8.deb
+```
+
+</div>
+
+Then we can start `scala` with `mxnet` imported by
+
+```bash
+scala -cp scala-package/assembly/*/target/*SNAPSHOT.jar
+```
+
+## Build the Julia package
+
+We need to first install Julia.
+
+<div class="ubuntu centos linux">
+
+The following commands install Julia 0.5.1
+
+```bash
+wget -q https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.1-linux-x86_64.tar.gz
+tar -zxf julia-0.5.1-linux-x86_64.tar.gz
+rm julia-0.5.1-linux-x86_64.tar.gz
+ln -s $(pwd)/julia-6445c82d00/bin/julia /usr/bin/julia
+```
+
+</div>
+
+Next set the environment variable `MXNET_HOME=/path/to/mxnet` so that Julia
+can find the pre-built library.
+
+Install the Julia package for MXNet with:
+
+```bash
+julia -e 'Pkg.add("MXNet")'
+```

--- a/docs/get_started/centos_setup.md
+++ b/docs/get_started/centos_setup.md
@@ -1,0 +1,160 @@
+# Installing MXNet on CentOS
+
+**NOTE:** For MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/get_started/install.html).
+
+MXNet currently supports Python, R, Julia, Scala, and Perl. For users on CentOS with Docker environment, MXNet provides [Docker installation guide](http://mxnet.io/get_started/docker_setup.html). If you do not have a Docker environment set up, follow below-provided step by step instructions.
+
+
+## Minimum Requirements
+Make sure you have the root permission, and `yum` is properly installed. Check it using the following command:
+
+```bash
+sudo yum check-update
+```
+If you don't get an error message, then `yum` is installed.
+
+**To install MXNet on CentOS, you must have the following:**
+
+1. gcc, g++ (4.8 or later)
+2. python2, python-numpy, python-pip, clang
+3. graphviz, jupyter (pip or yum install)
+4. OpenBLAS
+5. CUDA for GPU
+6. cmake and opencv (do not use yum to install opencv, some shared libs may not be installed)
+
+## Install Dependencies
+Make sure your machine is connected to Internet. A few installations need to download (`git clone` or `wget`) some packages from Internet.
+
+### Install Basic Environment
+```bash
+	# Install gcc-4.8/make and other development tools
+	sudo yum install -y gcc
+	sudo yum install -y gcc-c++
+	sudo yum install -y clang
+
+	# Install Python, Numpy, pip and set up tools.
+	sudo yum groupinstall -y "Development Tools"
+	sudo yum install -y python27 python27-setuptools python27-tools python-pip
+	sudo yum install -y python27-numpy
+
+	# install graphviz, jupyter
+	sudo pip install graphviz
+	sudo pip install jupyter
+```
+### Install OpenBLAS
+Note that OpenBLAS can be replaced by other BLAS libs, e.g, Intel MKL.
+
+```bash
+	# Install OpenBLAS at /usr/local/openblas
+	git clone https://github.com/xianyi/OpenBLAS
+	cd OpenBLAS
+	make -j $(($(nproc) + 1))
+	sudo make PREFIX=/usr/local install
+	cd ..
+```
+### Install CUDA for GPU
+Note: Setting up CUDA is optional for MXNet. If you do not have a GPU machine (or if you want to train with CPU), you can skip this section and proceed with installation of OpenCV.
+
+If you plan to build with GPU, you need to set up the environment for CUDA and CUDNN.
+
+First, download and install [CUDA 8 toolkit](https://developer.nvidia.com/cuda-toolkit).
+
+Then download [cudnn 5](https://developer.nvidia.com/cudnn).
+
+Unzip the file and change to the cudnn root directory. Move the header and libraries to your local CUDA Toolkit folder:
+
+```bash
+    tar xvzf cudnn-8.0-linux-x64-v5.1-ga.tgz
+    sudo cp -P cuda/include/cudnn.h /usr/local/cuda/include
+    sudo cp -P cuda/lib64/libcudnn* /usr/local/cuda/lib64
+    sudo chmod a+r /usr/local/cuda/include/cudnn.h /usr/local/cuda/lib64/libcudnn*
+    sudo ldconfig
+```
+### Install opencv
+Note: Setting up opencv is optional but strongly recommended for MXNet, unless you do not want to work on Computer Vision and Image Augmentation. If you are quite sure about that, skip this section and  set `USE_OPENCV = 0` in `config.mk`.
+
+The Open Source Computer Vision (OpenCV) library contains programming functions for computer vision and image augmentation. For more information, see [OpenCV](https://en.wikipedia.org/wiki/OpenCV).
+
+```bash
+	# Install cmake for building opencv
+	sudo yum install -y cmake
+	# Install OpenCV at /usr/local/opencv
+	git clone https://github.com/opencv/opencv
+	cd opencv
+	mkdir -p build
+	cd build
+	cmake -D BUILD_opencv_gpu=OFF -D WITH_EIGEN=ON -D WITH_TBB=ON -D WITH_CUDA=OFF -D WITH_1394=OFF -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..
+	sudo make PREFIX=/usr/local install
+```
+
+## Install MXNet
+
+### Build MXNet shared library
+After installing the dependencies, use the following command to pull the MXNet source code from GitHub.
+
+```bash
+    # Download MXNet source code to ~/mxnet directory
+    git clone https://github.com/dmlc/mxnet.git ~/mxnet --recursive
+    # Move to source code parent directory
+    cd ~/mxnet
+    cp make/config.mk .
+    # Replace this line if you use other BLAS libs
+    echo "USE_BLAS=openblas" >>config.mk
+    echo "ADD_CFLAGS += -I/usr/include/openblas" >>config.mk
+    echo "ADD_LDFLAGS += -lopencv_core -lopencv_imgproc -lopencv_imgcodecs" >>config.mk
+```
+
+If building with ```GPU``` support, run below commands to add GPU dependency configurations to `config.mk` file:
+
+```bash
+    echo "USE_CUDA=1" >>config.mk
+    echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk
+    echo "USE_CUDNN=1" >>config.mk
+```
+
+Then build mxnet:
+
+```bash
+    make -j$(nproc)
+```
+
+Executing these commands creates a library called ```libmxnet.so``` in `~/mxnet/lib/`.
+
+### Install MXNet for R, Julia, Scala, and Perl.
+
+- [R](http://mxnet.io/get_started/amazonlinux_setup.html#install-the-mxnet-package-for-r)
+- [Julia](http://mxnet.io/get_started/amazonlinux_setup.html#install-the-mxnet-package-for-julia)
+- [Scala](http://mxnet.io/get_started/amazonlinux_setup.html#install-the-mxnet-package-for-scala)
+- [Perl](http://mxnet.io/get_started/amazonlinux_setup.html#install-the-mxnet-package-for-perl)
+
+## Troubleshooting
+
+Here is some information to help you troubleshoot, in case you encounter error messages:
+
+**1. Cannot build opencv from source code**
+
+This may be caused by download failure during building, e.g., `ippicv`.
+
+Prepare some large packages by yourself, then copy them to the right place, e.g, `opencv/3rdparty/ippicv/downloads/linux-808XXXXXXXXX/`.
+
+**2. Link errors when building MXNet**
+
+```bash
+/usr/bin/ld: /tmp/ccQ9qruP.o: undefined reference to symbol '_ZN2cv6String10deallocateEv'
+/usr/local/lib/libopencv_core.so.3.2: error adding symbols: DSO missing from command line
+```
+This error occurs when you already have old opencv (e.g, 2.4) installed using `yum` (in `/usr/lib64`). When g++ tries to link opencv libs, it will first find and link old opencv libs in `/usr/lib64`.
+
+Please modify `config.mk` in `mxnet` directory, and add `-L/usr/local/lib` to `ADD_CFLAGS`.
+
+```bash
+	ADD_CFLAGS += -I/usr/include/openblas -L/usr/local/lib
+```
+This solution solves this link error, but there are still lots of warnings.
+
+
+## Next Steps
+
+* [Tutorials](http://mxnet.io/tutorials/index.html)
+* [How To](http://mxnet.io/how_to/index.html)
+* [Architecture](http://mxnet.io/architecture/index.html)

--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -1,20 +1,3 @@
-<!-- START - Cloud Python Installation Instructions -->
-
-<div class="cloud">
-  <div class="python">
-
-AWS Marketplace distributes AMIs (Amazon Machine Image) with MXNet pre-installed. You can launch an Amazon EC2 instance with one of the below AMIs:
-1. Deep Learning AMI (Amazon Machine Image) for [Ubuntu](https://aws.amazon.com/marketplace/pp/B06VSPXKDX)
-2. Deep Learning AMI for [Amazon Linux](https://aws.amazon.com/marketplace/pp/B01M0AXXQB)
-
-You could also run distributed deeplearning with *MXNet* on AWS using [Cloudformation Template](https://github.com/awslabs/deeplearning-cfn/blob/master/README.md).
-
-</div>
-</div>
-
-<!-- END - Cloud Python Installation Instructions -->
-
-
 # Installing MXNet
 
 Indicate your preferred configuration. Then, follow the customized commands to install *MXNet*.

--- a/docs/get_started/osx_setup.md
+++ b/docs/get_started/osx_setup.md
@@ -1,0 +1,221 @@
+# Installing MXNet on OS X (Mac)
+
+**NOTE:** For MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/get_started/install.html).
+
+Installing MXNet is a two-step process:
+
+1. Build the shared library from the MXNet C++ source code.
+2. Install the supported language-specific packages for MXNet.
+
+**Note:** To change the compilation options for your build, edit the ```make/config.mk``` file and submit a build request with the ```make``` command.
+
+## Prepare Environment for GPU Installation
+
+This section is optional. Skip to next section if you don't plan to use GPUs. If you plan to build with GPU, you need to set up the environment for CUDA and cuDNN.
+
+First, download and install [CUDA 8 toolkit](https://developer.nvidia.com/cuda-toolkit).
+
+Once you have the CUDA Toolkit installed you will need to set up the required environment variables by adding the following to your ~/.bash_profile file:
+
+```bash
+    export CUDA_HOME=/usr/local/cuda
+    export DYLD_LIBRARY_PATH="$CUDA_HOME/lib:$DYLD_LIBRARY_PATH"
+    export PATH="$CUDA_HOME/bin:$PATH"
+```
+
+Reload ~/.bash_profile file and install dependencies:
+```bash
+    . ~/.bash_profile
+    brew install coreutils
+    brew tap caskroom/cask
+```
+
+Then download [cuDNN 5](https://developer.nvidia.com/cudnn).
+
+Unzip the file and change to the cudnn root directory. Move the header files and libraries to your local CUDA Toolkit folder:
+
+```bash
+    $ sudo mv include/cudnn.h /Developer/NVIDIA/CUDA-8.0/include/
+    $ sudo mv lib/libcudnn* /Developer/NVIDIA/CUDA-8.0/lib
+    $ sudo ln -s /Developer/NVIDIA/CUDA-8.0/lib/libcudnn* /usr/local/cuda/lib/
+```
+
+Now we can start to build MXNet.
+
+## Build the Shared Library
+
+### Install MXNet dependencies
+Install the dependencies, required for MXNet, with the following commands:
+- [Homebrew](http://brew.sh/)
+- OpenBLAS and homebrew/science (for linear algebraic operations)
+- OpenCV (for computer vision operations)
+
+```bash
+	# Paste this command in Mac terminal to install Homebrew
+	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+	# Insert the Homebrew directory at the top of your PATH environment variable
+	export PATH=/usr/local/bin:/usr/local/sbin:$PATH
+```
+
+```bash
+	brew update
+	brew install pkg-config
+	brew install graphviz
+	brew install openblas
+	brew tap homebrew/science
+	brew install opencv
+	# For getting pip
+	brew install python
+	# For visualization of network graphs
+	pip install graphviz
+	# Jupyter notebook
+	pip install jupyter
+```
+
+### Build MXNet Shared Library
+After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```.
+
+The file called ```osx.mk``` has the configuration required for building MXNet on OS X. First copy ```make/osx.mk``` into ```config.mk```, which is used by the ```make``` command:
+
+```bash
+    git clone --recursive https://github.com/dmlc/mxnet ~/mxnet
+    cd ~/mxnet
+    cp make/osx.mk ./config.mk
+    echo "USE_BLAS = openblas" >> ./config.mk
+    echo "ADD_CFLAGS += -I/usr/local/opt/openblas/include" >> ./config.mk
+    echo "ADD_LDFLAGS += -L/usr/local/opt/openblas/lib" >> ./config.mk
+    echo "ADD_LDFLAGS += -L/usr/local/lib/graphviz/" >> ./config.mk
+    make -j$(sysctl -n hw.ncpu)
+```
+
+If building with ```GPU``` support, add the following configuration to config.mk and build:
+```bash
+    echo "USE_CUDA = 1" >> ./config.mk
+    echo "USE_CUDA_PATH = /usr/local/cuda" >> ./config.mk
+    echo "USE_CUDNN = 1" >> ./config.mk
+    make
+```
+**Note:** To change build parameters, edit ```config.mk```.
+
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for the programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
+- [Perl](#install-the-mxnet-package-for-perl)
+
+## Install the MXNet Package for R
+You have 2 options:
+1. Building MXNet with the Prebuilt Binary Package
+2. Building MXNet from Source Code
+
+### Building MXNet with the Prebuilt Binary Package
+
+For OS X (Mac) users, MXNet provides a prebuilt binary package for CPUs. The prebuilt package is updated weekly. You can install the package directly in the R console using the following commands:
+
+```r
+	install.packages("drat", repos="https://cran.rstudio.com")
+	drat:::addRepo("dmlc")
+	install.packages("mxnet")
+```
+
+### Building MXNet from Source Code
+
+Run the following commands to install the MXNet dependencies and build the MXNet R package.
+
+```r
+    Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')"
+```
+```bash
+    cd R-package
+    Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cran.rstudio.com')); install_deps(dependencies = TRUE)"
+    cd ..
+    make rpkg
+```
+
+**Note:** R-package is a folder in the MXNet source.
+
+These commands create the MXNet R package as a tar.gz file that you can install as an R package. To install the R package, run the following command, use your MXNet version number:
+
+```bash
+	R CMD INSTALL mxnet_current_r.tar.gz
+```
+
+## Install the MXNet Package for Julia
+The MXNet package for Julia is hosted in a separate repository, MXNet.jl, which is available on [GitHub](https://github.com/dmlc/MXNet.jl). To use Julia binding it with an existing libmxnet installation, set the ```MXNET_HOME``` environment variable by running the following command:
+
+```bash
+	export MXNET_HOME=/<path to>/libmxnet
+```
+
+The path to the existing libmxnet installation should be the root directory of libmxnet. In other words, you should be able to find the ```libmxnet.so``` file at ```$MXNET_HOME/lib```. For example, if the root directory of libmxnet is ```~```, you would run the following command:
+
+```bash
+	export MXNET_HOME=/~/libmxnet
+```
+
+You might want to add this command to your ```~/.bashrc``` file. If you do, you can install the Julia package in the Julia console using the following command:
+
+```julia
+	Pkg.add("MXNet")
+```
+
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+
+## Install the MXNet Package for Scala
+Before you build MXNet for Scala from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
+
+```bash
+    make scalapkg
+```
+
+This command creates the JAR files for the assembly, core, and example modules. It also creates the native library in the ```native/{your-architecture}/target directory```, which you can use to cooperate with the core module.
+
+To install the MXNet Scala package into your local Maven repository, run the following command from the MXNet source root directory:
+
+```bash
+    make scalainstall
+```
+
+## Install the MXNet Package for Perl
+Before you build MXNet for Perl from source code, you must complete [building the shared library](#build-the-shared-library).
+After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Perl package:
+
+```bash
+    brew install swig
+    sudo sh -c 'curl -L https://cpanmin.us | perl - App::cpanminus'
+    sudo cpanm -q -n PDL Mouse Function::Parameters
+
+    MXNET_HOME=${PWD}
+    export PERL5LIB=${HOME}/perl5/lib/perl5
+
+    cd ${MXNET_HOME}/perl-package/AI-MXNetCAPI/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make
+    install_name_tool -change lib/libmxnet.so \
+        ${MXNET_HOME}/lib/libmxnet.so \
+        blib/arch/auto/AI/MXNetCAPI/MXNetCAPI.bundle
+    make install
+
+    cd ${MXNET_HOME}/perl-package/AI-NNVMCAPI/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make
+    install_name_tool -change lib/libmxnet.so \
+            ${MXNET_HOME}/lib/libmxnet.so \
+            blib/arch/auto/AI/NNVMCAPI/NNVMCAPI.bundle
+    make install
+
+    cd ${MXNET_HOME}/perl-package/AI-MXNet/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make install
+```
+
+## Next Steps
+
+* [Tutorials](http://mxnet.io/tutorials/index.html)
+* [How To](http://mxnet.io/how_to/index.html)
+* [Architecture](http://mxnet.io/architecture/index.html)

--- a/docs/get_started/raspbian_setup.md
+++ b/docs/get_started/raspbian_setup.md
@@ -1,0 +1,74 @@
+# Installing MXNet on Raspbian
+MXNet currently supports the Debian based Raspbian operating system so you can run MXNet on Raspberry Pi Devices.
+
+These instructions will walk through how to build MXNet for the Raspberry Pi and install the Python bindings for the library.
+
+The full MXNet library is over 200MB when loaded into memory and the requirements can take almost 1GB of disk space. Due to the size we currently recommend running MXNet on the Raspberry Pi 3 or equivalent devices with more than 1GB of RAM and with an SD card that has at least 4 GB of memory free. The Raspberry Pi 1, 2, Zero and other devices with less than 1GB of RAM are not sufficient to run the full MXNet library (though they can run the MXNet amalgamation library). 
+
+The complete MXNet library and its requirements can take almost 200MB of RAM, and loading large models with the library can take over 1GB of RAM. Because of this, we recommend running MXNet on the Raspberry Pi 3 or an equivalent device that has more than 1 GB of RAM and a Secure Digital (SD) card that has at least 4 GB of free memory. The Raspberry Pi 1, 2, Zero and other devices with less than 1 GB of RAM cannot run the complete MXNet library.
+
+## Installing MXNet
+
+Installing MXNet is a two-step process:
+
+1. Build the shared library from the MXNet C++ source code.
+2. Install the supported language-specific packages for MXNet.
+
+### Build the Shared Library
+
+On Raspbian versions Wheezy and later, you need the following dependencies:
+
+- Git (to pull code from GitHub)
+
+- libblas (for linear algebraic operations)
+
+- libopencv (for computer vision operations. This is optional if you want to save RAM and Disk Space)
+
+- A C++ compiler that supports C++ 11. The C++ compiler compiles and builds MXNet source code. Supported compilers include the following:
+
+- [G++ (4.8 or later)](https://gcc.gnu.org/gcc-4.8/)
+
+Install these dependencies using the following commands in any directory:
+
+```bash
+    sudo apt-get update
+    sudo apt-get -y install git cmake build-essential g++-4.8 c++-4.8 liblapack* libblas* libopencv*
+```
+
+Clone the MXNet source code repository using the following ```git``` command in your home directory:
+```bash
+    git clone https://github.com/dmlc/mxnet.git --recursive
+    cd mxnet
+```
+
+If you aren't processing images with MXNet on the Raspberry Pi, you can minimize the size of the compiled library by building MXNet without the Open Source Computer Vision (OpenCV) library with the following commands:
+```bash
+    export USE_OPENCV = 0
+    make
+```
+
+Otherwise, you can build the complete MXNet library with the following command: 
+```bash
+    make
+```
+
+Executing either of these commands creates a file called ```libmxnet.so``` in the mxnet/lib directory.
+
+*Note - If you are getting build errors it is likely you are on an older version of MXNet, and there are x86 specific -msse CFLAGS hardcoded in the project Makefile or one of the submodule Makefiles that need to be manually removed.*
+
+## Install MXNet Python Bindings
+
+To install python bindings run the following commands in the MXNet directory:
+
+```bash
+    cd python
+    sudo python setup.py install
+```
+
+You are now ready to run MXNet on your Raspberry Pi device.
+
+*Note - Because the complete MXNet library takes up a significant amount of the Raspberry Pi's limited RAM, when loading training data or large models into memory, you might have to turn off the GUI and terminate running processes to free RAM.*
+
+## Next Steps
+
+* [Tutorials](http://mxnet.io/tutorials/index.html#embedded)

--- a/docs/get_started/ubuntu_setup.md
+++ b/docs/get_started/ubuntu_setup.md
@@ -1,0 +1,264 @@
+# Installing MXNet on Ubuntu
+
+**NOTE:** For MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/get_started/install.html).
+
+MXNet currently supports Python, R, Julia, Scala, and Perl. For users of R on Ubuntu operating systems, MXNet provides a set of Git Bash scripts that installs all of the required MXNet dependencies and the MXNet library.
+
+The simple installation scripts set up MXNet for Python and R on computers running Ubuntu 12 or later. The scripts install MXNet in your home folder ```~/mxnet```.
+
+## Prepare environment for GPU Installation
+
+If you plan to build with GPU, you need to set up the environment for CUDA and CUDNN.
+
+First, download and install [CUDA 8 toolkit](https://developer.nvidia.com/cuda-toolkit).
+
+Then download [cudnn 5](https://developer.nvidia.com/cudnn).
+
+Unzip the file and change to the cudnn root directory. Move the header and libraries to your local CUDA Toolkit folder:
+
+```bash
+    tar xvzf cudnn-8.0-linux-x64-v5.1-ga.tgz
+    sudo cp -P cuda/include/cudnn.h /usr/local/cuda/include
+    sudo cp -P cuda/lib64/libcudnn* /usr/local/cuda/lib64
+    sudo chmod a+r /usr/local/cuda/include/cudnn.h /usr/local/cuda/lib64/libcudnn*
+    sudo ldconfig
+```
+
+Finally, add configurations to config.mk file:
+
+```bash
+    cp make/config.mk .
+```
+
+## Quick Installation
+
+### Install MXNet for R
+
+MXNet requires R-version to be 3.2.0 and above. If you are running an earlier version of R, run below commands to update your R version, before running the installation script.
+
+```bash
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+    sudo add-apt-repository ppa:marutter/rdev
+
+    sudo apt-get update
+    sudo apt-get upgrade
+    sudo apt-get install r-base r-base-dev
+```
+
+To install MXNet for R:
+
+```bash
+    # Clone mxnet repository. In terminal, run the commands WITHOUT "sudo"
+    git clone https://github.com/dmlc/mxnet.git ~/mxnet --recursive
+
+    cd ~/mxnet
+    cp make/config.mk .
+    # If building with GPU, add configurations to config.mk file:
+    echo "USE_CUDA=1" >>config.mk
+    echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk
+    echo "USE_CUDNN=1" >>config.mk
+
+    cd ~/mxnet/setup-utils
+    bash install-mxnet-ubuntu-r.sh
+```
+The installation script to install MXNet for R can be found [here](https://raw.githubusercontent.com/dmlc/mxnet/master/setup-utils/install-mxnet-ubuntu-r.sh).
+
+## Standard installation
+
+Installing MXNet is a two-step process:
+
+1. Build the shared library from the MXNet C++ source code.
+2. Install the supported language-specific packages for MXNet.
+
+**Note:** To change the compilation options for your build, edit the ```make/config.mk``` file and submit a build request with the ```make``` command.
+
+### Build the Shared Library
+
+On Ubuntu versions 13.10 or later, you need the following dependencies:
+
+- Git (to pull code from GitHub)
+
+- libatlas-base-dev (for linear algebraic operations)
+
+- libopencv-dev (for computer vision operations)
+
+Install these dependencies using the following commands:
+
+```bash
+    sudo apt-get update
+    sudo apt-get install -y build-essential git libatlas-base-dev libopencv-dev
+```
+
+After installing the dependencies, use the following command to pull the MXNet source code from GitHub
+
+```bash
+    # Get MXNet source code
+    git clone https://github.com/dmlc/mxnet.git ~/mxnet --recursive
+    # Move to source code parent directory
+    cd ~/mxnet
+    cp make/config.mk .
+    echo "USE_BLAS=openblas" >>config.mk
+    echo "ADD_CFLAGS += -I/usr/include/openblas" >>config.mk
+    echo "ADD_LDFLAGS += -lopencv_core -lopencv_imgproc -lopencv_imgcodecs" >>config.mk
+```
+If building with ```GPU``` support, run below commands to add GPU dependency configurations to config.mk file:
+
+```bash
+    echo "USE_CUDA=1" >>config.mk
+    echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk
+    echo "USE_CUDNN=1" >>config.mk
+```
+
+Then build mxnet:
+
+```bash
+    make -j$(nproc)
+```
+
+Executing these commands creates a library called ```libmxnet.so```.
+
+Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](http://jupyter.readthedocs.io/) used for running MXNet tutorials and examples.
+
+```bash
+    sudo apt-get install -y python-pip
+    sudo pip install graphviz
+    sudo pip install Jupyter
+```
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
+- [Perl](#install-the-mxnet-package-for-perl)
+
+### Install the MXNet Package for R
+
+Run the following commands to install the MXNet dependencies and build the MXNet R package.
+
+```r
+    Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')"
+```
+```bash
+    cd R-package
+    Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cran.rstudio.com')); install_deps(dependencies = TRUE)"
+    cd ..
+    make rpkg
+```
+
+**Note:** R-package is a folder in the MXNet source.
+
+These commands create the MXNet R package as a tar.gz file that you can install as an R package. To install the R package, run the following command, use your MXNet version number:
+
+```bash
+    R CMD INSTALL mxnet_current_r.tar.gz
+```
+
+### Install the MXNet Package for Julia
+
+The MXNet package for Julia is hosted in a separate repository, MXNet.jl, which is available on [GitHub](https://github.com/dmlc/MXNet.jl). To use Julia binding it with an existing libmxnet installation, set the ```MXNET_HOME``` environment variable by running the following command:
+
+```bash
+    export MXNET_HOME=/<path to>/libmxnet
+```
+
+The path to the existing libmxnet installation should be the root directory of libmxnet. In other words, you should be able to find the ```libmxnet.so``` file at ```$MXNET_HOME/lib```. For example, if the root directory of libmxnet is ```~```, you would run the following command:
+
+```bash
+    export MXNET_HOME=/~/libmxnet
+```
+
+You might want to add this command to your ```~/.bashrc``` file. If you do, you can install the Julia package in the Julia console using the following command:
+
+```julia
+    Pkg.add("MXNet")
+```
+
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+
+### Install the MXNet Package for Scala
+There are two ways to install the MXNet package for Scala:
+
+* Use the prebuilt binary package
+
+* Build the library from source code
+
+#### Use the Prebuilt Binary Package
+For Linux users, MXNet provides prebuilt binary packages that support computers with either GPU or CPU processors. To download and build these packages using ```Maven```, change the ```artifactId``` in the following Maven dependency to match your architecture:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-full_<system architecture></artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+For example, to download and build the 64-bit CPU-only version for Linux, use:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-full_2.10-linux-x86_64-cpu</artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+If your native environment differs slightly from the assembly package, for example, if you use the openblas package instead of the atlas package, it's better to use the mxnet-core package and put the compiled Java native library in your load path:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-core_2.10</artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+#### Build the Library from Source Code
+Before you build MXNet for Scala from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
+
+```bash
+    make scalapkg
+```
+
+This command creates the JAR files for the assembly, core, and example modules. It also creates the native library in the ```native/{your-architecture}/target directory```, which you can use to cooperate with the core module.
+
+To install the MXNet Scala package into your local Maven repository, run the following command from the MXNet source root directory:
+
+```bash
+    make scalainstall
+```
+### Install the MXNet Package for Perl
+
+Before you build MXNet for Scala from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
+
+```bash
+    sudo apt-get install libmouse-perl pdl cpanminus swig libgraphviz-perl
+    cpanm -q -L "${HOME}/perl5" Function::Parameters
+
+    MXNET_HOME=${PWD}
+    export LD_LIBRARY_PATH=${MXNET_HOME}/lib
+    export PERL5LIB=${HOME}/perl5/lib/perl5
+
+    cd ${MXNET_HOME}/perl-package/AI-MXNetCAPI/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make install
+
+    cd ${MXNET_HOME}/perl-package/AI-NNVMCAPI/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make install
+
+    cd ${MXNET_HOME}/perl-package/AI-MXNet/
+    perl Makefile.PL INSTALL_BASE=${HOME}/perl5
+    make install
+```
+
+**Note - ** You are more than welcome to contribute easy installation scripts for other operating systems and programming languages, see [community page](http://mxnet.io/community/index.html) for contributors guidelines.
+
+## Next Steps
+
+* [Tutorials](http://mxnet.io/tutorials/index.html)
+* [How To](http://mxnet.io/how_to/index.html)
+* [Architecture](http://mxnet.io/architecture/index.html)

--- a/docs/get_started/windows_setup.md
+++ b/docs/get_started/windows_setup.md
@@ -1,0 +1,235 @@
+# Installing MXNet in Windows
+
+On Windows, you can download and install the prebuilt MXNet package, or download, build, and install MXNet yourself.
+
+## Build the Shared Library
+You can either use a prebuilt binary package or build from source to build the MXNet shared library - ```libmxnet.dll```.
+
+### Installing the Prebuilt Package on Windows
+MXNet provides a prebuilt package for Windows. The prebuilt package includes the MXNet library, all of the dependent third-party libraries, a sample C++ solution for Visual Studio, and the Python installation script. To install the prebuilt package:
+
+1. Download the latest prebuilt package from the [Releases](https://github.com/dmlc/mxnet/releases) tab of MXNet.
+   There are two versions. One with GPU support (using CUDA and CUDNN v3), and one without GPU support. Choose the version that suits your hardware configuration. For more information on which version works on each hardware configuration, see [Requirements for GPU](http://mxnet.io/get_started/setup.html#requirements-for-using-gpus).
+2. Unpack the package into a folder, with an appropriate name, such as ```D:\MXNet```.
+3. Open the folder, and install the package by double-clicking ```setupenv.cmd```. This sets up all of the environment variables required by MXNet.
+4. Test the installation by opening the provided sample C++ Visual Studio solution and building it.
+
+
+&nbsp;
+This produces a library called ```libmxnet.dll```.
+
+### Building and Installing Packages on Windows
+
+To build and install MXNet yourself, you need the following dependencies. Install the required dependencies:
+
+1. If [Microsoft Visual Studio 2013](https://www.visualstudio.com/downloads/) is not already installed, download and install it. You can download and install the free community edition.
+2. Install [Visual C++ Compiler Nov 2013 CTP](https://www.microsoft.com/en-us/download/details.aspx?id=41151).
+3. Back up all of the files in the ```C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC``` folder to a different location.
+4. Copy all of the files in the ```C:\Program Files (x86)\Microsoft Visual C++ Compiler Nov 2013 CTP``` folder (or the folder where you extracted the zip archive) to the ```C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC``` folder, and overwrite all existing files.
+5. Download and install [OpenCV](http://sourceforge.net/projects/opencvlibrary/files/opencv-win/3.0.0/opencv-3.0.0.exe/download).
+6. Unzip the OpenCV package.
+7. Set the environment variable ```OpenCV_DIR``` to point to the ```OpenCV build directory```.
+8. If you don't have the Intel Math Kernel Library (MKL) installed, download and install [OpenBlas](http://sourceforge.net/projects/openblas/files/v0.2.14/).
+9. Set the environment variable ```OpenBLAS_HOME``` to point to the ```OpenBLAS``` directory that contains the ```include``` and ```lib``` directories. Typically, you can find the directory in ```C:\Program files (x86)\OpenBLAS\```.
+10. Download and install [CuDNN](https://developer.nvidia.com/cudnn). To get access to the download link, register as an NVIDIA community user.
+
+After you have installed all of the required dependencies, build the MXNet source code:
+
+1. Download the MXNet source code from [GitHub](https://github.com/dmlc/mxnet).
+2. Use [CMake](https://cmake.org/) to create a Visual Studio solution in ```./build```.
+3. In Visual Studio, open the solution file,```.sln```, and compile it.
+These commands produce a library called ```mxnet.dll``` in the ```./build/Release/``` or ```./build/Debug``` folder.
+
+
+
+&nbsp;
+Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](http://jupyter.readthedocs.io/)  used for running MXNet tutorials and examples.
+- Install ```graphviz``` by downloading MSI installer from [Graphviz Download Page](http://www.graphviz.org/Download_windows.php).
+**Note** Make sure to add graphviz executable path to PATH environment variable. Refer [here for more details](http://stackoverflow.com/questions/35064304/runtimeerror-make-sure-the-graphviz-executables-are-on-your-systems-path-aft)
+- Install ```Jupyter``` by installing [Anaconda for Python 2.7](https://www.continuum.io/downloads)
+**Note** Do not install Anaconda for Python 3.5. MXNet has few compatibility issue with Python 3.5.
+
+&nbsp;
+
+We have installed MXNet core library. Next, we will install MXNet interface package for programming language of your choice:
+- [Python](#install-the-mxnet-package-for-python)
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Scala](#install-the-mxnet-package-for-scala)
+
+## Install MXNet for Python
+
+1. Install ```Python``` using windows installer available [here](https://www.python.org/downloads/release/python-2712/).
+2. Install ```Numpy``` using windows installer available [here](http://scipy.org/install.html).
+3. Next, we install Python package interface for MXNet. You can find the Python interface package for [MXNet on GitHub](https://github.com/dmlc/mxnet/tree/master/python/mxnet).
+
+```bash
+    # Assuming you are in root mxnet source code folder
+    cd python
+    sudo python setup.py install
+```
+Done! We have installed MXNet with Python interface. Run below commands to verify our installation is successful.
+```bash
+    # Open Python terminal
+    python
+
+    # You should be able to import mxnet library without any issues.
+    >>> import mxnet as mx;
+    >>> a = mx.nd.ones((2, 3));
+    >>> print ((a*2).asnumpy());
+        [[ 2.  2.  2.]
+        [ 2.  2.  2.]]
+```
+We actually did a small tensor computation using MXNet! You are all set with MXNet on your Windows machine.
+
+## Install MXNet for R
+MXNet for R is available for both CPUs and GPUs.
+
+### Installing MXNet on a Computer with a CPU Processor
+
+To install MXNet on a computer with a CPU processor, choose from two options:
+
+* Use the prebuilt binary package
+* Build the library from source code
+
+#### Building MXNet with the Prebuilt Binary Package
+For Windows users, MXNet provides a prebuilt binary package for CPUs. The prebuilt package is updated weekly. You can install the package directly in the R console using the following commands:
+
+```r
+  install.packages("drat", repos="https://cran.rstudio.com")
+  drat:::addRepo("dmlc")
+  install.packages("mxnet")
+```
+
+#### Building MXNet from Source Code
+
+Run the following commands to install the MXNet dependencies and build the MXNet R package.
+
+```r
+  Rscript -e "install.packages('devtools', repo = 'https://cran.rstudio.com')"
+```
+```bash
+  cd R-package
+  Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cran.rstudio.com')); install_deps(dependencies = TRUE)"
+  cd ..
+  make rpkg
+```
+
+**Note:** R-package is a folder in the MXNet source.
+
+These commands create the MXNet R package as a tar.gz file that you can install as an R package. To install the R package, run the following command, use your MXNet version number:
+
+```bash
+  R CMD INSTALL mxnet_current_r.tar.gz
+```
+
+### Installing MXNet on a Computer with a GPU Processor
+
+To install MXNet on a computer with a GPU processor, you need the following:
+
+* Microsoft Visual Studio 2013
+
+* The NVidia CUDA Toolkit
+
+* The MXNet package
+
+* CuDNN (to provide a Deep Neural Network library)
+
+To install the required dependencies and install MXNet for R:
+
+1. If [Microsoft Visual Studio 2013](https://www.visualstudio.com/downloads/) is not already installed, download and install it. You can download and install the free community edition.
+2. Install the [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit). The CUDA Toolkit depends on Visual Studio. To check whether your GPU is compatible with the CUDA Toolkit and for information on installing it, see NVidia's [CUDA Installation Guide](http://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/).
+3. Download the MXNet package as a .zip file from the [MXNet Github repository](https://github.com/dmlc/mxnet/) and unpack it. You will be editing the ```"/mxnet/R-package"``` folder.
+4. Download the most recent GPU-enabled MXNet package from the [Releases](https://github.com/dmlc/mxnet/releases) tab. Unzip this file and navigate to the ```/nocudnn``` folder.
+**Note:** You will copy some of these extracted files into MXNet's R-package folder. We are now working two folders, 	```R-package/``` and ```nocudnn/```.
+5. Download and install [CuDNN V3](https://developer.nvidia.com/cudnn). To get access to the download link, register as an NVIDIA community user. Unpack the .zip file. You will see three folders: ```/bin```, ```/include```, and ```/lib```. Copy these folders into ```nocudnn/3rdparty/cudnn/```, replacing the folders that are already there. You can also unpack the .zip file directly into the nocudnn/ folder.
+6. Create a folder called ```R-package/inst/libs/x64```. MXNet supports only 64-bit operating systems, so you need the x64 folder.
+7. Copy the following shared libraries (.dll files) into the ```R-package/inst/libs/x64``` folder:
+    * nocudnn/lib/libmxnet.dll.
+    * The *.dll files in all four subfolders of the nocudnn/3rdparty/ directory. The cudnn and openblas .dll files are in the /bin folders.
+You should now have 11 .dll files in the R-package/inst/libs/x64 folder.
+8. Copy the ```nocudnn/include/``` folder into ```R-package/inst/```. You should now have a folder called ```R-package/inst/include/``` with three subfolders.
+9. Make sure that R is added to your ```PATH``` in the environment variables. Running the ```where R``` command at the command prompt should return the location.
+10.	Run ```R CMD INSTALL --no-multiarch R-package```.
+
+**Note:** To maximize its portability, the MXNet library is built with the Rcpp end. Computers running Windows need [MSVC](https://en.wikipedia.org/wiki/Visual_C%2B%2B) (Microsoft Visual C++) to handle CUDA toolchain compatibilities.
+
+## Install the MXNet Package for Julia
+The MXNet package for Julia is hosted in a separate repository, MXNet.jl, which is available on [GitHub](https://github.com/dmlc/MXNet.jl). To use Julia binding it with an existing libmxnet installation, set the ```MXNET_HOME``` environment variable by running the following command:
+
+```bash
+export MXNET_HOME=/<path to>/libmxnet
+```
+
+The path to the existing libmxnet installation should be the root directory of libmxnet. In other words, you should be able to find the ```libmxnet.so``` file at ```$MXNET_HOME/lib```. For example, if the root directory of libmxnet is ```~```, you would run the following command:
+
+```bash
+	export MXNET_HOME=/~/libmxnet
+```
+
+You might want to add this command to your ```~/.bashrc``` file. If you do, you can install the Julia package in the Julia console using the following command:
+
+```julia
+	Pkg.add("MXNet")
+```
+
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+
+## Installing the MXNet Package for Scala
+There are four ways to install the MXNet package for Scala:
+
+* Use the prebuilt binary package
+
+* Build the library from source code
+
+### Use the Prebuilt Binary Package
+For Linux and OS X (Mac) users, MXNet provides prebuilt binary packages that support computers with either GPU or CPU processors. To download and build these packages using ```Maven```, change the ```artifactId``` in the following Maven dependency to match your architecture:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-full_<system architecture></artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+For example, to download and build the 64-bit CPU-only version for Linux, use:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-full_2.10-linux-x86_64-cpu</artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+If your native environment differs slightly from the assembly package, for example, if you use the openblas package instead of the atlas package, it's better to use the mxnet-core package and put the compiled Java native library in your load path:
+
+```HTML
+<dependency>
+  <groupId>ml.dmlc.mxnet</groupId>
+  <artifactId>mxnet-core_2.10</artifactId>
+  <version>0.1.1</version>
+</dependency>
+```
+
+### Build the Library from Source Code
+Before you build MXNet for Scala from source code, you must complete [Step 1. Build the Shared Library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
+
+```bash
+  make scalapkg
+```
+
+This command creates the JAR files for the assembly, core, and example modules. It also creates the native library in the ```native/{your-architecture}/target directory```, which you can use to cooperate with the core module.
+
+To install the MXNet Scala package into your local Maven repository, run the following command from the MXNet source root directory:
+
+```bash
+  make scalainstall
+```
+
+## Next Steps
+
+* [Tutorials](http://mxnet.io/tutorials/index.html)
+* [How To](http://mxnet.io/how_to/index.html)
+* [Architecture](http://mxnet.io/architecture/index.html)


### PR DESCRIPTION
Critical changes. We need to get this merged ASAP.

* Adding back all install guides that were accidentally deleted.
* In each of this page, for Python installation, I added a Note and hyperlink to new install guide we have written and tested.
* Next steps:
   - Link these pages appropriately from main install page.
   - Test and clean up the install guide.

@piiswrong @madjam - There is no new content. I locally built and tested the rendering. Can we please merge this soon? We have broken links.