### PR TITLE
Add h5py support to NDArrayIter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,8 @@ addons:
       - python3-numpy
       - python3-dev
       - python3-nose
+      - python-h5py
+      - python3-h5py
       - graphviz
       - libmouse-perl
       - pdl

--- a/tests/ci_build/install/ubuntu_install_python.sh
+++ b/tests/ci_build/install/ubuntu_install_python.sh
@@ -6,5 +6,5 @@ apt-get update && apt-get install -y python-dev python3-dev
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 cd /tmp && wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && python2 get-pip.py
 
-pip2 install nose pylint numpy nose-timer requests
-pip3 install nose pylint numpy nose-timer requests
+pip2 install nose pylint numpy nose-timer requests h5py
+pip3 install nose pylint numpy nose-timer requests h5py

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -4,6 +4,7 @@ import numpy as np
 import os, gzip
 import pickle as pickle
 import time
+import h5py
 import sys
 from common import get_data
 
@@ -63,17 +64,17 @@ def test_Cifar10Rec():
         assert(labelcount[i] == 5000)
 
 def test_NDArrayIter():
-    datas = np.ones([1000, 2, 2])
-    labels = np.ones([1000, 1])
+    data = np.ones([1000, 2, 2])
+    label = np.ones([1000, 1])
     for i in range(1000):
-        datas[i] = i / 100
-        labels[i] = i / 100
-    dataiter = mx.io.NDArrayIter(datas, labels, 128, True, last_batch_handle='pad')
+        data[i] = i / 100
+        label[i] = i / 100
+    dataiter = mx.io.NDArrayIter(data, label, 128, True, last_batch_handle='pad')
     batchidx = 0
     for batch in dataiter:
         batchidx += 1
     assert(batchidx == 8)
-    dataiter = mx.io.NDArrayIter(datas, labels, 128, False, last_batch_handle='pad')
+    dataiter = mx.io.NDArrayIter(data, label, 128, False, last_batch_handle='pad')
     batchidx = 0
     labelcount = [0 for i in range(10)]
     for batch in dataiter:
@@ -88,7 +89,42 @@ def test_NDArrayIter():
         else:
             assert(labelcount[i] == 100)
 
+def test_NDArrayIter_h5py():
+    data = np.ones([1000, 2, 2])
+    label = np.ones([1000, 1])
+    for i in range(1000):
+        data[i] = i / 100
+        label[i] = i / 100
+
+    try:
+        os.remove("ndarraytest.h5")
+    except OSError:
+        pass
+    with h5py.File("ndarraytest.h5") as f:
+        f.create_dataset("data", data=data)
+        f.create_dataset("label", data=label)
+
+        dataiter = mx.io.NDArrayIter(f["data"], f["label"], 128, last_batch_handle='pad')
+        batchidx = 0
+        labelcount = [0 for i in range(10)]
+        for batch in dataiter:
+            batchidx += 1
+            label = batch.label[0].asnumpy().flatten()
+            assert((batch.data[0].asnumpy()[:,0,0] == label).all())
+            for i in range(label.shape[0]):
+                labelcount[int(label[i])] += 1
+
+        assert(batchidx == 8)
+
+    for i in range(10):
+        if i == 0:
+            assert(labelcount[i] == 124)
+        else:
+            assert(labelcount[i] == 100)
+
+
 if __name__ == "__main__":
     test_NDArrayIter()
+    test_NDArrayIter_h5py()
     test_MNISTIter()
     test_Cifar10Rec()

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -4,7 +4,10 @@ import numpy as np
 import os, gzip
 import pickle as pickle
 import time
-import h5py
+try:
+    import h5py
+except ImportError:
+    h5py = None
 import sys
 from common import get_data
 
@@ -90,6 +93,9 @@ def test_NDArrayIter():
             assert(labelcount[i] == 100)
 
 def test_NDArrayIter_h5py():
+    if not h5py:
+        return
+
     data = np.ones([1000, 2, 2])
     label = np.ones([1000, 1])
     for i in range(1000):
@@ -118,6 +124,11 @@ def test_NDArrayIter_h5py():
             for i in range(label.shape[0]):
                 labelcount[int(label[i])] += 1
 
+    try:
+        os.remove("ndarraytest.h5")
+    except OSError:
+        pass
+
     for i in range(10):
         if i == 0:
             assert(labelcount[i] == 124)
@@ -127,6 +138,7 @@ def test_NDArrayIter_h5py():
 
 if __name__ == "__main__":
     test_NDArrayIter()
-    test_NDArrayIter_h5py()
+    if h5py:
+        test_NDArrayIter_h5py()
     test_MNISTIter()
     test_Cifar10Rec()

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -104,17 +104,19 @@ def test_NDArrayIter_h5py():
         f.create_dataset("data", data=data)
         f.create_dataset("label", data=label)
 
-        dataiter = mx.io.NDArrayIter(f["data"], f["label"], 128, last_batch_handle='pad')
+        dataiter = mx.io.NDArrayIter(f["data"], f["label"], 128, True, last_batch_handle='pad')
         batchidx = 0
-        labelcount = [0 for i in range(10)]
         for batch in dataiter:
             batchidx += 1
+        assert(batchidx == 8)
+
+        dataiter = mx.io.NDArrayIter(f["data"], f["label"], 128, False, last_batch_handle='pad')
+        labelcount = [0 for i in range(10)]
+        for batch in dataiter:
             label = batch.label[0].asnumpy().flatten()
             assert((batch.data[0].asnumpy()[:,0,0] == label).all())
             for i in range(label.shape[0]):
                 labelcount[int(label[i])] += 1
-
-        assert(batchidx == 8)
 
     for i in range(10):
         if i == 0:


### PR DESCRIPTION
This pull request adds basic h5py support to NDArrayIter.

Data will be read from the h5 dataset on demand (when creating a batch) so that large datasets that don't fit in memory are supported. Shuffling is also supported by storing a set of shuffled indices.