### PR TITLE
Adding mxnet slack and apache email list details

### DIFF
--- a/docs/community/mxnet_channels.md
+++ b/docs/community/mxnet_channels.md
@@ -1,0 +1,6 @@
+# Join MXNet Development Discussion
+
+You can join the MXNet development discussion
+
+- On the [MXNet Apache mailing list](https://lists.apache.org/list.html?dev@mxnet.apache.org): `dev@mxnet.apache.org`. To subscribe, send an email to `dev-subscribe@mxnet.apache.org`.
+- On the [MXNet Slack channel](https://apache-mxnet.slack.com): To request an invitation to the channel please email: `dev@mxnet.apache.org`.

--- a/docs/how_to/index.md
+++ b/docs/how_to/index.md
@@ -40,6 +40,8 @@ and full working examples, visit the [tutorials section](../tutorials/index.md).
 
 ## Extend and Contribute to MXNet
 
+* [How do I join and contribute to MXNet development discussion?](http://mxnet.io/community/mxnet_channels.html)
+
 * [How do I contribute a patch to MXNet?](http://mxnet.io/community/contribute.html)
 
 * [How do I create new operators in MXNet?](http://mxnet.io/how_to/new_op.html)


### PR DESCRIPTION
Adding How To for joining mxnet apache mailing list and slack channel details.

@madjam @mli @piiswrong - Can we review and merge this changes? This is an urgent requirement from Dominic to present in ApacheCon