### PR TITLE
fix bug in optimizer because state is not synced with weight context

### DIFF
--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -788,9 +788,9 @@ class Updater(object):
     def sync_state_context(self, state, context):
         if isinstance(state, NDArray):
             return state.as_in_context(context)
-        elif isinstance(state, (tuple,list)):
+        elif isinstance(state, (tuple, list)):
             synced_state = (self.sync_state_context(i, context) for i in state)
-            if isinstance(state,tuple):
+            if isinstance(state, tuple):
                 return tuple(synced_state)
             else:
                 return list(synced_state)

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -788,12 +788,12 @@ class Updater(object):
     def sync_state_context(self, state, context):
         if isinstance(state, NDArray):
             return state.as_in_context(context)
-        elif isinstance(state, tuple):
-            state_list = list(state)
-            for index, elem in enumerate(state_list):
-                if isinstance(elem, NDArray):
-                    state_list[index] = state_list[index].as_in_context(context)
-            return tuple(state_list)
+        elif isinstance(state, (tuple,list)):
+            synced_state = (self.sync_state_context(i, context) for i in state)
+            if isinstance(state,tuple):
+                return tuple(synced_state)
+            else:
+                return list(synced_state)
         else:
             return state
 

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -751,6 +751,7 @@ class Ftrl(Optimizer):
 
 @register
 class Test(Optimizer):
+    """The Test optimizer"""
     def __init__(self, **kwargs):
         super(Test, self).__init__(**kwargs)
 
@@ -771,16 +772,35 @@ class Updater(object):
     def __init__(self, optimizer):
         self.optimizer = optimizer
         self.states = {}
+        self.states_synced = {}
 
     def __call__(self, index, grad, weight):
         """Updates weight given gradient and index."""
         if index not in self.states:
             self.states[index] = self.optimizer.create_state(index, weight)
+            self.states_synced[index] = True
+        elif not self.states_synced[index]:
+            self.states[index] = \
+                self.sync_state_context(self.states[index], weight.context)
+            self.states_synced[index] = True
         self.optimizer.update(index, weight, grad, self.states[index])
+    
+    def sync_state_context(self, state, context):
+        if isinstance(state, NDArray):
+            return state.as_in_context(context)
+        if isinstance(state, tuple):
+            state_list = list(state)
+            for index, elem in enumerate(state_list):
+                if isinstance(elem, NDArray):
+                    state_list[index] = state_list[index].as_in_context(context)
+            return tuple(state_list)
+        else:
+            return state
 
     def set_states(self, states):
         """Sets updater states."""
         self.states = pickle.loads(states)
+        self.states_synced = dict.fromkeys(self.states.keys(), False)
 
     def get_states(self):
         """Gets updater states."""

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -784,7 +784,7 @@ class Updater(object):
                 self.sync_state_context(self.states[index], weight.context)
             self.states_synced[index] = True
         self.optimizer.update(index, weight, grad, self.states[index])
-    
+
     def sync_state_context(self, state, context):
         if isinstance(state, NDArray):
             return state.as_in_context(context)

--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -788,7 +788,7 @@ class Updater(object):
     def sync_state_context(self, state, context):
         if isinstance(state, NDArray):
             return state.as_in_context(context)
-        if isinstance(state, tuple):
+        elif isinstance(state, tuple):
             state_list = list(state)
             for index, elem in enumerate(state_list):
                 if isinstance(elem, NDArray):


### PR DESCRIPTION
Thank you for your review @piiswrong.
I accepted your review and removed sync_state_context from Optimizer class.

There was a bug in Updater and Optimizer when training model from gpu0 context, then loading it with gpu1 context and load_optimizer_states=True for module load.
Error message is like below.
Check failed: e == cudaSuccess CUDA: an illegal memory access was encountered
and it causes NVRM error also(from dmesg)
[248747.249293] NVRM: Xid (PCI:0000:83:00): 31, Ch 00000014, engmask 00000101, intr 10000000

This bug prevents users to keep training from the previous optimizer states when attempting with different context.
Related issue is #5428