### PR TITLE
enable use of lapack by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ mxnet_option(USE_OPENCV           "Build with OpenCV support" ON)
 mxnet_option(USE_OPENMP           "Build with Openmp support" ON)
 mxnet_option(USE_CUDA             "Build with CUDA support"   ON)
 mxnet_option(USE_CUDNN            "Build with cudnn support"  ON) # one could set CUDNN_ROOT for search path
+mxnet_option(USE_LAPACK           "Build with lapack support" ON)
 mxnet_option(USE_MKL_IF_AVAILABLE "Use MKL if found" ON)
 mxnet_option(USE_MKLML_MKL        "Use MKLML variant of MKL (if MKL found)" ON IF USE_MKL_IF_AVAILABLE AND UNIX AND (NOT APPLE))
 mxnet_option(USE_MKL_EXPERIMENTAL "Use experimental MKL (if MKL enabled and found)" OFF)

--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,8 @@ ifeq ($(USE_LAPACK), 1)
 ifeq ($(USE_BLAS),$(filter $(USE_BLAS),blas openblas atlas))
 ifeq (,$(wildcard /lib/liblapack.a))
 ifeq (,$(wildcard /usr/lib/liblapack.a))
-ifeq (,$(wildcard /usr/local/lib/liblapack.a))
 ifeq (,$(wildcard $(USE_LAPACK_PATH)/liblapack.a))
 	USE_LAPACK = 0
-endif
 endif
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -106,14 +106,35 @@ else
 endif
 endif
 
+# verify existence of separate lapack library when using blas/openblas/atlas
+# switch off lapack support in case it can't be found
+# issue covered with this
+#   -  for Ubuntu 14.04 or lower, lapack is not automatically installed with openblas
+#   -  for Ubuntu, installing atlas will not automatically install the atlas provided lapack library
+# silently switching lapack off instead of letting the build fail because of backward compatibility
+ifeq ($(USE_LAPACK), 1)
+ifeq ($(USE_BLAS),$(filter $(USE_BLAS),blas openblas atlas))
+ifeq (,$(wildcard /lib/liblapack.a))
+ifeq (,$(wildcard /usr/lib/liblapack.a))
+ifeq (,$(wildcard /usr/local/lib/liblapack.a))
+ifeq (,$(wildcard $(USE_LAPACK_PATH)/liblapack.a))
+	USE_LAPACK = 0
+endif
+endif
+endif
+endif
+endif
+endif
+
 # lapack settings.
 ifeq ($(USE_LAPACK), 1)
-ifeq ($(USE_BLAS),$(filter $(USE_BLAS),openblas apple atlas mkl))
-        CFLAGS += -DMXNET_USE_LAPACK
-endif
-ifeq ($(USE_BLAS),$(filter $(USE_BLAS),openblas atlas mkl))
-        LDFLAGS += -llapack
-endif
+	ifneq ($(USE_LAPACK_PATH), )
+		LDFLAGS += -L$(USE_LAPACK_PATH)
+	endif
+	ifeq ($(USE_BLAS),$(filter $(USE_BLAS),blas openblas atlas))
+		LDFLAGS += -llapack
+	endif
+	CFLAGS += -DMXNET_USE_LAPACK
 endif
 
 ifeq ($(USE_CUDNN), 1)

--- a/include/mxnet/c_lapack_api.h
+++ b/include/mxnet/c_lapack_api.h
@@ -71,9 +71,11 @@ inline char loup(char uplo, bool invert) { return invert ? (uplo == 'U' ? 'L' : 
   MXNET_LAPACK_CWRAPPER1(dpotri, double)
 
 #else
+
   // use pragma message instead of warning
-  #pragma message("Warning: lapack usage not enabled, linalg-operators will be not available." \
-                  " Build with USE_LAPACK=1 to get lapack functionalities.")
+  #pragma message("Warning: lapack usage not enabled, linalg-operators will not be available." \
+     " Ensure that lapack library is installed and build with USE_LAPACK=1 to get lapack" \
+     " functionalities.")
 
   // Define compilable stubs.
   #define MXNET_LAPACK_CWRAPPER1(func, dtype) \

