### PR TITLE
Fix for broken link

### DIFF
--- a/example/image-classification/README.md
+++ b/example/image-classification/README.md
@@ -108,7 +108,7 @@ to classify an image with jupyter notebook.
 ### ImageNet 1K
 
 It is first used by
-[ImageNet challenge 2012](http://mxnet.io/tutorials/python/predict_imagenet.html),
+[ImageNet challenge 2012](http://www.image-net.org/challenges/LSVRC/2012/),
 which contains about 1.2M images with 1000 classes. To test these models, one
 can use
 [data/imagenet1k-val.sh](https://github.com/dmlc/mxnet/blob/master/example/image-classification/data/imagenet1k-val.sh)


### PR DESCRIPTION
Also, the link to how to predict by pretrained model(http://mxnet.io/tutorials/python/predict_imagenet.html) is broken.