### PR TITLE
Fix typos in installation guide

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -1357,7 +1357,7 @@ array([[ 3.,  3.,  3.],
   <div class="r">
     <div class="cpu">
 
-Run a short *MXNet* python program to create a 2X3 matrix of ones, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3.
+Run a short *MXNet* R program to create a 2X3 matrix of ones, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3.
 
 ```r
 library(mxnet)
@@ -1376,7 +1376,7 @@ b
   <div class="r">
     <div class="gpu">
 
-Run a short *MXNet* python program to create a 2X3 matrix of ones *a* on a *GPU*, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3. We use *mx.gpu()*, to set *MXNet* context to be GPUs.
+Run a short *MXNet* R program to create a 2X3 matrix of ones *a* on a *GPU*, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3. We use *mx.gpu()*, to set *MXNet* context to be GPUs.
 
 ```r
 library(mxnet)


### PR DESCRIPTION
Change *python program* to *R program* in R validation examples.