--- a/make/config.mk
+++ b/make/config.mk
@@ -65,10 +65,6 @@ USE_OPENCV = 1
 # use openmp for parallelization
 USE_OPENMP = 1
 
-# whether use lapack during compilation
-# only effective when compiled with blas versions openblas/apple/atlas/mkl
-USE_LAPACK = 0
-
 # MKL ML Library for Intel CPU/Xeon Phi
 # Please refer to MKL_README.md for details
 
@@ -96,6 +92,13 @@ USE_BLAS = apple
 else
 USE_BLAS = atlas
 endif
+
+# whether use lapack during compilation
+# only effective when compiled with blas versions openblas/apple/atlas/mkl
+USE_LAPACK = 1
+
+# path to lapack library in case of a non-standard installation
+USE_LAPACK_PATH =
 
 # add path to intel library, you may need it for MKL, if you did not add the path
 # to environment variable

--- a/make/osx.mk
+++ b/make/osx.mk
@@ -62,13 +62,13 @@ USE_OPENCV = 1
 # use openmp for parallelization
 USE_OPENMP = 0
 
-# whether use lapack during compilation
-# only effective when compiled with blas versions openblas/apple/atlas/mkl
-USE_LAPACK = 0
-
 # choose the version of blas you want to use
 # can be: mkl, blas, atlas, openblas
 USE_BLAS = apple
+
+# whether use lapack during compilation
+# only effective when compiled with blas versions openblas/apple/atlas/mkl
+USE_LAPACK = 1
 
 # add path to intel library, you may need it for MKL, if you did not add the path
 # to environment variable

--- a/make/pip_linux_cpu.mk
+++ b/make/pip_linux_cpu.mk
@@ -29,15 +29,17 @@ ADD_CFLAGS += -Ldeps/lib -Ideps/include
 # matrix computation libraries for CPU/GPU
 #---------------------------------------------
 
-# whether use lapack during compilation
-# only effective when compiled with blas versions openblas/apple/atlas/mkl
-# you can disable it, however, you will not be able to use linalg-operators
-USE_LAPACK = 0
-
 # choose the version of blas you want to use
 # can be: mkl, blas, atlas, openblas
 # in default use atlas for linux while apple for osx
 USE_BLAS=openblas
+
+# whether use lapack during compilation
+# only effective when compiled with blas versions openblas/apple/atlas/mkl
+USE_LAPACK = 1
+
+# path to lapack library in case of a non-standard installation
+USE_LAPACK_PATH =
 
 # whether use opencv during compilation
 # you can disable it, however, you will not able to use

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3161,8 +3161,6 @@ def test_custom_op():
 
 
 def test_laop():
-    # Temporarily disabled until lapack is enabled by default
-    return
 
     # Currently no support for GPU. Will be added soon
     # so keep these tests here in this file and activate


### PR DESCRIPTION
Changes to makefiles/config to safely enable use of lapack based functionalities by default. By platform:
- Windows: No issues as we get lapack  with openblas automatically
- osx: No issues as we get lapack with "apple" automatically
- Ubuntu: On Ubuntu 14.04 we don't get the lapack-library automatically installed with openblas. On all Ubuntu versions we don't get it automatically installed when using "atlas". The simplest and most consistent handling is to explicitly check whether the lapack-library is in /usr/lib or /usr/local/lib and if not, then switch off lapack support automatically.

In addition provided an extra variable in the config to support setting a custom path for the lapack library. Just for convenience. 

BTW: The build using "atlas" is generally broken on Ubuntu (at least). Reason is that the mshadow-config adds a "-lcblas" while Ubuntu will install a "blas"-library. The latter is in contrast to the official atlas documentation which states that the library is "cblas". But as atlas is not providing precompiled libraries, guess anyone else is free to name them differently and apparently that is what happened. We have no regression build for atlas on Jenkins, so we never see this. 
Eric, do you think we can simply change this setting in mshadow?



