### PR TITLE
[R] AWS S3 to host all pre-built binary packages.

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -20,12 +20,13 @@ Resources
 Installation
 ------------
 
-For Windows/Mac users, we provide a pre-built binary package using CPU.
-You can install a weekly updated package directly from the R console:
+We provide pre-built binary packages for Windows/OSX users.
+You can install the CPU package directly from the R console:
 
 ```r
-install.packages("drat", repos="https://cran.rstudio.com")
-drat:::addRepo("dmlc")
+cran <- getOption("repos")
+cran["dmlc"] <- "https://s3-us-west-2.amazonaws.com/apache-mxnet/R/CRAN/"
+options(repos = cran)
 install.packages("mxnet")
 ```
 

--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -706,8 +706,9 @@ You could also run distributed deeplearning with *MXNet* on AWS using [Cloudform
 The CPU version of MXNet R package can be installed in R like other packages
 
 ```r
-install.packages("drat")
-drat::addRepo("dmlc")
+cran <- getOption("repos")
+cran["dmlc"] <- "https://s3-us-west-2.amazonaws.com/apache-mxnet/R/CRAN/"
+options(repos = cran)
 install.packages("mxnet")
 ```
 
@@ -870,23 +871,33 @@ The CPU version of MXNet R package can be installed in R like other packages
 
 
 ```r
-install.packages("drat")
-drat::addRepo("dmlc")
+cran <- getOption("repos")
+cran["dmlc"] <- "https://s3-us-west-2.amazonaws.com/apache-mxnet/R/CRAN/"
+options(repos = cran)
 install.packages("mxnet")
 ```
 
-
-</div>
-
-<div class="gpu">
-
-Will be available soon.
-
-</div>
-</div>
 </div>
 
 <!-- END - Windows R CPU Installation Instructions -->
+
+<div class="gpu">
+
+The GPU version of MXNet R package can be installed in R like other packages
+
+
+```r
+cran <- getOption("repos")
+cran["dmlc"] <- "https://s3-us-west-2.amazonaws.com/apache-mxnet/R/CRAN/GPU"
+options(repos = cran)
+install.packages("mxnet")
+```
+
+</div>
+</div>
+</div>
+
+<!-- END - Windows R GPU Installation Instructions -->
 
 <div class="linux">
   <div class="scala julia perl">

--- a/docs/get_started/osx_setup.md
+++ b/docs/get_started/osx_setup.md
@@ -117,9 +117,10 @@ You have 2 options:
 For OS X (Mac) users, MXNet provides a prebuilt binary package for CPUs. The prebuilt package is updated weekly. You can install the package directly in the R console using the following commands:
 
 ```r
-	install.packages("drat", repos="https://cran.rstudio.com")
-	drat:::addRepo("dmlc")
-	install.packages("mxnet")
+  cran <- getOption("repos")
+  cran["dmlc"] <- "https://s3-us-west-2.amazonaws.com/apache-mxnet/R/CRAN/"
+  options(repos = cran)
+  install.packages("mxnet")
 ```
 
 ### Building MXNet from Source Code

--- a/docs/get_started/windows_setup.md
+++ b/docs/get_started/windows_setup.md
@@ -93,11 +93,24 @@ To install MXNet on a computer with a CPU processor, choose from two options:
 * Build the library from source code
 
 #### Building MXNet with the Prebuilt Binary Package
-For Windows users, MXNet provides a prebuilt binary package for CPUs. The prebuilt package is updated weekly. You can install the package directly in the R console using the following commands:
+For Windows users, MXNet provides prebuilt binary packages.
+You can install the package directly in the R console.
+
+For CPU-only package:
 
 ```r
-  install.packages("drat", repos="https://cran.rstudio.com")
-  drat:::addRepo("dmlc")
+  cran <- getOption("repos")
+  cran["dmlc"] <- "https://s3-us-west-2.amazonaws.com/apache-mxnet/R/CRAN/"
+  options(repos = cran)
+  install.packages("mxnet")
+```
+
+For GPU-enabled package:
+
+```r
+  cran <- getOption("repos")
+  cran["dmlc"] <- "https://s3-us-west-2.amazonaws.com/apache-mxnet/R/CRAN/GPU"
+  options(repos = cran)
   install.packages("mxnet")
 ```
 


### PR DESCRIPTION
Please don't merge. I need opinions from R users.

I am considering using S3 to host all the pre-built pkgs for Windows/OSX users, because they are too large to host on github. The GPU-enabled pkg for Windows is more than 180 MB.

For CPU-only pkg:

```r
  cran <- getOption("repos")
  cran["dmlc"] <- "https://s3.amazonaws.com/mxnet-r/"
  options(repos = cran)
  install.packages("mxnet")
```

For GPU-enabled pkg:

```r
  cran <- getOption("repos")
  cran["dmlc"] <- "https://s3.amazonaws.com/mxnet-r/GPU"
  options(repos = cran)
  install.packages("mxnet")
```