### PR TITLE
Use pinned memory in IO iterator to avoid unnecessary memory copies

### DIFF
--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -266,15 +266,7 @@ inline bool ImageRecordIOParser2<DType>::ParseNext(DataBatch *out) {
         auto dtype = prefetch_param_.dtype
           ? prefetch_param_.dtype.value()
           : first_batch.data[i].type_flag_;
-#if MXNET_USE_CUDA
-        int gpu_num;
-        int ret = cudaGetDeviceCount(&gpu_num);
-        Context pinned_ctx = (ret == 0 && gpu_num > 0) ?
-                             Context::CPUPinned(0) : Context::CPU();
-        out->data.at(i) = NDArray(dst_shape, pinned_ctx, false, src_type_flag);
-#else
-        out->data.at(i) = NDArray(dst_shape, Context::CPU(), false, src_type_flag);
-#endif
+        out->data.at(i) = NDArray(dst_shape, Context::CPUPinned(0), false, src_type_flag);
         unit_size_[i] = src_shape.Size();
       }
     }

--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -266,7 +266,15 @@ inline bool ImageRecordIOParser2<DType>::ParseNext(DataBatch *out) {
         auto dtype = prefetch_param_.dtype
           ? prefetch_param_.dtype.value()
           : first_batch.data[i].type_flag_;
+#if MXNET_USE_CUDA
+        int gpu_num;
+        int ret = cudaGetDeviceCount(&gpu_num);
+        Context pinned_ctx = (ret == 0 && gpu_num > 0) ?
+                             Context::CPUPinned(0) : Context::CPU();
+        out->data.at(i) = NDArray(dst_shape, pinned_ctx, false, src_type_flag);
+#else
         out->data.at(i) = NDArray(dst_shape, Context::CPU(), false, src_type_flag);
+#endif
         unit_size_[i] = src_shape.Size();
       }
     }

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -18,14 +18,7 @@ namespace kvstore {
 class Comm {
  public:
   Comm() {
-#if MXNET_USE_CUDA
-    int gpu_num;
-    int ret = cudaGetDeviceCount(&gpu_num);
-    pinned_ctx_ = (ret == 0 && gpu_num > 0) ?
-                  Context::CPUPinned(0) : Context::CPU();
-#else
-    pinned_ctx_ = Context::CPU();
-#endif
+    pinned_ctx_ = Context::CPUPinned(0);
   }
   virtual ~Comm() { }
   /**


### PR DESCRIPTION
Using non-pinned memory in asynchronous copies makes the CUDA driver perform additional unnecessary non-pinned->pinned memcpy. That's why this PR changes the memory type used as an output from IO iterator to be pinned to avoid this additional copy.