### PR TITLE
Avoid pushing dangling references into engine

### DIFF
--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -72,7 +72,7 @@ class NaiveEngine final : public Engine {
     Profiler *profiler = Profiler::Get();
     NaiveOpr *opr = op->Cast<NaiveOpr>();
     opr->profiling = profiling && (profiler->GetMode() == Profiler::kOnlySymbolic);
-    this->PushAsync([&](RunContext ctx, CallbackOnComplete on_complete) {
+    this->PushAsync([opr, exec_ctx](RunContext ctx, CallbackOnComplete on_complete) {
 #if MXNET_USE_PROFILER
         if (opr->profiling) {
           opr->opr_stat = Profiler::Get()->AddOprStat(exec_ctx.dev_type, exec_ctx.dev_id);


### PR DESCRIPTION
Please correct me if I'm wrong, I think we cannot push references to local variable into the dependency engine, because the dependency engine may invoke the lambda function after the lifetime of those local variable has ended.
However, it seems that this undefined behavior has not causes any real problem.