### PR TITLE
Fix install rendering issue

### DIFF
--- a/docs/_static/js/sidebar.js
+++ b/docs/_static/js/sidebar.js
@@ -210,6 +210,9 @@ function keepExpand() {
 
 $(document).ready(function () {
     var url = window.location.href, searchFlag = 'search.html';
+    if(url.indexOf('/get_started/') != -1) {
+        $('body').css("visibility", "visible");
+    }
     if (url.indexOf(searchFlag) == -1) {
         for(var i = 0; i < API_PAGE.length; ++i) {
             if (url.indexOf('/api/' + API_PAGE[i]) != -1) {


### PR DESCRIPTION
Force rendering other installation pages under get_started. This is a short term solution. In the future we should move all installation information into installation page.

@arank @madjam 