### PR TITLE
Remove BUILD_TAG in DOCKER_IMG_NAME in ci_build.sh

### DIFF
--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -69,13 +69,12 @@ function upsearch () {
         cd .. && upsearch "$1"
 }
 
-# Set up WORKSPACE and BUILD_TAG. Jenkins will set them for you or we pick
+# Set up WORKSPACE. Jenkins will set them for you or we pick
 # reasonable defaults if you run it outside of Jenkins.
 WORKSPACE="${WORKSPACE:-${SCRIPT_DIR}/../../}"
-BUILD_TAG="${BUILD_TAG:-mx-ci}"
 
 # Determine the docker image name
-DOCKER_IMG_NAME="${BUILD_TAG}.${CONTAINER_TYPE}"
+DOCKER_IMG_NAME="mx-ci.${CONTAINER_TYPE}"
 
 # Under Jenkins matrix build, the build tag may contain characters such as
 # commas (,) and equal signs (=), which are not valid inside docker image names.
@@ -98,6 +97,7 @@ echo "CI_DOCKER_EXTRA_PARAMS: ${CI_DOCKER_EXTRA_PARAMS[@]}"
 echo "COMMAND: ${COMMAND[@]}"
 echo "CONTAINER_TYPE: ${CONTAINER_TYPE}"
 echo "BUILD_TAG: ${BUILD_TAG}"
+echo "NODE_NAME: ${NODE_NAME}"
 echo "DOCKER CONTAINER NAME: ${DOCKER_IMG_NAME}"
 echo "PRE_COMMAND: ${PRE_COMMAND}"
 echo ""


### PR DESCRIPTION
To avoid generating too many images when run `docker images`