### PR TITLE
Fix Python 3 compatibilities

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -81,12 +81,12 @@ class EvalMetric(object):
         if self.output_names is not None:
             pred = [pred[name] for name in self.output_names]
         else:
-            pred = pred.values()
+            pred = list(pred.values())
 
         if self.label_names is not None:
             label = [label[name] for name in self.label_names]
         else:
-            label = label.values()
+            label = list(label.values())
 
         self.update(label, pred)
 

--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -12,6 +12,9 @@ import cv2
 import time
 import traceback
 
+if sys.version_info[0] == 3:
+    xrange = range
+
 try:
     import multiprocessing
 except ImportError:
@@ -89,7 +92,7 @@ def read_list(path_in):
                 continue
             try:
                 item = [int(line[0])] + [line[-1]] + [float(i) for i in line[1:-1]]
-            except Exception, e:
+            except Exception as e:
                 print('Parsing lst met error for %s, detail: %s' %(line, e))
                 continue
             yield item
@@ -108,7 +111,7 @@ def image_encode(args, i, item, q_out):
                 img = fin.read()
             s = mx.recordio.pack(header, img)
             q_out.put((i, s, item))
-        except Exception, e:
+        except Exception as e:
             traceback.print_exc()
             print('pack_img error:', item[1], e)
             q_out.put((i, None, item))
@@ -142,7 +145,7 @@ def image_encode(args, i, item, q_out):
     try:
         s = mx.recordio.pack_img(header, img, quality=args.quality, img_fmt=args.encoding)
         q_out.put((i, s, item))
-    except Exception, e:
+    except Exception as e:
         traceback.print_exc()
         print('pack_img error on file: %s' % fullpath, e)
         q_out.put((i, None, item))
@@ -279,8 +282,11 @@ if __name__ == '__main__':
                     write_process.join()
                 else:
                     print('multiprocessing not available, fall back to single threaded encoding')
-                    import Queue
-                    q_out = Queue.Queue()
+                    try:
+                        import Queue as queue
+                    except ImportError:
+                        import queue
+                    q_out = queue.Queue()
                     fname = os.path.basename(fname)
                     fname_rec = os.path.splitext(fname)[0] + '.rec'
                     fname_idx = os.path.splitext(fname)[0] + '.idx'


### PR DESCRIPTION
In Python 3, values() method returns a dict_values instead of  a list.