### PR TITLE
Add .clang-format to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tracker
 .vimrc
 .ycm_extra_conf.py
 .ycm_extra_conf.pyc
+.clang-format
 
 # Emacs
 .#*


### PR DESCRIPTION
Used with clang-format binary and a vim plugin for C++ style guide check