### PR TITLE
Removed deprecated configs.

### DIFF
--- a/example/rcnn/script/additional_deps.sh
+++ b/example/rcnn/script/additional_deps.sh
@@ -10,7 +10,6 @@ cp make/config.mk ./
 echo "USE_CUDA=1" >>config.mk
 echo "USE_CUDA_PATH=/usr/local/cuda" >>config.mk
 echo "USE_CUDNN=1" >>config.mk
-echo "EXTRA_OPERATORS = example/rcnn/operator" >>config.mk
 make -j$(nproc)
 pushd python
 python setup.py install --user


### PR DESCRIPTION
The configuration for the rcnn operator package "examples/rcnn/operator" is deprecated. Now "mxnet.contrib.symbol" encapsulates the operators instead.