### PR TITLE
Fixed few typos in the Python tutorials

### DIFF
--- a/docs/tutorials/python/linear-regression.md
+++ b/docs/tutorials/python/linear-regression.md
@@ -1,6 +1,6 @@
 # Linear Regression
 
-In this tutorial we'll walk though how one can implement *linear regression* using MXNet APIs.
+In this tutorial we'll walk through how one can implement *linear regression* using MXNet APIs.
 
 The function we are trying to learn is: *y = x<sub>1</sub>  +  2x<sub>2</sub>*, where *(x<sub>1</sub>,x<sub>2</sub>)* are input features and *y* is the corresponding label.
 
@@ -71,7 +71,7 @@ and make up various components of the model. Symbols are used to define:
    One such example is the `FullyConnected` symbol which specifies a fully connected
    layer of a neural network.
 3. **Outputs:** Output symbols are MXNet's way of defining a loss. They are
-   suffixed with the word "Output" (eg. the `SoftmaxOutput` layer. You can also
+   suffixed with the word "Output" (eg. the `SoftmaxOutput` layer). You can also
    [create your own loss function](https://github.com/dmlc/mxnet/blob/master/docs/tutorials/r/CustomLossFunction.md#how-to-use-your-own-loss-function).
    Some examples of existing losses are: `LinearRegressionOutput`, which computes
    the l2-loss between it's input symbol and the labels provided to it;

--- a/docs/tutorials/python/predict_image.md
+++ b/docs/tutorials/python/predict_image.md
@@ -100,7 +100,7 @@ all_layers = sym.get_internals()
 all_layers.list_outputs()[-10:]
 ```
 
-A often used layer for feature extraction is the one before the last fully
+An often used layer for feature extraction is the one before the last fully
 connected layer. For ResNet, and also Inception, it is the flatten layer with
 name `flatten0` which reshapes the 4-D convolutional layer output into 2-D for
 the fully connected layer. The following source code extracts a new Symbol which


### PR DESCRIPTION
Comparing to basic tutorials, training ones had way fewer typos. Nevertheless, spotted some as I was going through