### PR TITLE
convert float to int and use matplotlib

### DIFF
--- a/example/gan/dcgan.py
+++ b/example/gan/dcgan.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import mxnet as mx
 import numpy as np
 from sklearn.datasets import fetch_mldata
+from matplotlib import pyplot as plt
 import logging
 import cv2
 from datetime import datetime
@@ -121,12 +122,13 @@ def visual(title, X):
     X = X.transpose((0, 2, 3, 1))
     X = np.clip((X+1.0)*(255.0/2.0), 0, 255).astype(np.uint8)
     n = np.ceil(np.sqrt(X.shape[0]))
-    buff = np.zeros((n*X.shape[1], n*X.shape[2], X.shape[3]), dtype=np.uint8)
+    buff = np.zeros((int(n*X.shape[1]), int(n*X.shape[2]), int(X.shape[3])), dtype=np.uint8)
     for i, img in enumerate(X):
         fill_buf(buff, i, img, X.shape[1:3])
     buff = cv2.cvtColor(buff, cv2.COLOR_BGR2RGB)
-    cv2.imshow(title, buff)
-    cv2.waitKey(1)
+    plt.imshow(buff)
+    plt.title(title)
+    plt.show()
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
@@ -278,6 +280,3 @@ if __name__ == '__main__':
             print('Saving...')
             modG.save_params('%s_G_%s-%04d.params'%(dataset, stamp, epoch))
             modD.save_params('%s_D_%s-%04d.params'%(dataset, stamp, epoch))
-
-
-


### PR DESCRIPTION
I have updated 2 items:
1. using np.zeros with floats has been deprecated, so I am casting the floats to int's. 
2. using matplotlib instead of cv2 to plot the image. This is because I was running this on a Jupyter notebook on AWS using deep learning AMI, and cv2 does not plot when running Jupyter over ssh, but matplotlib is able to plot both locally and over ssh on AWS EC2.

I am also making a notebook example for dc gan.