### PR TITLE
[WIP] Foo (NN) API reference doc

### DIFF
--- a/docs/api/python/foo.loss.md
+++ b/docs/api/python/foo.loss.md
@@ -1,7 +1,7 @@
-# Foo API
+# Foo Loss API
 
 ```eval_rst
-.. currentmodule:: mxnet.foo
+.. currentmodule:: mxnet.foo.loss
 ```
 
 ```eval_rst
@@ -13,12 +13,11 @@
 <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
-.. autoclass:: mxnet.foo.Parameter
-    :members:
-.. autoclass:: mxnet.foo.ParameterDict
-    :members:
-.. autoclass:: mxnet.foo.Trainer
-    :members:
+.. automethod:: mxnet.foo.loss.custom_loss
+.. automethod:: mxnet.foo.loss.multitask_loss
+.. automethod:: mxnet.foo.loss.l1_loss
+.. automethod:: mxnet.foo.loss.l2_loss
+.. automethod:: mxnet.foo.loss.softmax_cross_entropy_loss
 ```
 
 <script>auto_index("api-reference");</script>

--- a/docs/api/python/foo.md
+++ b/docs/api/python/foo.md
@@ -1,8 +1,4 @@
-# NN API
-
-```eval_rst
-.. currentmodule:: mxnet.foo.nn
-```
+# Foo API
 
 ```eval_rst
 .. warning:: This package is currently experimental and may change in the near future.
@@ -13,6 +9,16 @@
 <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
+.. currentmodule:: mxnet.foo
+.. autoclass:: mxnet.foo.Parameter
+    :members:
+.. autoclass:: mxnet.foo.ParameterDict
+    :members:
+.. autoclass:: mxnet.foo.Trainer
+    :members:
+
+
+.. currentmodule:: mxnet.foo.nn
 .. autoclass:: mxnet.foo.nn.Layer
     :members:
 
@@ -27,7 +33,7 @@
     :members:
 .. autoclass:: mxnet.foo.nn.BatchNorm
     :members:
-.. autoclass:: mxnet.LeakyReLU
+.. autoclass:: mxnet.foo.nn.LeakyReLU
     :members:
 
 .. autoclass:: mxnet.foo.nn.Conv1D
@@ -68,32 +74,42 @@
     :members:
 
 
-.. currentmodule:: mxnet.foo.nn.loss
-.. automethod:: mxnet.foo.nn.loss.custom_loss
+.. currentmodule:: mxnet.foo.loss
+.. automethod:: mxnet.foo.loss.custom_loss
+.. automethod:: mxnet.foo.loss.multitask_loss
+.. automethod:: mxnet.foo.loss.l1_loss
+.. automethod:: mxnet.foo.loss.l2_loss
+.. automethod:: mxnet.foo.loss.softmax_cross_entropy_loss
 
-.. automethod:: mxnet.foo.nn.loss.multitask_loss
 
-.. automethod:: mxnet.foo.nn.loss.l1_loss
+.. currentmodule:: mxnet.foo.utils
+.. automethod:: mxnet.foo.utils.split_data
+.. automethod:: mxnet.foo.utils.load_data
 
-.. automethod:: mxnet.foo.nn.loss.l2_loss
 
-.. automethod:: mxnet.foo.nn.loss.softmax_cross_entropy_loss
-
-.. currentmodule:: mxnet.foo.nn
-.. autoclass:: mxnet.foo.nn.Optim
+.. currentmodule:: mxnet.foo.rnn
+.. autoclass:: mxnet.foo.rnn.RecurrentCell
     :members:
 
-.. autoclass:: mxnet.foo.nn.Parameter
+    .. automethod:: __call__
+.. autoclass:: mxnet.foo.rnn.LSTMCell
     :members:
-.. autoclass:: mxnet.foo.nn.ParameterDict
+.. autoclass:: mxnet.foo.rnn.GRUCell
     :members:
-
-.. currentmodule:: mxnet.foo.nn.utils
-.. automethod:: mxnet.foo.nn.utils.split_data
-
-.. automethod:: mxnet.foo.nn.utils.load_data
-
-.. currentmodule:: mxnet.foo.nn
+.. autoclass:: mxnet.foo.rnn.RNNCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.FusedRNNCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.SequentialRNNCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.BidirectionalCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.DropoutCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.ZoneoutCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.ResidualCell
+    :members:
 ```
 
 <script>auto_index("api-reference");</script>

