### PR TITLE
Pre-trained model tutorial fixes.

### DIFF
--- a/docs/tutorials/basic/ndarray.md
+++ b/docs/tutorials/basic/ndarray.md
@@ -10,7 +10,7 @@ to `numpy.ndarray`.  Like the corresponding NumPy data structure, MXNet's
 So you might wonder, why not just use NumPy?  MXNet offers two compelling
 advantages.  First, MXNet's `NDArray` supports fast execution on a wide range of
 hardware configurations, including CPU, GPU, and multi-GPU machines.  _MXNet_
-also scales to distribute systems in the cloud.  Second, MXNet's NDArray
+also scales to distributed systems in the cloud.  Second, MXNet's `NDArray`
 executes code lazily, allowing it to automatically parallelize multiple
 operations across the available hardware.
 

--- a/docs/tutorials/python/predict_image.md
+++ b/docs/tutorials/python/predict_image.md
@@ -24,9 +24,10 @@ occurances of `mx.cpu()` with `mx.gpu()` to accelerate the computation.
 
 ```python
 sym, arg_params, aux_params = mx.model.load_checkpoint('resnet-152', 0)
-mod = mx.mod.Module(symbol=sym, context=mx.cpu())
-mod.bind(for_training=False, data_shapes=[('data', (1,3,224,224))])
-mod.set_params(arg_params, aux_params)
+mod = mx.mod.Module(symbol=sym, context=mx.cpu(), label_names=None)
+mod.bind(for_training=False, data_shapes=[('data', (1,3,224,224))], 
+         label_shapes=mod._label_shapes)
+mod.set_params(arg_params, aux_params, allow_missing=True)
 with open('synset.txt', 'r') as f:
     labels = [l.rstrip() for l in f]
 ```
@@ -68,8 +69,8 @@ def predict(url):
     prob = mod.get_outputs()[0].asnumpy()
     # print the top-5
     prob = np.squeeze(prob)
-    prob = np.argsort(prob)[::-1]
-    for i in prob[0:5]:
+    a = np.argsort(prob)[::-1]
+    for i in a[0:5]:
         print('probability=%f, class=%s' %(prob[i], labels[i]))
 ```
 


### PR DESCRIPTION
Before the change, on running the tutorial for the first time, a user would get this warning: "UserWarning: Data provided by label_shapes don't match names specified by label_names ([] vs. ['softmax_label'])". It also showed probability scores of >>1 due to an incorrect usage of np.argsort().

@kevinthesun @nswamy @piiswrong @Roshrini @madjam 