### PR TITLE
fix bug in update_metric

### DIFF
--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -553,9 +553,9 @@ class DataParallelExecutorGroup(object):
                 else:
                     labels_slice.append(label)
 
-            labels = OrderedDict(zip(self.label_names, labels_slice))
+            labels_ = OrderedDict(zip(self.label_names, labels_slice))
             preds = OrderedDict(zip(self.output_names, texec.outputs))
-            eval_metric.update_dict(labels, preds)
+            eval_metric.update_dict(labels_, preds)
 
     def _bind_ith_exec(self, i, data_shapes, label_shapes, shared_group):
         """Internal utility function to bind the i-th executor.


### PR DESCRIPTION
variable `labels` in for loop covers the input variable. This makes `examples/rcnn` fails when training on multi gpus.

Did the CI covers multi-gpu tests? I think this bug could be easily found when run multi gpu tests.