### PR TITLE
add num_group argument in tools/caffe_converter/convert_symbol.py

### DIFF
--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -54,6 +54,11 @@ def _convert_conv_param(param):
     # deal with dilation. Won't be in deconvolution
     if dilate > 1:
         param_string += ", dilate=(%d, %d)" % (dilate, dilate)
+
+    if isinstance(param.group, int):
+        if param.group != 1:
+            param_string += ", num_group=%d" % param.group
+
     return param_string
 
 def _convert_pooling_param(param):


### PR DESCRIPTION
The original code ignores the num_group parameter in convolution layers. Thus, this script is not able to convert caffe's alexnet model into mxnet.