--- a/docs/api/python/foo.nn.md
+++ b/docs/api/python/foo.nn.md
@@ -1,0 +1,72 @@
+# Foo NN API
+
+```eval_rst
+.. currentmodule:: mxnet.foo.nn
+```
+
+```eval_rst
+.. warning:: This package is currently experimental and may change in the near future.
+```
+
+## API Reference
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+.. currentmodule:: mxnet.foo.nn
+.. autoclass:: mxnet.foo.nn.Layer
+    :members:
+
+    .. automethod:: __call__
+.. autoclass:: mxnet.foo.nn.Sequential
+    :members:
+.. autoclass:: mxnet.foo.nn.Dense
+    :members:
+.. autoclass:: mxnet.foo.nn.Activation
+    :members:
+.. autoclass:: mxnet.foo.nn.Dropout
+    :members:
+.. autoclass:: mxnet.foo.nn.BatchNorm
+    :members:
+.. autoclass:: mxnet.foo.nn.LeakyReLU
+    :members:
+
+.. autoclass:: mxnet.foo.nn.Conv1D
+    :members:
+.. autoclass:: mxnet.foo.nn.Conv2D
+    :members:
+.. autoclass:: mxnet.foo.nn.Conv3D
+    :members:
+.. autoclass:: mxnet.foo.nn.Conv1DTranspose
+    :members:
+.. autoclass:: mxnet.foo.nn.Conv2DTranspose
+    :members:
+.. autoclass:: mxnet.foo.nn.Conv3DTranspose
+    :members:
+.. autoclass:: mxnet.foo.nn.MaxPool1D
+    :members:
+.. autoclass:: mxnet.foo.nn.MaxPool2D
+    :members:
+.. autoclass:: mxnet.foo.nn.MaxPool3D
+    :members:
+.. autoclass:: mxnet.foo.nn.AvgPool1D
+    :members:
+.. autoclass:: mxnet.foo.nn.AvgPool2D
+    :members:
+.. autoclass:: mxnet.foo.nn.AvgPool3D
+    :members:
+.. autoclass:: mxnet.foo.nn.GlobalMaxPool1D
+    :members:
+.. autoclass:: mxnet.foo.nn.GlobalMaxPool2D
+    :members:
+.. autoclass:: mxnet.foo.nn.GlobalMaxPool3D
+    :members:
+.. autoclass:: mxnet.foo.nn.GlobalAvgPool1D
+    :members:
+.. autoclass:: mxnet.foo.nn.GlobalAvgPool2D
+    :members:
+.. autoclass:: mxnet.foo.nn.GlobalAvgPool3D
+    :members:
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/foo.rnn.md
+++ b/docs/api/python/foo.rnn.md
@@ -1,0 +1,40 @@
+# Foo RNN API
+
+```eval_rst
+.. currentmodule:: mxnet.foo.rnn
+```
+
+```eval_rst
+.. warning:: This package is currently experimental and may change in the near future.
+```
+
+## API Reference
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+.. autoclass:: mxnet.foo.rnn.RecurrentCell
+    :members:
+
+    .. automethod:: __call__
+.. autoclass:: mxnet.foo.rnn.LSTMCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.GRUCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.RNNCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.FusedRNNCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.SequentialRNNCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.BidirectionalCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.DropoutCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.ZoneoutCell
+    :members:
+.. autoclass:: mxnet.foo.rnn.ResidualCell
+    :members:
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/foo.utils.md
+++ b/docs/api/python/foo.utils.md
@@ -1,7 +1,7 @@
-# Foo API
+# Foo Utility API
 
 ```eval_rst
-.. currentmodule:: mxnet.foo
+.. currentmodule:: mxnet.foo.utils
 ```
 
 ```eval_rst
@@ -13,12 +13,8 @@
 <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
-.. autoclass:: mxnet.foo.Parameter
-    :members:
-.. autoclass:: mxnet.foo.ParameterDict
-    :members:
-.. autoclass:: mxnet.foo.Trainer
-    :members:
+.. automethod:: mxnet.foo.utils.split_data
+.. automethod:: mxnet.foo.utils.load_data
 ```
 
 <script>auto_index("api-reference");</script>

