### PR TITLE
Fix minor typos and grammar issues in tutorial docs

### DIFF
--- a/docs/tutorials/basic/data.md
+++ b/docs/tutorials/basic/data.md
@@ -1,6 +1,6 @@
 # Iterators - Loading data
 
-This tutorial we focus on how to feeding data into a training and inference
+In this tutorial we focus on how to feed data into a training and inference
 program. Most training and inference modules in MXNet accepts data iterators,
 which simplifies this procedure, especially when reading large datasets from
 filesystems. Here we discuss the API conventions and several provided iterators.
@@ -34,7 +34,7 @@ class SimpleBatch(object):
 We explain what each attribute means:
 
 - `data` is a list of `NDArray`, each array contains *n* examples. For
-  instance, if an example is presented by a length $k$ vector, then the shape of
+  instance, if an example is presented by a length `k` vector, then the shape of
   the array will be `(n, k)`.
 
   Each array will be copied into a free variable such as created by
@@ -46,7 +46,7 @@ We explain what each attribute means:
   array with shape `(n,)`. For classification, each class is represented by an
   integer starting from 0.
 
-- `pad` is an integer shows the number of examples added in the last of the
+- `pad` is an integer which shows the number of examples added in the last of the
   batch that are merely used for padding. These examples should be ignored in
   the results, such as computing the gradient. A nonzero padding is often used
   when we reach the end of the data and the total number of examples cannot be
@@ -58,7 +58,7 @@ Before showing the data iterator, we first discuss how to find free variables in
 a symbol. A symbol often contains one or more explicit free variables and also
 implicit ones.
 
-The following codes define a multilayer perceptron.
+The following code defines a multilayer perceptron.
 
 ```python
 import mxnet as mx
@@ -69,7 +69,7 @@ net = mx.sym.FullyConnected(data=net, name='fc2', num_hidden=10)
 net = mx.sym.SoftmaxOutput(data=net, name='softmax')
 ```
 
-We can get the names of the all free variables by calling `list_arguments`:
+We can get the names of all the free variables by calling `list_arguments`:
 
 ```python
 net.list_arguments()
@@ -90,7 +90,7 @@ variables. Four of them are learnable parameters, `fc1_weight`, `fc1_bias`,
 `fc2_weight`, and `fc2_bias`. These parameters are often initialized by
 `mx.initializer` and updated by `mx.optimizer`. The rest two
 are for input data: `data` for examples and `softmax_label` for the
-according labels. Then it is the iterator's job to fed data into these two
+according labels. Then it is the iterator's job to feed data into these two
 variables.
 
 ### Data iterator
@@ -127,8 +127,8 @@ for batch in data_iter:
 
 ## Read CSV
 
-There is an iterator called to `CSVIter` to read data batches from CSV files. We
-first dump `data` into a csv file, and then load the data
+There is an iterator called `CSVIter` to read data batches from CSV files. We
+first dump `data` into a csv file, and then load the data.
 
 ```python
 np.savetxt('data.csv', data, delimiter=',')
@@ -149,7 +149,7 @@ Note that we have not given a label file, then `batch.label` is empty here.
 ## Write your own data iterators
 
 Sometimes the provided iterators are not enough for some application. There are
-mainly two ways to develop a new iterator. One is creating from scratch, the
+mainly two ways to develop a new iterator. One is creating from scratch: the
 following codes define an iterator that creates a given number of data batches
 through a data generator `data_gen`.
 

--- a/docs/tutorials/basic/module.md
+++ b/docs/tutorials/basic/module.md
@@ -6,9 +6,9 @@ high-level interface for executing predefined networks.
 
 ## Preliminary
 
