### PR TITLE
Fixing tutorials.

### DIFF
--- a/docs/tutorials/basic/data.md
+++ b/docs/tutorials/basic/data.md
@@ -346,7 +346,7 @@ Download and unzip
 ```python
 fname = mx.test_utils.download(url='http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz', dirname='data', overwrite=False)
 tar = tarfile.open(fname)
-tar.extracall()
+tar.extractall()
 tar.close()
 os.chdir('../')
 ```

--- a/docs/tutorials/basic/ndarray.md
+++ b/docs/tutorials/basic/ndarray.md
@@ -182,7 +182,7 @@ shapes must be the same along the other axes.
 ```python
 a = mx.nd.ones((2,3))
 b = mx.nd.ones((2,3))*2
-c = mx.nd.concat([a,b])
+c = mx.nd.concat(a,b)
 c.asnumpy()
 ```
 
@@ -358,7 +358,7 @@ The `load` and `save` methods are preferable to pickle in two respects
 
 ```python
 a = mx.nd.ones((2, 3))
-mx.save("temp.ndarray", [a,])
+mx.nd.save("temp.ndarray", [a,])
 ```
 
 we can later load it from R:

--- a/docs/tutorials/basic/symbol.md
+++ b/docs/tutorials/basic/symbol.md
@@ -173,8 +173,8 @@ data = mx.sym.Variable("data")
 net = data
 n_layer = 2
 for i in range(n_layer):
-   with mx.name.Prefix("layer%d_" % (i + 1)):
-   net = mx.sym.FullyConnected(data=net, name="fc", num_hidden=100)
+    with mx.name.Prefix("layer%d_" % (i + 1)):
+        net = mx.sym.FullyConnected(data=net, name="fc", num_hidden=100)
 net.list_arguments()
 ```
 

--- a/docs/tutorials/python/predict_image.md
+++ b/docs/tutorials/python/predict_image.md
@@ -80,7 +80,7 @@ predict('http://writm.com/wp-content/uploads/2016/08/Cat-hd-wallpapers.jpg')
 ```
 
 ```python
-predict('http://images-na.ssl-images-amazon.com/images/G/01/img15/pet-products/small-tiles/23695_pets_vertical_store_dogs_small_tile_8._CB312176604_.jpg')
+predict('http://thenotoriouspug.com/wp-content/uploads/2015/01/Pug-Cookie-1920x1080-1024x576.jpg')
 ```
 
 ## Feature extraction

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -2,6 +2,8 @@
 # pylint: disable=too-many-lines
 from __future__ import absolute_import, print_function, division
 import time
+import gzip
+import struct
 import traceback
 import numbers
 import subprocess


### PR DESCRIPTION
Most of the fixes should be self-evident. For the tutorial on pre-trained models, one of the images doesn't exist anymore so selected a new one. Long-term, we should put such images on web-data repo but alas, some other day.

For Handwritten digit tutorial, we are missing a couple of imports in the test_utils.py that was recently created.

Note that: for the pre-trained model tutorial, we get a softmax_label warning and the probability scores are not really probabilities. Will deal with that issue in another PR.

Testing:
I've tried to test all the notebooks with this change and things look fine.

@nswamy @mli @piiswrong @madjam 