--- a/docs/api/python/index.md
+++ b/docs/api/python/index.md
@@ -28,7 +28,7 @@ imported by running:
    ndarray
    symbol
    module
-   nn
+   foo
    rnn
    kvstore
    io

--- a/docs/api/python/index.md
+++ b/docs/api/python/index.md
@@ -28,6 +28,7 @@ imported by running:
    ndarray
    symbol
    module
+   nn
    rnn
    kvstore
    io

--- a/docs/api/python/index.md
+++ b/docs/api/python/index.md
@@ -29,6 +29,10 @@ imported by running:
    symbol
    module
    foo
+   foo.nn
+   foo.rnn
+   foo.loss
+   foo.utils
    rnn
    kvstore
    io

--- a/docs/api/python/nn.md
+++ b/docs/api/python/nn.md
@@ -1,7 +1,7 @@
 # NN API
 
 ```eval_rst
-.. currentmodule:: mxnet.nn
+.. currentmodule:: mxnet.foo.nn
 ```
 
 ```eval_rst
@@ -13,87 +13,87 @@
 <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
-.. autoclass:: mxnet.nn.Layer
+.. autoclass:: mxnet.foo.nn.Layer
     :members:
 
     .. automethod:: __call__
-.. autoclass:: mxnet.nn.Sequential
+.. autoclass:: mxnet.foo.nn.Sequential
     :members:
-.. autoclass:: mxnet.nn.Dense
+.. autoclass:: mxnet.foo.nn.Dense
     :members:
-.. autoclass:: mxnet.nn.Activation
+.. autoclass:: mxnet.foo.nn.Activation
     :members:
-.. autoclass:: mxnet.nn.Dropout
+.. autoclass:: mxnet.foo.nn.Dropout
     :members:
-.. autoclass:: mxnet.nn.BatchNorm
+.. autoclass:: mxnet.foo.nn.BatchNorm
     :members:
 .. autoclass:: mxnet.LeakyReLU
     :members:
 
-.. autoclass:: mxnet.nn.Conv1D
+.. autoclass:: mxnet.foo.nn.Conv1D
     :members:
-.. autoclass:: mxnet.nn.Conv2D
+.. autoclass:: mxnet.foo.nn.Conv2D
     :members:
-.. autoclass:: mxnet.nn.Conv3D
+.. autoclass:: mxnet.foo.nn.Conv3D
     :members:
-.. autoclass:: mxnet.nn.Conv1DTranspose
+.. autoclass:: mxnet.foo.nn.Conv1DTranspose
     :members:
-.. autoclass:: mxnet.nn.Conv2DTranspose
+.. autoclass:: mxnet.foo.nn.Conv2DTranspose
     :members:
-.. autoclass:: mxnet.nn.Conv3DTranspose
+.. autoclass:: mxnet.foo.nn.Conv3DTranspose
     :members:
-.. autoclass:: mxnet.nn.MaxPool1D
+.. autoclass:: mxnet.foo.nn.MaxPool1D
     :members:
-.. autoclass:: mxnet.nn.MaxPool2D
+.. autoclass:: mxnet.foo.nn.MaxPool2D
     :members:
-.. autoclass:: mxnet.nn.MaxPool3D
+.. autoclass:: mxnet.foo.nn.MaxPool3D
     :members:
-.. autoclass:: mxnet.nn.AvgPool1D
+.. autoclass:: mxnet.foo.nn.AvgPool1D
     :members:
-.. autoclass:: mxnet.nn.AvgPool2D
+.. autoclass:: mxnet.foo.nn.AvgPool2D
     :members:
-.. autoclass:: mxnet.nn.AvgPool3D
+.. autoclass:: mxnet.foo.nn.AvgPool3D
     :members:
-.. autoclass:: mxnet.nn.GlobalMaxPool1D
+.. autoclass:: mxnet.foo.nn.GlobalMaxPool1D
     :members:
-.. autoclass:: mxnet.nn.GlobalMaxPool2D
+.. autoclass:: mxnet.foo.nn.GlobalMaxPool2D
     :members:
-.. autoclass:: mxnet.nn.GlobalMaxPool3D
+.. autoclass:: mxnet.foo.nn.GlobalMaxPool3D
     :members:
-.. autoclass:: mxnet.nn.GlobalAvgPool1D
+.. autoclass:: mxnet.foo.nn.GlobalAvgPool1D
     :members:
-.. autoclass:: mxnet.nn.GlobalAvgPool2D
+.. autoclass:: mxnet.foo.nn.GlobalAvgPool2D
     :members:
-.. autoclass:: mxnet.nn.GlobalAvgPool3D
-    :members:
-
-
-.. currentmodule:: mxnet.nn.loss
-.. automethod:: mxnet.nn.loss.custom_loss
-
-.. automethod:: mxnet.nn.loss.multitask_loss
-
-.. automethod:: mxnet.nn.loss.l1_loss
-
-.. automethod:: mxnet.nn.loss.l2_loss
-
-.. automethod:: mxnet.nn.loss.softmax_cross_entropy_loss
-
-.. currentmodule:: mxnet.nn
-.. autoclass:: mxnet.nn.Optim
+.. autoclass:: mxnet.foo.nn.GlobalAvgPool3D
     :members:
 
-.. autoclass:: mxnet.nn.Parameter
+
+.. currentmodule:: mxnet.foo.nn.loss
+.. automethod:: mxnet.foo.nn.loss.custom_loss
+
+.. automethod:: mxnet.foo.nn.loss.multitask_loss
+
+.. automethod:: mxnet.foo.nn.loss.l1_loss
+
+.. automethod:: mxnet.foo.nn.loss.l2_loss
+
+.. automethod:: mxnet.foo.nn.loss.softmax_cross_entropy_loss
+
+.. currentmodule:: mxnet.foo.nn
+.. autoclass:: mxnet.foo.nn.Optim
     :members:
-.. autoclass:: mxnet.nn.ParameterDict
+
+.. autoclass:: mxnet.foo.nn.Parameter
+    :members:
+.. autoclass:: mxnet.foo.nn.ParameterDict
     :members:
 
-.. currentmodule:: mxnet.nn.utils
-.. automethod:: mxnet.nn.utils.split_data
+.. currentmodule:: mxnet.foo.nn.utils
+.. automethod:: mxnet.foo.nn.utils.split_data
 
-.. automethod:: mxnet.nn.utils.load_data
+.. automethod:: mxnet.foo.nn.utils.load_data
 
-.. currentmodule:: mxnet.nn
+.. currentmodule:: mxnet.foo.nn
 ```
 
 <script>auto_index("api-reference");</script>

