### PR TITLE
Fixed Broken links at various Documentation files

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -14,7 +14,7 @@ Sounds exciting? This page contains links to all the related documentation of th
 
 Resources
 ---------
-* [MXNet R Package Document](http://mxnet.io/get_started/setup.html#install-the-mxnet-package-for-r)
+* [MXNet R Package Document](http://mxnet.io/get_started/install.html)
   - Check this out for detailed documents, examples and installation guides.
 
 Installation
@@ -29,7 +29,7 @@ drat:::addRepo("dmlc")
 install.packages("mxnet")
 ```
 
-To use the GPU version or to use it on Linux, please follow [Installation Guide](http://mxnet.io/get_started/setup.html#installing-mxnet-on-a-gpu)
+To use the GPU version or to use it on Linux, please follow [Installation Guide](http://mxnet.io/get_started/install.html)
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Contents
 --------
 * [Documentation and Tutorials](http://mxnet.io/)
 * [Design Notes](http://mxnet.io/architecture/index.html)
-* [Code Examples](example)
-* [Installation](http://mxnet.io/get_started/setup.html)
+* [Code Examples](https://github.com/dmlc/mxnet/tree/master/example)
+* [Installation](http://mxnet.io/get_started/install.html)
 * [Pretrained Models](https://github.com/dmlc/mxnet-model-gallery)
 * [Contribute to MXNet](http://mxnet.io/community/contribute.html)
 * [Frequent Asked Questions](http://mxnet.io/how_to/faq.html)
@@ -58,7 +58,7 @@ Features
 * Mix and match imperative and symbolic programming to maximize flexibility and efficiency
 * Lightweight, memory efficient and portable to smart devices
 * Scales up to multi GPUs and distributed setting with auto parallelism
-* Support for Python, R, C++ and Julia
+* Support for Python, R, Scala, C++ and Julia
 * Cloud-friendly and directly compatible with S3, HDFS, and Azure
 
 Ask Questions

--- a/docs/api/scala/index.md
+++ b/docs/api/scala/index.md
@@ -38,5 +38,5 @@ You can perform tensor or matrix computation in pure Scala:
 
 * [MXNet Scala API Documentation](http://mxnet.io/api/scala/docs/index.html)
 * [Handwritten Digit Classification in Scala](http://mxnet.io/tutorials/scala/mnist.html)
-* [Neural Style in Scala on MXNet](https://github.com/dmlc/mxnet/blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/neuralstyle/NeuralStyle.scala)
-* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples)
+* [Neural Style in Scala on MXNet](https://github.com/dmlc/mxnet/blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/neuralstyle/NeuralStyle.scala)
+* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,6 @@
 # Tutorials
 
-These tutorials introduce fundamental concepts in deep learning and their realizations in _MXNet_. Under the _basics_ section, you'll find tutorials covering manipulating arrays, building networks, loading and preprocessing data, etc. Further sections introduce fundamental models for image classification, natural language processing, speech recognition, and unsupervised learning. While most tutorials are currently presented in Python, we also present a subset of tutorials using the R and Scala front ends.
+These tutorials introduce fundamental concepts in deep learning and their realizations in _MXNet_. Under the _basics_ section, you'll find tutorials covering manipulating arrays, building networks, loading and preprocessing data, etc. Further sections introduce fundamental models for image classification, natural language processing, speech recognition, and unsupervised learning. While most tutorials are currently presented in Python, we also present a subset of tutorials using the R and Scala languages.
 
 
 ## Python

--- a/docs/tutorials/scala/char_lstm.md
+++ b/docs/tutorials/scala/char_lstm.md
@@ -1,6 +1,6 @@
 # Developing a Character-level Language model
 
-This tutorial shows how to train a character-level language model with a multilayer recurrent neural network (RNN) using Scala. The model takes one text file as input and trains an RNN that learns to predict the next character in the sequence. In this tutorial, you train a multilayer LSTM (Long Short-Term Memory) network that generates relevant text using Barack Obama's speech patterns.
+This tutorial shows how to train a character-level language model with a multilayer recurrent neural network (RNN) using Scala. This model takes one text file as input and trains an RNN that learns to predict the next character in the sequence. In this tutorial, you train a multilayer LSTM (Long Short-Term Memory) network that generates relevant text using Barack Obama's speech patterns.
 
 There are many documents that explain LSTM concepts. If you aren't familiar with LSTM, refer to the following before you proceed:
 - Christopher Olah's [Understanding LSTM blog post](http://colah.github.io/posts/2015-08-Understanding-LSTMs/)
@@ -56,7 +56,7 @@ In this tutorial, you will accomplish the following:
 
 To complete this tutorial, you need:
 
-- MXNet. See the instructions for your operating system in [Setup and Installation](http://mxnet.io/get_started/setup.html#overview)
+- MXNet. See the instructions for your operating system in [Setup and Installation](http://mxnet.io/get_started/install.html)
 - [Scala 2.11.8](https://www.scala-lang.org/download/2.11.8.html)
 - [Maven 3](https://maven.apache.org/install.html)
 
@@ -179,7 +179,7 @@ Now, create a multi-layer LSTM model.
 To create the model:
 
 1) Load the helper files (`Lstm.scala`, `BucketIo.scala` and `RnnModel.scala`).
-`Lstm.scala` contains the definition of the LSTM cell. `BucketIo.scala` creates a sentence iterator. `RnnModel.scala` is used for model inference. The helper files are available on the [MXNet site](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples/rnn).
+`Lstm.scala` contains the definition of the LSTM cell. `BucketIo.scala` creates a sentence iterator. `RnnModel.scala` is used for model inference. The helper files are available on the [MXNet site](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn).
 To load them, at the Scala command prompt type:
 
     ```scala
@@ -332,7 +332,7 @@ Note: The BucketSentenceIter data iterator supports various length examples; how
 
     ```
 
-8) Now, you have implemented all the supporting infrastructures for the char-lstm model. To train the model, use the standard [MXNet high-level API](http://mxnet.io/api/scala/docs/index.html#ml.dmlc.mxnet.FeedForward). You can train the model on a single GPU or CPU from multiple GPUs or CPUs by changing ```.setContext(Array(Context.gpu(0),Context.gpu(1),Context.gpu(2),Context.gpu(3)))``` to ```.setContext(Array(Context.gpu(0)))```:
+8) Now, you have implemented all the supporting infrastructures for the char-lstm model. To train the model, use the standard [MXNet high-level API](http://mxnet.io/api/scala/docs/index.html#ml.dmlc.mxnet.FeedForward). You can train the model on a single GPU or CPU from multiple GPUs or CPUs by changing ```scala .setContext(Array(Context.gpu(0),Context.gpu(1),Context.gpu(2),Context.gpu(3)))``` to ```scala .setContext(Array(Context.gpu(0)))```:
 
     ```scala
         scala> val model = FeedForward.newBuilder(symbol)
@@ -509,5 +509,5 @@ You can see the output generated from Obama's speeches. All of the line breaks, 
 
 ## Next Steps
 * [Scala API](http://mxnet.io/api/scala/)
-* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples)
+* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/)
 * [MXNet tutorials index](http://mxnet.io/tutorials/index.html)

--- a/docs/tutorials/scala/mnist.md
+++ b/docs/tutorials/scala/mnist.md
@@ -2,7 +2,7 @@
 
 This Scala tutorial guides you through a classic computer vision application: identifying hand written digits.
 
-Let's train a 3-layer multilayer perceptron on the MNIST dataset to classify handwritten digits.
+Let's train a 3-layer network (i.e multilayer perceptron network) on the MNIST dataset to classify handwritten digits.
 
 ## Define the Network
 
@@ -107,5 +107,5 @@ Check out more MXNet Scala examples below.
 
 ## Next Steps
 * [Scala API](http://mxnet.io/api/scala/)
-* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples)
+* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/)
 * [MXNet tutorials index](http://mxnet.io/tutorials/index.html)

--- a/docs/tutorials/scala/mxnet_scala_on_intellij.md
+++ b/docs/tutorials/scala/mxnet_scala_on_intellij.md
@@ -7,7 +7,7 @@ To use this tutorial, you need:
 
 - [Maven 3](https://maven.apache.org/install.html).
 - [Scala 2.11.8](https://www.scala-lang.org/download/2.11.8.html).
-- MXNet. See the instructions for your operating system in [Setup and Installation](http://mxnet.io/get_started/setup.html#overview).
+- MXNet. See the instructions for your operating system in [Setup and Installation](http://mxnet.io/get_started/install.html).
 - The MXNet package for Scala. For installation instructions, see [this procedure](http://mxnet.io/get_started/osx_setup.html#install-the-mxnet-package-for-scala).
 - [IntelliJ IDE](https://www.jetbrains.com/idea/).
 
@@ -58,5 +58,5 @@ Be sure to change the system path of MXNet-Scala-jar, which is in the `native/<y
 For more information about MXNet Scala resources, see the following:
 
 * [Scala API](http://mxnet.io/api/scala/)
-* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/src/main/scala/ml/dmlc/mxnet/examples)
+* [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/)
 * [MXNet tutorials index](http://mxnet.io/tutorials/index.html)


### PR DESCRIPTION
What were proposed in this Pull Request ?

Broken links has been fixed for following documentations pages.

*  R-package/README.md
*  README.md
*  docs/api/scala/index.md
*  docs/tutorials/index.md
*  docs/tutorials/scala/char_lstm.md
*  docs/tutorials/scala/mnist.md
*  docs/tutorials/scala/mxnet_scala_on_intellij.md

@madjam Can you please review this Pull Request and merge if looks good.