### PR TITLE
Fix data layout handling in BucketSentenceIter (Fixes #5509)

### DIFF
--- a/python/mxnet/rnn/io.py
+++ b/python/mxnet/rnn/io.py
@@ -7,7 +7,7 @@ import bisect
 import random
 import numpy as np
 
-from ..io import DataIter, DataBatch
+from ..io import DataIter, DataBatch, DataDesc
 from .. import ndarray
 
 def encode_sentences(sentences, vocab=None, invalid_label=-1, invalid_key='\n', start_label=0):
@@ -116,14 +116,23 @@ class BucketSentenceIter(DataIter):
         self.nddata = []
         self.ndlabel = []
         self.major_axis = layout.find('N')
+        self.layout = layout
         self.default_bucket_key = max(buckets)
 
         if self.major_axis == 0:
-            self.provide_data = [(data_name, (batch_size, self.default_bucket_key))]
-            self.provide_label = [(label_name, (batch_size, self.default_bucket_key))]
+            self.provide_data=[DataDesc(
+                name=self.data_name, shape=(batch_size, self.default_bucket_key),
+                layout=self.layout)]
+            self.provide_label=[DataDesc(
+                name=self.label_name, shape=(batch_size, self.default_bucket_key),
+                layout=self.layout)]
         elif self.major_axis == 1:
-            self.provide_data = [(data_name, (self.default_bucket_key, batch_size))]
-            self.provide_label = [(label_name, (self.default_bucket_key, batch_size))]
+            self.provide_data=[DataDesc(
+                name=self.data_name, shape=(self.default_bucket_key, batch_size),
+                layout=self.layout)]
+            self.provide_label=[DataDesc(
+                name=self.label_name, shape=(self.default_bucket_key, batch_size),
+                layout=self.layout)]
         else:
             raise ValueError("Invalid layout %s: Must by NT (batch major) or TN (time major)")
 
@@ -166,5 +175,9 @@ class BucketSentenceIter(DataIter):
 
         return DataBatch([data], [label], pad=0,
                          bucket_key=self.buckets[i],
-                         provide_data=[(self.data_name, data.shape)],
-                         provide_label=[(self.label_name, label.shape)])
+                         provide_data=[DataDesc(
+                             name=self.data_name, shape=data.shape,
+                             layout=self.layout)],
+                         provide_label=[DataDesc(
+                             name=self.label_name, shape=label.shape,
+                             layout=self.layout)])

--- a/python/mxnet/rnn/io.py
+++ b/python/mxnet/rnn/io.py
@@ -120,17 +120,17 @@ class BucketSentenceIter(DataIter):
         self.default_bucket_key = max(buckets)
 
         if self.major_axis == 0:
-            self.provide_data=[DataDesc(
+            self.provide_data = [DataDesc(
                 name=self.data_name, shape=(batch_size, self.default_bucket_key),
                 layout=self.layout)]
-            self.provide_label=[DataDesc(
+            self.provide_label = [DataDesc(
                 name=self.label_name, shape=(batch_size, self.default_bucket_key),
                 layout=self.layout)]
         elif self.major_axis == 1:
-            self.provide_data=[DataDesc(
+            self.provide_data = [DataDesc(
                 name=self.data_name, shape=(self.default_bucket_key, batch_size),
                 layout=self.layout)]
-            self.provide_label=[DataDesc(
+            self.provide_label = [DataDesc(
                 name=self.label_name, shape=(self.default_bucket_key, batch_size),
                 layout=self.layout)]
         else:

--- a/python/mxnet/rnn/io.py
+++ b/python/mxnet/rnn/io.py
@@ -85,7 +85,7 @@ class BucketSentenceIter(DataIter):
     """
     def __init__(self, sentences, batch_size, buckets=None, invalid_label=-1,
                  data_name='data', label_name='softmax_label', dtype='float32',
-                 layout='NTC'):
+                 layout='NT'):
         super(BucketSentenceIter, self).__init__()
         if not buckets:
             buckets = [i for i, j in enumerate(np.bincount([len(s) for s in sentences]))


### PR DESCRIPTION
BucketSentenceIter did not correctly specify the used data layout in the
provide_data and provide_label attributes. This lead to the executor_group
always assuming an NCHW layout, trying to split up the time dimension instead of
the batch_size dimension over all contexts in case that TNC layout was used.

For some reason this nevertheless worked for the provided FusedRNNCell,
resulting in model parallelism.

Interestingly this patch reduces performance by 25% as it replaces the unmeant
model parallelism with the "correct" data parallelism. (Reference architecture
is a simple single-layer CharRNN trained on 4 GTX 1080 cards. Without the patch
~2000 samples/sec, with the patch ~1500 samples/sec)