### PR TITLE
Improve API Style

### DIFF
--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -176,5 +176,10 @@
     <script type="text/javascript" src="{{ pathto('_static/js/navbar.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/js/clipboard.min.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/js/copycode.js', 1) }}"></script>
+    <script type="text/javascript">
+        $('body').ready(function () {
+            $('body').css('visibility', 'visible');
+        });
+    </script>
   </body>
 </html>

--- a/docs/_static/mxnet.css
+++ b/docs/_static/mxnet.css
@@ -8,6 +8,7 @@ html, body {
 
 body {
     display: block;
+    visibility: hidden;
 }
 
 body, div {
@@ -820,7 +821,7 @@ dl > dt:before {
     content: " ";
     display: block;
     height: 70px; /* fixed header height*/
-    margin-top: -70px; /* negative fixed header height */
+    margin-top: -50px; /* negative fixed header height */
 }
 
 p.rubric {
@@ -829,8 +830,19 @@ p.rubric {
 
 dt:target, .highlighted {
     background-color: #fff;
+    background: transparent;
     border-bottom: 3px solid #c7254e;
     margin-bottom: -3px;
+}
+
+dt em {
+    font-weight: normal;
+    font-style: normal;
+    font-size: 90%; 
+}
+
+code {
+    color: #337ab7;
 }
 
 /*----------------Model zoo page style------------------*/


### PR DESCRIPTION
1. Change API arguments style. Use normal font-weight, normal font-style and smaller font-size.
2. Add space between APIs.
3. Change API name color to blue to be compatible with the whole website.
4. For the api title background color which is similar to pytorch, it is not easy to make this change due to our current design. Maybe we can postpone this after doc release.

![api1](https://cloud.githubusercontent.com/assets/15520525/26221974/2a86d19a-3bcd-11e7-9093-812a7e021ce5.png)
![api2](https://cloud.githubusercontent.com/assets/15520525/26221976/2c7833cc-3bcd-11e7-9e4d-97b47fa54c6a.png)