### PR TITLE
Sparse dot enhancement

### DIFF
--- a/src/operator/nn/cast_storage-inl.h
+++ b/src/operator/nn/cast_storage-inl.h
@@ -60,13 +60,18 @@ inline void CastStorageDnsRspImpl(mshadow::Stream<cpu>* s, const TBlob& dns, NDA
       mxnet_op::Kernel<MarkRspRowIdx, cpu>::Launch(s, num_rows, row_idx,
           dns.dptr<DType>(), num_cols);
       index_t nnr = 0;
+      double start = dmlc::GetTime();
       nnr = mxnet::common::ParallelAccumulate(row_idx, num_rows, nnr);
+      double elapsed = dmlc::GetTime() - start;
+      LOG(INFO) << "CastStorageDnsRspImpl: ParallelAccumulate time cost " << elapsed * 1000 << " ms";
+      LOG(INFO) << "CastStorageDnsRspImpl: nnr = " << nnr;
       rsp->set_aux_shape(rowsparse::kIdx, mshadow::Shape1(nnr));
       if (0 == nnr) return;
       rsp->CheckAndAllocData(mshadow::Shape2(nnr, num_cols));
       mshadow::Tensor<cpu, 2, DType> dns_data = dns.FlatTo2D<cpu, DType>(s);
       mshadow::Tensor<cpu, 2, DType> rsp_data = rsp->data().FlatTo2D<cpu, DType>(s);
       size_t idx = 0;
+      start = dmlc::GetTime();
       for (index_t i = 0; i < num_rows; ++i) {
         if (row_idx[i] > 0) {
           row_idx[idx] = i;
@@ -74,6 +79,8 @@ inline void CastStorageDnsRspImpl(mshadow::Stream<cpu>* s, const TBlob& dns, NDA
           ++idx;
         }
       }
+      elapsed = dmlc::GetTime() - start;
+      LOG(INFO) << "CastStorageDnsRspImpl: copy rows time cost " << elapsed * 1000 << " ms";
     });
   });
 }
