### PR TITLE
fix python debug cpp markdown format

### DIFF
--- a/example/python-howto/README.md
+++ b/example/python-howto/README.md
@@ -15,7 +15,7 @@ Python Howto Examples
 	*  run python under gdb:  ```gdb --args python debug_conv.py```
 	*  in gdb set break point on particular line of the code and run execution: 
 
-		```
+```
 (gdb) break src/operator/convolution-inl.h:120
 (gdb) run
 Breakpoint 1, mxnet::op::ConvolutionOp<mshadow::cpu, float>::Forward (this=0x12219d0, ctx=..., in_data=std::vector of length 3, capacity 4 = {...}, req=std::vector of length 1, capacity 1 = {...}, out_data=std::vector of length 1, capacity 1 = {...},
@@ -32,4 +32,4 @@ Breakpoint 1, mxnet::op::ConvolutionOp<mshadow::cpu, float>::Forward (this=0x122
 123	        in_data[conv::kWeight].get_with_shape<xpu, 3, DType>(wmat_shape, s);
 124	    Tensor<xpu, 4, DType> out = out_data[conv::kOut].get<xpu, 4, DType>(s);
 125	#if defined(__CUDACC__)
-		```
+```


### PR DESCRIPTION
fix markdown format. the original format will not be recognize as a `block`