### PR TITLE
set __layout__  attribute for FusedRNNCell output states

### DIFF
--- a/python/mxnet/rnn/rnn_cell.py
+++ b/python/mxnet/rnn/rnn_cell.py
@@ -672,14 +672,15 @@ class FusedRNNCell(BaseRNNCell):
                          mode=self._mode, name=self._prefix+'rnn',
                          **states)
 
+        attr = {'__layout__' : 'LNC'}
         if not self._get_next_state:
             outputs, states = rnn, []
         elif self._mode == 'lstm':
-            rnn[1]._set_attr(__layout__='LNC')
-            rnn[2]._set_attr(__layout__='LNC')
+            rnn[1]._set_attr(**attr)
+            rnn[2]._set_attr(**attr)
             outputs, states = rnn[0], [rnn[1], rnn[2]]
         else:
-            rnn[1]._set_attr(__layout__='LNC')
+            rnn[1]._set_attr(**attr)
             outputs, states = rnn[0], [rnn[1]]
 
         if axis == 1:

--- a/python/mxnet/rnn/rnn_cell.py
+++ b/python/mxnet/rnn/rnn_cell.py
@@ -675,8 +675,11 @@ class FusedRNNCell(BaseRNNCell):
         if not self._get_next_state:
             outputs, states = rnn, []
         elif self._mode == 'lstm':
+            rnn[1]._set_attr(__layout__='LNC')
+            rnn[2]._set_attr(__layout__='LNC')
             outputs, states = rnn[0], [rnn[1], rnn[2]]
         else:
+            rnn[1]._set_attr(__layout__='LNC')
             outputs, states = rnn[0], [rnn[1]]
 
         if axis == 1:


### PR DESCRIPTION
https://github.com/dmlc/mxnet/issues/6736
In `FusedRNNCell`, default layout `N...` is not possible for its output states which should be 'LNC'.
@piiswrong 