### PR TITLE
round batch should start with first element.

### DIFF
--- a/src/io/iter_csv.cc
+++ b/src/io/iter_csv.cc
@@ -174,8 +174,8 @@ Examples::
   [3.  4.  5.]]
 
   [[4.  5.  6.]
-  [2.  3.  4.]
-  [3.  4.  5.]]
+  [1.  2.  3.]
+  [2.  3.  4.]]
 
   // Now, `reset` method is called.
   CSVIter.reset()


### PR DESCRIPTION
when set round_batch=True, we should start with first element. Current document is not correct.
Please refer to `mxnet/src/iter_batchloader.h` for details of loading strategy.

```python
# round_batch=True
[[ 1.  2.  3.]
 [ 2.  3.  4.]
 [ 3.  4.  5.]]
[[ 4.  5.  6.]
 [ 1.  2.  3.]
 [ 2.  3.  4.]]
# round_batch=False
[[ 1.  2.  3.]
 [ 2.  3.  4.]
 [ 3.  4.  5.]]
[[ 4.  5.  6.]
 [ 2.  3.  4.]
 [ 3.  4.  5.]]
```