--- a/docs/api/python/nn.md
+++ b/docs/api/python/nn.md
@@ -68,16 +68,18 @@
     :members:
 
 
-.. automethod:: mxnet.nn.custom_loss
+.. currentmodule:: mxnet.nn.loss
+.. automethod:: mxnet.nn.loss.custom_loss
 
-.. automethod:: mxnet.nn.multitask_loss
+.. automethod:: mxnet.nn.loss.multitask_loss
 
-.. automethod:: mxnet.nn.l1_loss
+.. automethod:: mxnet.nn.loss.l1_loss
 
-.. automethod:: mxnet.nn.l2_loss
+.. automethod:: mxnet.nn.loss.l2_loss
 
-.. automethod:: mxnet.nn.softmax_cross_entropy_loss
+.. automethod:: mxnet.nn.loss.softmax_cross_entropy_loss
 
+.. currentmodule:: mxnet.nn
 .. autoclass:: mxnet.nn.Optim
     :members:
 
@@ -86,9 +88,12 @@
 .. autoclass:: mxnet.nn.ParameterDict
     :members:
 
-.. automethod:: mxnet.nn.split_data
+.. currentmodule:: mxnet.nn.utils
+.. automethod:: mxnet.nn.utils.split_data
 
-.. automethod:: mxnet.nn.load_data
+.. automethod:: mxnet.nn.utils.load_data
+
+.. currentmodule:: mxnet.nn
 ```
 
 <script>auto_index("api-reference");</script>

--- a/docs/api/python/nn.md
+++ b/docs/api/python/nn.md
@@ -1,0 +1,94 @@
+# NN API
+
+```eval_rst
+.. currentmodule:: mxnet.nn
+```
+
+```eval_rst
+.. warning:: This package is currently experimental and may change in the near future.
+```
+
+## API Reference
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+.. autoclass:: mxnet.nn.Layer
+    :members:
+
+    .. automethod:: __call__
+.. autoclass:: mxnet.nn.Sequential
+    :members:
+.. autoclass:: mxnet.nn.Dense
+    :members:
+.. autoclass:: mxnet.nn.Activation
+    :members:
+.. autoclass:: mxnet.nn.Dropout
+    :members:
+.. autoclass:: mxnet.nn.BatchNorm
+    :members:
+.. autoclass:: mxnet.LeakyReLU
+    :members:
+
+.. autoclass:: mxnet.nn.Conv1D
+    :members:
+.. autoclass:: mxnet.nn.Conv2D
+    :members:
+.. autoclass:: mxnet.nn.Conv3D
+    :members:
+.. autoclass:: mxnet.nn.Conv1DTranspose
+    :members:
+.. autoclass:: mxnet.nn.Conv2DTranspose
+    :members:
+.. autoclass:: mxnet.nn.Conv3DTranspose
+    :members:
+.. autoclass:: mxnet.nn.MaxPool1D
+    :members:
+.. autoclass:: mxnet.nn.MaxPool2D
+    :members:
+.. autoclass:: mxnet.nn.MaxPool3D
+    :members:
+.. autoclass:: mxnet.nn.AvgPool1D
+    :members:
+.. autoclass:: mxnet.nn.AvgPool2D
+    :members:
+.. autoclass:: mxnet.nn.AvgPool3D
+    :members:
+.. autoclass:: mxnet.nn.GlobalMaxPool1D
+    :members:
+.. autoclass:: mxnet.nn.GlobalMaxPool2D
+    :members:
+.. autoclass:: mxnet.nn.GlobalMaxPool3D
+    :members:
+.. autoclass:: mxnet.nn.GlobalAvgPool1D
+    :members:
+.. autoclass:: mxnet.nn.GlobalAvgPool2D
+    :members:
+.. autoclass:: mxnet.nn.GlobalAvgPool3D
+    :members:
+
+
+.. automethod:: mxnet.nn.custom_loss
+
+.. automethod:: mxnet.nn.multitask_loss
+
+.. automethod:: mxnet.nn.l1_loss
+
+.. automethod:: mxnet.nn.l2_loss
+
+.. automethod:: mxnet.nn.softmax_cross_entropy_loss
+
+.. autoclass:: mxnet.nn.Optim
+    :members:
+
+.. autoclass:: mxnet.nn.Parameter
+    :members:
+.. autoclass:: mxnet.nn.ParameterDict
+    :members:
+
+.. automethod:: mxnet.nn.split_data
+
+.. automethod:: mxnet.nn.load_data
+```
+
+<script>auto_index("api-reference");</script>

