### PR TITLE
Failing with a more descriptive error message in infer_shape.

### DIFF
--- a/python/mxnet/symbol.py
+++ b/python/mxnet/symbol.py
@@ -1013,19 +1013,22 @@ class Symbol(SymbolBase):
         indptr = [0]
         if len(args) != 0:
             keys = None
-            for s in args:
+            for i, s in enumerate(args):
                 if s is not None:
                     if not isinstance(s, tuple):
-                        raise TypeError('Arguments must be shapes (tuple)')
+                        raise TypeError("Arguments need to be shapes (tuple), "
+                                        "but argument %d is %s." % (i, type(s)))
                     sdata.extend(s)
                 indptr.append(len(sdata))
         else:
             keys = []
             for k, v in kwargs.items():
-                if isinstance(v, tuple):
-                    keys.append(c_str(k))
-                    sdata.extend(v)
-                    indptr.append(len(sdata))
+                if not isinstance(v, tuple):
+                    raise TypeError("Arguments need to be shapes (tuple), "
+                                    "but '%s' is %s." % (k, type(v)))
+                keys.append(c_str(k))
+                sdata.extend(v)
+                indptr.append(len(sdata))
         arg_shape_size = mx_uint()
         arg_shape_ndim = ctypes.POINTER(mx_uint)()
         arg_shape_data = ctypes.POINTER(ctypes.POINTER(mx_uint))()


### PR DESCRIPTION
Given this example:
```python
import mxnet as mx
data = mx.sym.Variable('data')
prev = mx.sym.Variable('prev')
fc1  = mx.sym.FullyConnected(data=data, name='fc1', num_hidden=128)
fc2  = mx.sym.FullyConnected(data=prev, name='fc2', num_hidden=128)
out  = mx.sym.Activation(data=mx.sym.elemwise_add(fc1, fc2), act_type='relu')
```
The following mistake (user wants to pass tuple, but leaves out the comma for the 1-element tuple):
```
out.infer_shape((10))
```
Would fail with the message:
```
TypeError: Arguments must be shapes (tuple)
```
After the change we get:
```
TypeError: Arguments need to be shapes (tuple), but argument 0 is <class 'int'>.
```

Even worse when using keyword arguments before this change we would just not print an
error message and just silently fail:
```
out.infer_shape(data=(10))
```
lead to:
```
symboltestkvarg.py:7: UserWarning: Cannot decide shape for the following arguments (0s in shape means unknown dimensions). Consider providing them as input:
	data: ()
	fc1_weight: ()
	fc1_bias: ()
	prev: ()
	fc2_weight: ()
	fc2_bias: ()
  out.infer_shape(data=(10))
```
Now we get a more user friendly error message:
```
TypeError: Arguments need to be shapes (tuple), but 'data' is <class 'int'>.
```
