### PR TITLE
fix typo on BatchNorm for mirroring

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -221,7 +221,7 @@ nnvm::Graph GraphExecutor::InitFullGraph(
     if (type == "FullyConnected") return false;
     if (type == "Concat") return false;
     if (type == "SoftmaxOutput") return false;
-    if (type == "CuDNNBatchNorm") return false;
+    if (type == "BatchNorm") return false;
     return true;
   };
 

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -222,6 +222,7 @@ nnvm::Graph GraphExecutor::InitFullGraph(
     if (type == "Concat") return false;
     if (type == "SoftmaxOutput") return false;
     if (type == "BatchNorm") return false;
+    if (type == "CuDNNBatchNorm") return false;
     return true;
   };
 


### PR DESCRIPTION
After changing this line, we are able to set the attribute `force_mirroring` of a BatchNorm layer to `True`.