### PR TITLE
tools/measure.py: add 'from functools import reduce' for python3 …

### DIFF
--- a/tools/bandwidth/measure.py
+++ b/tools/bandwidth/measure.py
@@ -9,6 +9,7 @@ import time
 import numpy as np
 from importlib import import_module
 from collections import namedtuple
+from functools import reduce
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
…compatibility (note: needs python 2.6). one line change. on quick search, seems to be only such usage in tools/... and python/...