--- a/python/mxnet/foo/rnn/rnn_cell.py
+++ b/python/mxnet/foo/rnn/rnn_cell.py
@@ -93,9 +93,9 @@ class RecurrentCell(Layer):
         Prefix for names of layers
         (this prefix is also used for names of weights if `params` is None
         i.e. if `params` are being created and not reused)
-    params : RNNParams or None, optional
+    params : Parameter or None, optional
         Container for weight sharing between cells.
-        A new RNNParams container is created if `params` is None.
+        A new Parameter container is created if `params` is None.
     """
     def __init__(self, prefix=None, params=None):
         super(RecurrentCell, self).__init__(prefix=prefix, params=params)
@@ -345,7 +345,7 @@ class RNNCell(RecurrentCell):
     prefix : str, default 'rnn_'
         prefix for name of layers
         (and name of weight if params is None)
-    params : RNNParams or None
+    params : Parameter or None
         container for weight sharing between cells.
         created if None.
     """
@@ -395,7 +395,7 @@ class LSTMCell(RecurrentCell):
     prefix : str, default 'lstm_'
         prefix for name of layers
         (and name of weight if params is None)
-    params : RNNParams or None
+    params : Parameter or None
         container for weight sharing between cells.
         created if None.
     forget_bias : bias added to forget gate, default 1.0.
@@ -465,7 +465,7 @@ class GRUCell(RecurrentCell):
     prefix : str, default 'gru_'
         prefix for name of layers
         (and name of weight if params is None)
-    params : RNNParams or None
+    params : Parameter or None
         container for weight sharing between cells.
         created if None.
     """


### PR DESCRIPTION
The API reference doc page for foo (pending a name) is hosted [here](http://mxnet-doc.s3-website-us-east-1.amazonaws.com/api/python/foo.html)