### PR TITLE
add requests, graphviz used test_utils and visualization to python setup

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ if "--inplace" in sys.argv:
 else:
     from setuptools import setup
     from setuptools.extension import Extension
-    kwargs = {'install_requires': ['numpy'], 'zip_safe': False}
+    kwargs = {'install_requires': ['numpy', 'requests', 'graphviz'], 'zip_safe': False}
 
 with_cython = False
 if '--with-cython' in sys.argv:


### PR DESCRIPTION
test_utils.py uses requests package but fails when it cannot be found, similarly visualization.py uses graphviz.

dependent packages should be installed along with mxnet installation.

@piiswrong @mli @madjam 