-In this tutorial, we will use train a multilayer perception on a
+In this tutorial, we will use train a multilayer perceptron on a
 [UCI letter recognition](https://archive.ics.uci.edu/ml/datasets/letter+recognition)
-dataset to demonostrate the usage of `Module`
+dataset to demonstrate the usage of `Module`.
 
 We first download and split the dataset, and then create iterators that return a
 batch of examples each time.
@@ -45,7 +45,7 @@ mx.viz.plot_network(net)
 ### Create Module
 
 Now we are ready to introduce module. The commonly used module class is
-`Module`. We can construct amodule by specifying:
+`Module`. We can construct a module by specifying:
 
 - symbol : the network definition
 - context : the device (or a list of devices) for execution
@@ -108,7 +108,7 @@ mod.fit(train_iter, num_epoch=5, epoch_end_callback=checkpoint)
 ```
 
 To load the saved module parameters, call the `load_checkpoint` function. It
-load the Symbol and the associated parameters. We can then set the loaded
+loads the Symbol and the associated parameters. We can then set the loaded
 parameters into the module.
 
 
@@ -123,7 +123,7 @@ mod.set_params(arg_params, aux_params)
 Or if we just want to resume training from a saved checkpoint, instead of
 calling `set_params()`, we can directly call `fit()`, passing the loaded
 parameters, so that `fit()` knows to start from those parameters instead of
-initializing from random. We also set the `begin_epoch` so that so that `fit()`
+initializing from random. We also set the `begin_epoch` so that `fit()`
 knows we are resuming from a previous saved epoch.
 
 
@@ -138,7 +138,7 @@ mod.fit(train_iter,
 
 ## Intermediate-level Interface
 
-We already seen how to module for basic training and inference. Now we are going
+We already seen how to use module for basic training and inference. Now we are going
 to show a more flexiable usage of module. Instead of calling the high-level
 `fit` and `predict`, we can write a training program with the intermediate-level
 interface such as `forward` and `backward`.

--- a/docs/tutorials/basic/ndarray.md
+++ b/docs/tutorials/basic/ndarray.md
@@ -235,7 +235,7 @@ c.asnumpy()
 ## Copies
 
 When assigning an NDArray to another Python variable, we copy a reference to the
-*same* NDArray. However, we often need to maek a copy of the data, so that we
+*same* NDArray. However, we often need to make a copy of the data, so that we
 can manipulate the new array without overwriting the original values.
 
 ```python

--- a/docs/tutorials/basic/symbol.md
+++ b/docs/tutorials/basic/symbol.md
@@ -70,9 +70,9 @@ def ConvFactory(data, num_filter, kernel, stride=(1,1), pad=(0, 0), name=None, s
     bn = mx.sym.BatchNorm(data=conv, name='bn_%s%s' %(name, suffix))
     act = mx.sym.Activation(data=bn, act_type='relu', name='relu_%s%s' %(name, suffix))
     return act
-prev = mx.sym.Variable(name="Previos Output")
+prev = mx.sym.Variable(name="Previous Output")
 conv_comp = ConvFactory(data=prev, num_filter=64, kernel=(7,7), stride=(2, 2))
-shape = {"Previos Output" : (128, 3, 28, 28)}
+shape = {"Previous Output" : (128, 3, 28, 28)}
 mx.viz.plot_network(symbol=conv_comp, shape=shape)
 ```
 
@@ -96,7 +96,7 @@ def InceptionFactoryA(data, num_1x1, num_3x3red, num_3x3, num_d3x3red, num_d3x3,
     # concat
     concat = mx.sym.Concat(*[c1x1, c3x3, cd3x3, cproj], name='ch_concat_%s_chconcat' % name)
     return concat
-prev = mx.sym.Variable(name="Previos Output")
+prev = mx.sym.Variable(name="Previous Output")
 in3a = InceptionFactoryA(prev, 64, 64, 64, 64, 96, "avg", 32, name="in3a")
 mx.viz.plot_network(symbol=in3a, shape=shape)
 ```


### PR DESCRIPTION
There are some minor grammar issues and typos in the tutorial documentation. I've gone through the Python Basics docs and fixed some typos/grammar issues. I did my best to stay true to the issue and fix only obvious typos and grammar issues. There is still more work to do in terms of fixing sentences and paragraphs, but that can be done in a separate pull request.

(Originally from #6192.  I messed up that one.)