### PR TITLE
lstm_bucketing now shows more information if the training file is not present

### DIFF
--- a/example/rnn/lstm_bucketing.py
+++ b/example/rnn/lstm_bucketing.py
@@ -1,6 +1,7 @@
 import numpy as np
 import mxnet as mx
 import argparse
+import os
 
 parser = argparse.ArgumentParser(description="Train RNN on Penn Tree Bank",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -32,6 +33,8 @@ parser.add_argument('--disp-batches', type=int, default=50,
 
 
 def tokenize_text(fname, vocab=None, invalid_label=-1, start_label=0):
+    if not os.path.isfile(fname):
+        raise IOError("Please use get_ptb_data.sh to download requied file (data/ptb.train.txt)")
     lines = open(fname).readlines()
     lines = [filter(None, i.split(' ')) for i in lines]
     sentences, vocab = mx.rnn.encode_sentences(lines, vocab=vocab, invalid_label=invalid_label,


### PR DESCRIPTION
fix for the #6856 .

Before:
python lstm_bucketing.py

leads to the following error:
Traceback (most recent call last):
File "lstm_bucketing.py", line 56, in 
invalid_label=invalid_label)
File "lstm_bucketing.py", line 35, in tokenize_text
lines = open(fname).readlines()
IOError: [Errno 2] No such file or directory: './data/ptb.train.txt'

After:
python lstm_bucketing.py
Traceback (most recent call last):
  File "lstm_bucketing.py", line 59, in <module>
    invalid_label=invalid_label)
  File "lstm_bucketing.py", line 37, in tokenize_text
    raise IOError("Please use get_ptb_data.sh to download requied file (data/ptb.train.txt)")
IOError: Please use get_ptb_data.sh to download requied file (data/ptb.train.txt)

Manually tests with and without the data/ptb.train.txt file.