### PR TITLE
Fixed: MXNET R Reference manual broken link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -135,3 +135,4 @@ List of Contributors
 * [David Salinas](https://github.com/geoalgo)
 * [Asmus Hetzel](https://github.com/asmushetzel)
 * [Roshani Nagmote](https://github.com/Roshrini)
+* [Chetan Khatri](https://github.com/chetkhatri/)

--- a/docs/api/r/index.md
+++ b/docs/api/r/index.md
@@ -1,6 +1,6 @@
 # MXNet - R API
 
-See the [MXNet R Reference Manual](http://mxnet.io/api/r/mxnet-r-reference-manual.pdf).
+See the [MXNet R Reference Manual](https://media.readthedocs.org/pdf/mxnet-test/latest/mxnet-test.pdf).
 
 MXNet supports the R programming language. The MXNet R package brings flexible and efficient GPU
 computing and state-of-art deep learning to R. It enables you to write seamless tensor/matrix computation with multiple GPUs in R. It also lets you construct and customize the state-of-art deep learning models in R,
@@ -23,6 +23,6 @@ You can perform tensor or matrix computation in R:
 ```
 ## Resources
 
-* [MXNet R Reference Manual](http://mxnet.io/api/r/mxnet-r-reference-manual.pdf)
+* [MXNet R Reference Manual](https://media.readthedocs.org/pdf/mxnet-test/latest/mxnet-test.pdf)
 * [MXNet for R Tutorials](http://mxnet.io/tutorials/index.html#R-Tutorials)
 


### PR DESCRIPTION
What were proposed in this Pull Request ?
* Broken link fixed for R Package Reference manual.