### PR TITLE
hide _move_var _move_mean _beta _gamma for visualization

### DIFF
--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -240,6 +240,9 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
             return True
         if name.endswith("_bias"):
             return True
+        if name.endswith("_beta") or name.endswith("_gamma") or \
+	   name.endswith("_moving_var") or name.endswith("_moving_mean"):
+            return True
         return False
 
     # make nodes


### PR DESCRIPTION
Parameters bn_gamma, bn_beta, bn_var, bn_mean occupy a lot of space while providing little information. I suggest to hide them during visualization

[plot_complex.pdf](https://github.com/dmlc/mxnet/files/1043750/plot_complex.pdf) 
[plot_complex_resnet.pdf](https://github.com/dmlc/mxnet/files/1043767/plot_complex_resnet.pdf)
[plot_clean.pdf](https://github.com/dmlc/mxnet/files/1043765/plot_clean.pdf) 
[plot_clean_resnet.pdf](https://github.com/dmlc/mxnet/files/1043776/plot_clean_resnet.pdf)