@@ -278,7 +285,10 @@ void CastStorageComputeImpl(mshadow::Stream<xpu>* s,
     CastStorageRspDnsImpl<xpu>(s, input, &ret);
   } else if (src_stype == kDefaultStorage && dst_stype == kRowSparseStorage) {
     NDArray ret = output;  // get rid of the const qualifer
+    double start = dmlc::GetTime();
     CastStorageDnsRspImpl(s, input.data(), &ret);
+    double elapsed = dmlc::GetTime() - start;
+    LOG(INFO) << "CastStorageDnsRspImpl: time cost " << elapsed * 1000 << " ms";
   } else if (src_stype == kDefaultStorage && dst_stype == kCSRStorage) {
     NDArray ret = output;  // get rid of the const qualifer
     CastStorageDnsCsrImpl(s, input.data(), &ret);

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -798,6 +798,7 @@ void DotCsrDnsRspImpl(const OpContext& ctx,
               index_t nnr = 0;
               nnr = mxnet::common::ParallelAccumulate(row_idx, ret->shape()[0], nnr);
               ret->set_aux_shape(rowsparse::kIdx, mshadow::Shape1(nnr));
+              ret->set_storage_shape(mshadow::Shape2(nnr, ret->shape()[1]));
               if (0 == nnr) return;
               mshadow::Tensor<xpu, 2, DType> rsp_data = data_out.FlatTo2D<xpu, DType>(s);
               size_t idx = 0;

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -777,9 +777,9 @@ void DotCsrDnsRspImpl(const OpContext& ctx,
   const TBlob row_idx_out = ret->aux_data(rowsparse::kIdx);
 
   MSHADOW_TYPE_SWITCH(data_l.type_flag_, DType, {  // data type
-    MSHADOW_INT_TYPE_SWITCH(indptr_l.type_flag_, IType, {  // indptr type
-      MSHADOW_INT_TYPE_SWITCH(col_idx_l.type_flag_, CType, {  // col idx type
-        MSHADOW_INT_TYPE_SWITCH(row_idx_out.type_flag_, RType, {  // col idx type
+    MSHADOW_IDX_TYPE_SWITCH(indptr_l.type_flag_, IType, {  // indptr type
+      MSHADOW_IDX_TYPE_SWITCH(col_idx_l.type_flag_, CType, {  // col idx type
+        MSHADOW_IDX_TYPE_SWITCH(row_idx_out.type_flag_, RType, {  // col idx type
           if (std::is_same<xpu, cpu>::value) {  // cpu parallelization by row blocks
             if (kWriteTo == req) {
               mxnet_op::Kernel<mxnet_op::set_zero, xpu>::Launch(

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -7,6 +7,7 @@
 #define MXNET_OPERATOR_TENSOR_MATRIX_OP_INL_H_
 
 #include <mxnet/operator_util.h>
+#include <dmlc/timer.h>
 #include <vector>
 #include <algorithm>
 #include <utility>
@@ -323,6 +324,7 @@ inline bool ExpandDimShape(const nnvm::NodeAttrs& attrs,
 struct DotParam : public dmlc::Parameter<DotParam> {
   bool transpose_a;
   bool transpose_b;
+  int _out_stype;
   DMLC_DECLARE_PARAMETER(DotParam) {
     DMLC_DECLARE_FIELD(transpose_a)
       .describe("If true then transpose the first input before dot.")
@@ -330,6 +332,10 @@ struct DotParam : public dmlc::Parameter<DotParam> {
     DMLC_DECLARE_FIELD(transpose_b)
       .describe("If true then transpose the second input before dot.")
       .set_default(false);
+    DMLC_DECLARE_FIELD(_out_stype)
+      .add_enum("dns", kDefaultStorage)
+      .add_enum("csr", kCSRStorage)
+      .add_enum("rsp", kRowSparseStorage);
   }
 };
 
@@ -484,12 +490,15 @@ inline bool DotForwardInferStorageType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 2U);
   CHECK_EQ(out_attrs->size(), 1U);
   const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
+  (*out_attrs)[0] = param._out_stype;
+#if 0
   if (param.transpose_a && kCSRStorage == (*in_attrs)[0]
       && kDefaultStorage == (*in_attrs)[1]) {
     STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 0, kRowSparseStorage);
   } else {
     STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 0, kDefaultStorage);
   }
+#endif
   return true;
 }
 
@@ -722,10 +731,14 @@ void DotCsrDnsDnsImpl(const OpContext& ctx,
           int num_threads = mxnet_op::get_num_threads<xpu>(data_out.shape_[0]);
           size_t seg_len = (data_out.shape_[0] + num_threads - 1) / num_threads;
           if (trans_lhs) {
+            double start = dmlc::GetTime();
             mxnet_op::Kernel<DotCsrTransDnsDnsByRowBlocks, xpu>::Launch(s, num_threads,
                 data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
                 col_idx_l.dptr<CType>(), data_r.dptr<DType>(), seg_len,
                 lhs.shape()[0], data_out.shape_[0], data_out.shape_[1]);
+            double elapsed = dmlc::GetTime() - start;
+            LOG(INFO) << "DotCsrDnsDnsImpl: Kernel<DotCsrTransDnsDnsByRowBlocks> time cost "
+                      << elapsed * 1000 << " ms";
           } else {
             mxnet_op::Kernel<DotCsrDnsDnsByRowBlocks, xpu>::Launch(s, num_threads,
                 data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
@@ -791,23 +804,37 @@ void DotCsrDnsRspImpl(const OpContext& ctx,
             int num_threads = mxnet_op::get_num_threads<xpu>(data_out.shape_[0]);
             size_t seg_len = (data_out.shape_[0] + num_threads - 1) / num_threads;
             if (trans_lhs) {
+              double start = dmlc::GetTime();
               mxnet_op::Kernel<DotCsrTransDnsRspByRowBlocks, xpu>::Launch(s, num_threads,
                   data_out.dptr<DType>(), row_idx, data_l.dptr<DType>(),
                   indptr_l.dptr<IType>(), col_idx_l.dptr<CType>(), data_r.dptr<DType>(),
                   seg_len, lhs.shape()[0], data_out.shape_[0], data_out.shape_[1]);
+              double elapsed = dmlc::GetTime() - start;
+              LOG(INFO) << "DotCsrDnsRspImpl: Kernel<DotCsrTransDnsRspByRowBlocks, cpu> time cost "
+                        << elapsed * 1000 << " ms";
               index_t nnr = 0;
+
+              start = dmlc::GetTime();
               nnr = mxnet::common::ParallelAccumulate(row_idx, ret->shape()[0], nnr);
+              elapsed = dmlc::GetTime() - start;
+              LOG(INFO) << "DotCsrDnsRspImpl: ParallelAccumulate time cost " << elapsed * 1000 << " ms";
+              LOG(INFO) << "DotCsrDnsRspImpl: nnr = " << nnr;
               ret->set_aux_shape(rowsparse::kIdx, mshadow::Shape1(nnr));
+              ret->set_storage_shape(mshadow::Shape2(nnr, ret->shape()[1]));
               if (0 == nnr) return;
               mshadow::Tensor<xpu, 2, DType> rsp_data = data_out.FlatTo2D<xpu, DType>(s);
               size_t idx = 0;
+
+              start = dmlc::GetTime();
               for (index_t i = 0; i < ret->shape()[0]; ++i) {
-                if (row_idx > 0) {
+                if (row_idx[i] > 0) {
                   row_idx[idx] = i;
                   mshadow::Copy(rsp_data[idx], rsp_data[i], s);
                   ++idx;
                 }
               }
+              elapsed = dmlc::GetTime() - start;
+              LOG(INFO) << "DotCsrDnsRspImpl: copy rows time cost " << elapsed * 1000 << " ms";
             } else {
               LOG(FATAL) << "DotCsrDnsRspImpl has not implemented dot(csr, dns)=rsp yet."
                             " Only the cpu version of dot(csr.T, dns)=rsp is supported now";
@@ -917,7 +944,10 @@ void DotForwardEx(const nnvm::NodeAttrs& attrs,
   auto out_stype = outputs[0].storage_type();
   if (lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage && out_stype == kDefaultStorage) {
     TBlob ret = outputs[0].data();
+    double start = dmlc::GetTime();
     DotCsrDnsDnsImpl<xpu>(ctx, inputs[0], inputs[1].data(), req[0], param.transpose_a, &ret);
+    double elapsed = dmlc::GetTime() - start;
+    LOG(INFO) << "DotCsrDnsDnsImpl: time cost " << elapsed * 1000 << " ms";
   } else if (lhs_stype == kCSRStorage && rhs_stype == kRowSparseStorage &&
     out_stype == kDefaultStorage) {
     TBlob ret = outputs[0].data();
@@ -925,7 +955,10 @@ void DotForwardEx(const nnvm::NodeAttrs& attrs,
   } else if (lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage
       && out_stype == kRowSparseStorage) {
     NDArray out = outputs[0];
+    double start = dmlc::GetTime();
     DotCsrDnsRspImpl<xpu>(ctx, inputs[0], inputs[1].data(), req[0], param.transpose_a, &out);
+    double elapsed = dmlc::GetTime() - start;
+    LOG(INFO) << "DotCsrDnsRspImpl: time cost " << elapsed * 1000 << " ms";
   } else {
     FCompExFallback<xpu>(attrs, ctx, inputs, req, outputs, DotForward_<xpu>, "DotForward_");
   }

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -483,7 +483,13 @@ inline bool DotForwardInferStorageType(const nnvm::NodeAttrs& attrs,
                                        std::vector<int> *out_attrs) {
   CHECK_EQ(in_attrs->size(), 2U);
   CHECK_EQ(out_attrs->size(), 1U);
-  out_attrs->at(0) = kDefaultStorage;
+  const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
+  if (param.transpose_a && kCSRStorage == (*in_attrs)[0]
+      && kDefaultStorage == (*in_attrs)[1]) {
+    STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 0, kRowSparseStorage);
+  } else {
+    STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 0, kDefaultStorage);
+  }
   return true;
 }
 
@@ -493,8 +499,14 @@ inline bool DotBackwardInferStorageType(const nnvm::NodeAttrs& attrs,
                                         std::vector<int> *out_attrs) {
   CHECK_EQ(in_attrs->size(), 3U);
   CHECK_EQ(out_attrs->size(), 2U);
-  out_attrs->at(0) = kDefaultStorage;
-  out_attrs->at(1) = kDefaultStorage;
+  const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
+  STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 0, kDefaultStorage);
+  if (!param.transpose_a && kDefaultStorage == (*in_attrs)[0]
+      && kCSRStorage == (*in_attrs)[1] && kDefaultStorage == (*in_attrs)[2]) {
+    STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 1, kRowSparseStorage);
+  } else {
+    STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 1, kDefaultStorage);
+  }
   return true;
 }
 
@@ -642,6 +654,45 @@ struct DotCsrTransDnsDnsByRowBlocks {
   }
 };
 
+/*!
+ * \brief Kernel of dot(csr.T(), dns) = rsp
+ * Parallelization by row blocks.
+ * This kernel fills up the row_idx array
+ * of the rsp with 1 for nonzero rows and 0
+ * for zero rows.
+ * The matrix will be compacted after this kernel call.
+ */
+struct DotCsrTransDnsRspByRowBlocks {
+  /*!
+   * \brief
+   * \param i the i-th thread
+   */
+  template<typename DType, typename RType, typename IType, typename CType>
+  MSHADOW_XINLINE static void Map(int i, DType* out, RType* row_idx, const DType* data_l,
+                                  const IType* indptr_l, const CType* col_idx_l,
+                                  const DType* data_r, const size_t seg_len,
+                                  const size_t num_rows_l, const size_t num_rows,
+                                  const size_t num_cols) {
+    const size_t seg_start = i * seg_len;
+    if (seg_start >= num_rows) return;
+    const size_t seg_end = (i + 1) * seg_len;
+    for (size_t j = 0; j < num_rows_l; ++j) {
+      if (indptr_l[j] == indptr_l[j+1]) continue;
+      const size_t offset_r = j * num_cols;
+      for (auto k = indptr_l[j]; k < indptr_l[j+1]; ++k) {
+        const auto col_idx = col_idx_l[k];
+        if (col_idx < seg_start || col_idx >= seg_end) continue;
+        const size_t offset_out = col_idx * num_cols;
+        row_idx[col_idx] = 1;
+        const auto val = data_l[k];
+        for (size_t l = 0; l < num_cols; ++l) {
+          out[offset_out+l] += data_r[offset_r+l] * val;
+        }
+      }
+    }
+  }
+};
+
 template<typename xpu>
 void DotCsrDnsDnsImpl(const OpContext& ctx,
                       const NDArray& lhs,
@@ -697,6 +748,74 @@ void DotCsrDnsDnsImpl(const OpContext& ctx,
             });
           }
         }
+      });
+    });
+  });
+}
+
+template<typename xpu>
+void DotCsrDnsRspImpl(const OpContext& ctx,
+                      const NDArray& lhs,
+                      const TBlob& rhs,
+                      const OpReqType req,
+                      const bool trans_lhs,
+                      NDArray* ret) {
+  if (kNullOp == req) return;
+  CHECK_EQ(lhs.storage_type(), kCSRStorage);
+  CHECK_EQ(ret->storage_type(), kRowSparseStorage);
+  if (!lhs.storage_initialized()) return;
+
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  const TBlob data_l = lhs.data();
+  const TBlob indptr_l = lhs.aux_data(csr::kIndPtr);
+  const TBlob col_idx_l = lhs.aux_data(csr::kIdx);
+  const TBlob& data_r = rhs;
+
+  // pre-allocate spaces for ret using the dense dimension size
+  ret->CheckAndAlloc({mshadow::Shape1(lhs.shape()[1])});
+  const TBlob data_out = ret->data();
+  const TBlob row_idx_out = ret->aux_data(rowsparse::kIdx);
+
+  MSHADOW_TYPE_SWITCH(data_l.type_flag_, DType, {  // data type
+    MSHADOW_INT_TYPE_SWITCH(indptr_l.type_flag_, IType, {  // indptr type
+      MSHADOW_INT_TYPE_SWITCH(col_idx_l.type_flag_, CType, {  // col idx type
+        MSHADOW_INT_TYPE_SWITCH(row_idx_out.type_flag_, RType, {  // col idx type
+          if (std::is_same<xpu, cpu>::value) {  // cpu parallelization by row blocks
+            if (kWriteTo == req) {
+              mxnet_op::Kernel<mxnet_op::set_zero, xpu>::Launch(
+                  s, data_out.Size(), data_out.dptr<DType>());
+            }
+            RType* row_idx = row_idx_out.dptr<RType>();
+            mxnet_op::Kernel<mxnet_op::set_zero, xpu>::Launch(
+                s, row_idx_out.Size(), row_idx);
+            int num_threads = mxnet_op::get_num_threads<xpu>(data_out.shape_[0]);
+            size_t seg_len = (data_out.shape_[0] + num_threads - 1) / num_threads;
+            if (trans_lhs) {
+              mxnet_op::Kernel<DotCsrTransDnsRspByRowBlocks, xpu>::Launch(s, num_threads,
+                  data_out.dptr<DType>(), row_idx, data_l.dptr<DType>(),
+                  indptr_l.dptr<IType>(), col_idx_l.dptr<CType>(), data_r.dptr<DType>(),
+                  seg_len, lhs.shape()[0], data_out.shape_[0], data_out.shape_[1]);
+              index_t nnr = 0;
+              nnr = mxnet::common::ParallelAccumulate(row_idx, ret->shape()[0], nnr);
+              ret->set_aux_shape(rowsparse::kIdx, mshadow::Shape1(nnr));
+              if (0 == nnr) return;
+              mshadow::Tensor<xpu, 2, DType> rsp_data = data_out.FlatTo2D<xpu, DType>(s);
+              size_t idx = 0;
+              for (index_t i = 0; i < ret->shape()[0]; ++i) {
+                if (row_idx > 0) {
+                  row_idx[idx] = i;
+                  mshadow::Copy(rsp_data[idx], rsp_data[i], s);
+                  ++idx;
+                }
+              }
+            } else {
+              LOG(FATAL) << "DotCsrDnsRspImpl has not implemented dot(csr, dns)=rsp yet."
+                            " Only the cpu version of dot(csr.T, dns)=rsp is supported now";
+            }
+          } else {
+            LOG(FATAL) << "DotCsrDnsRspImpl has not implemented GPU version yet.";
+          }
+        });
       });
     });
   });
@@ -803,10 +922,12 @@ void DotForwardEx(const nnvm::NodeAttrs& attrs,
     out_stype == kDefaultStorage) {
     TBlob ret = outputs[0].data();
     DotCsrRspDnsImpl<xpu>(ctx, inputs[0], inputs[1], req[0], param.transpose_a, &ret);
-  } else {  // TODO(junwu): add fallback
-    LOG(FATAL) << "Not supported dot operation for lhs.storage_type = "
-      << inputs[0].storage_type() << ", rhs.storage_type = " << inputs[1].storage_type()
-      << ", out.storage_type = " << outputs[0].storage_type();
+  } else if (lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage
+      && out_stype == kRowSparseStorage) {
+    NDArray out = outputs[0];
+    DotCsrDnsRspImpl<xpu>(ctx, inputs[0], inputs[1].data(), req[0], param.transpose_a, &out);
+  } else {
+    FCompExFallback<xpu>(attrs, ctx, inputs, req, outputs, DotForward_<xpu>, "DotForward_");
   }
 }
 
@@ -823,7 +944,6 @@ void DotBackwardEx(const nnvm::NodeAttrs& attrs,
     << "sparse dot does not support computing the gradient of the csr/lhs";
   CHECK_NE(req[1], kWriteInplace) << "DotBackwardEx does not support WriteInplace";
 
-  // TODO(junwu): check whether this CHECK is reasonable
   const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
   CHECK(!param.transpose_b) << "sparse dot only supports dot(A, X) and dot(A.T(), X)";
   auto ograd_stype = inputs[0].storage_type();
@@ -836,11 +956,15 @@ void DotBackwardEx(const nnvm::NodeAttrs& attrs,
     // dns, csr, dns => *, dns
     DotBackwardCsrDnsDns<xpu>(attrs, ctx, inputs, req, outputs);
   } else if (ograd_stype == kDefaultStorage && lhs_stype == kCSRStorage &&
-    rhs_stype == kRowSparseStorage && outputs[1].storage_type() == kDefaultStorage) {
+      rhs_stype == kRowSparseStorage && outputs[1].storage_type() == kDefaultStorage) {
     // dns, csr, rsp => *, dns
     DotBackwardCsrRspDns<xpu>(attrs, ctx, inputs, req, outputs);
+  } else if (ograd_stype == kDefaultStorage && lhs_stype == kCSRStorage &&
+      rhs_stype == kDefaultStorage && outputs[1].storage_type() == kRowSparseStorage) {
+    NDArray grad_rhs = outputs[1];
+    DotCsrDnsRspImpl<xpu>(ctx, inputs[1], inputs[2].data(), req[1], !param.transpose_a, &grad_rhs);
   } else {
-    LOG(FATAL) << "Not supported dot backward for sparse input(s) with sparse gradients";
+    FCompExFallback<xpu>(attrs, ctx, inputs, req, outputs, DotBackward_<xpu>, "DotBackward_");
   }
 }
 

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -802,7 +802,7 @@ void DotCsrDnsRspImpl(const OpContext& ctx,
               mshadow::Tensor<xpu, 2, DType> rsp_data = data_out.FlatTo2D<xpu, DType>(s);
               size_t idx = 0;
               for (index_t i = 0; i < ret->shape()[0]; ++i) {
-                if (row_idx > 0) {
+                if (row_idx[i] > 0) {
                   row_idx[idx] = i;
                   mshadow::Copy(rsp_data[idx], rsp_data[i], s);
                   ++idx;

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -383,7 +383,7 @@ def test_module_fm():
          x = mx.symbol.Variable("data", storage_type='csr')
          v = mx.symbol.Variable("v", shape=(feature_dim, k), init=norm, storage_type='row_sparse')
 
-         w1_weight = mx.symbol.var('w1_weight', shape=(feature_dim, 1), init=norm)
+         w1_weight = mx.symbol.var('w1_weight', shape=(feature_dim, 1), init=norm, storage_type='row_sparse')
          w1 = mx.symbol.dot(x, w1_weight)
 
          v_s = mx.symbol.sum(data=mx.symbol.square(data=v), axis=1)

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -100,6 +100,7 @@ def test_cast_storage_ex():
     test_csr_to_dns((4, 4))
     test_dns_to_csr([[0, 1, 0], [0, 2, 0], [3, 0, 0], [0, 0, 4], [5, 6, 0], [0, 0, 7]])
 
+
 def test_sparse_dot():
     def test_dot_csr(lhs_shape, rhs_shape, rhs_stype, trans_lhs):
         lhs_dns = rand_ndarray(lhs_shape, 'default')
@@ -107,7 +108,10 @@ def test_sparse_dot():
         rhs_nd = rand_ndarray(rhs_shape, rhs_stype, density=1)
         rhs_dns = rhs_nd if rhs_stype == 'default' else rhs_nd.todense()
         out = mx.nd.dot(lhs_nd, rhs_dns, transpose_a=trans_lhs)
-        assert out.storage_type == 'default'
+        if trans_lhs:
+            assert out.storage_type == 'row_sparse'
+        else:
+            assert out.storage_type == 'default'
         out_expected = mx.nd.dot(lhs_dns, rhs_dns, transpose_a=trans_lhs)
         out_np = out_expected.asnumpy()
         backward_trans = not trans_lhs
@@ -117,13 +121,19 @@ def test_sparse_dot():
         # test symbolic forward
         lhs = mx.symbol.Variable('lhs', storage_type='csr')
         rhs = mx.symbol.Variable('rhs', storage_type=rhs_stype)
+        dns_zeros = mx.symbol.Variable('dns')
         test = mx.symbol.dot(lhs, rhs, transpose_a=trans_lhs)
-        location = {'lhs': lhs_nd, 'rhs': rhs_nd}
+        # TODO(junwu): since sparse operator does not support sparse ograd as input for backward,
+        # we have to add the dot sparse output to a zero dense matrix to generate a dense matrix
+        # as the final output. In the future, we will evaluate the necessity of supporting
+        # sparse ograd as input for the backward pass.
+        test = mx.symbol.elemwise_add(test, dns_zeros)
+        location = {'lhs': lhs_nd, 'rhs': rhs_nd, 'dns': mx.nd.zeros(out.shape)}
         expected = {'rhs': rhs_backward_grad}
         check_symbolic_forward(test, location, [out_np], rtol=1e-3, atol=1e-4)
         # test symbolic backward
         check_symbolic_backward(test, location, [out_np], expected,
-                                grad_req={'lhs': 'null', 'rhs': 'write'},
+                                grad_req={'lhs': 'null', 'rhs': 'write', 'dns': 'null'},
                                 rtol=1e-3, atol=1e-4)
 
     lhs_shape = rand_shape_2d()
@@ -131,6 +141,7 @@ def test_sparse_dot():
     test_dot_csr(lhs_shape, (lhs_shape[0], rnd.randint(1, 10)), 'default', True)
     test_dot_csr(lhs_shape, (lhs_shape[1], rnd.randint(1, 10)), 'row_sparse', False)
     test_dot_csr(lhs_shape, (lhs_shape[0], rnd.randint(1, 10)), 'row_sparse', True)
+
 
 def test_sparse_embedding():
     in_dim = 10

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -121,19 +121,13 @@ def test_sparse_dot():
         # test symbolic forward
         lhs = mx.symbol.Variable('lhs', storage_type='csr')
         rhs = mx.symbol.Variable('rhs', storage_type=rhs_stype)
-        dns_zeros = mx.symbol.Variable('dns')
         test = mx.symbol.dot(lhs, rhs, transpose_a=trans_lhs)
-        # TODO(junwu): since sparse operator does not support sparse ograd as input for backward,
-        # we have to add the dot sparse output to a zero dense matrix to generate a dense matrix
-        # as the final output. In the future, we will evaluate the necessity of supporting
-        # sparse ograd as input for the backward pass.
-        test = mx.symbol.elemwise_add(test, dns_zeros)
-        location = {'lhs': lhs_nd, 'rhs': rhs_nd, 'dns': mx.nd.zeros(out.shape)}
+        location = {'lhs': lhs_nd, 'rhs': rhs_nd}
         expected = {'rhs': rhs_backward_grad}
         check_symbolic_forward(test, location, [out_np], rtol=1e-3, atol=1e-4)
         # test symbolic backward
         check_symbolic_backward(test, location, [out_np], expected,
-                                grad_req={'lhs': 'null', 'rhs': 'write', 'dns': 'null'},
+                                grad_req={'lhs': 'null', 'rhs': 'write'},
                                 rtol=1e-3, atol=1e-4)
 
     lhs_shape = rand_shape_2d()


### PR DESCRIPTION
Enhancement motivated by the benchmark results of [cast_storage](https://github.com/eric-haibin-lin/mxnet/pull/109#issuecomment-310571404).
1. Enabled `dot(csr.T, dns)` to output an rsp format matrix. This avoids the step of casting a dense matrix to a rowsparse one after `dot(csr.T, dns)=dns` is performed. We identified that casting operation is a bottleneck in the network.
2. Used `STORAGE_TYPE_ASSIGN_CHECK` in storage type inference for sparse dot.
3. Added fallback function for sparse dot forward and backward.
4. Fixed a unittest typo.

@piiswrong @eric-haibin-lin 