### PR TITLE
Optimized gpu dot kernels

### DIFF
--- a/src/io/inst_vector.h
+++ b/src/io/inst_vector.h
@@ -12,6 +12,7 @@
 #include <mxnet/base.h>
 #include <dmlc/base.h>
 #include <mshadow/tensor.h>
+#include <mshadow/tensor_blob.h>
 #include <vector>
 #include <string>
 

--- a/src/operator/tensor/dot-inl.cuh
+++ b/src/operator/tensor/dot-inl.cuh
@@ -11,13 +11,14 @@
 
 namespace mxnet {
 namespace op {
+using mshadow::cuda::kBaseThreadNum;
 
 /*!
- * \brief Kernel of dot(csr, dns1) = dns2
- * Parallelization by output matrix elements
+ * \brief Scalar kernel of dot(csr, dns1) = dns2
+ * Parallelization by output matrix elements: 1 thread/element
  */
 template<int req>
-struct DotCsrDnsDns {
+struct DotCsrDnsDnsScalarKernel {
   /*!
    * \brief This function represents performing an inner product between a row of lhs
    * and a column of rhs and then assigning the value to out[i].
@@ -45,11 +46,51 @@ struct DotCsrDnsDns {
 };
 
 /*!
- * \brief Kernel of dot(csr.T(), dns1) = dns2
- * Parallelization by output matrix elements
+ * \brief Vector kernel of dot(csr, dns1) = dns2
+ * Parallelization by output matrix elements: 1 warp/element
  */
 template<int req>
-struct DotCsrTransDnsDns {
+struct DotCsrDnsDnsVectorKernel {
+  template<typename DType, typename IType, typename CType>
+  __device__ __forceinline__ static void Map(int tid, DType* out, const DType* data_l, const IType* indptr_l,
+                                             const CType* col_idx_l, const DType* data_r,
+                                             const int num_cols_r) {
+    __shared__ volatile DType vals[kBaseThreadNum];
+
+    const int warp_id = tid / 32;           // global warp id
+    const int lane = tid & (32-1);          // local thread id within warp
+    const int irow = warp_id / num_cols_r;  // lhs row that this warp computes
+    const int kcol = warp_id % num_cols_r;  // rhs column that this warp computes
+
+    // Range of nnz elements in this row
+    const int low  = static_cast<int>(indptr_l[irow]);
+    const int high = static_cast<int>(indptr_l[irow+1]);
+
+    // Compute running sum per thread
+    vals[threadIdx.x] = 0;
+    for (int j = low+lane; j < high; j+=32) {
+      vals[threadIdx.x] += data_l[j] * data_r[col_idx_l[j]*num_cols_r + kcol];
+    }
+
+    // Parallel reduction in shared memory
+    if (lane < 16) vals[threadIdx.x] += vals[threadIdx.x+16];
+    if (lane <  8) vals[threadIdx.x] += vals[threadIdx.x+ 8];
+    if (lane <  4) vals[threadIdx.x] += vals[threadIdx.x+ 4];
+    if (lane <  2) vals[threadIdx.x] += vals[threadIdx.x+ 2];
+    if (lane <  1) vals[threadIdx.x] += vals[threadIdx.x+ 1];
+
+    if (lane == 0) {
+      KERNEL_ASSIGN(out[irow*num_cols_r+kcol], req, vals[threadIdx.x]);
+    }
+  }
+};
+
+/*!
+ * \brief Scalar kernel of dot(csr.T(), dns1) = dns2
+ * Parallelization by output matrix elements: 1 thread/element
+ */
+template<int req>
+struct DotCsrTransDnsDnsScalarKernel {
   /*!
    * \brief This function represents performing an inner product between a column of lhs
    * and a column of rhs and then assigning the value to out[i].
@@ -69,6 +110,8 @@ struct DotCsrTransDnsDns {
     const int irow = i / num_cols;  // col id of the lhs
     const int icol = i % num_cols;  // col id of the rhs
     DType sum = 0;
+
+    // Each thread scans each column with binary search to find nnz elements in its row
     for (int k = 0; k < num_rows_l; ++k) {
       const IType low = indptr_l[k];
       const IType high = indptr_l[k+1];
@@ -93,6 +136,98 @@ struct DotCsrTransDnsDns {
   }
 };
 
+/*!
+ * \brief Warp kernel of dot(csr.T(), dns1) = dns2
+ * Parallelization by columns: 1 warp computes one lhs column for one rhs column
+ */
+template<int req>
+struct DotCsrTransDnsDnsWarpKernel {
+  template<typename DType, typename IType, typename CType>
+  __device__ __forceinline__ static void Map(int tid, DType* out, const DType* data_l, const IType* indptr_l,
+                                             const CType* col_idx_l, const DType* data_r,
+                                             const int num_cols_r) {
+    const int warp_id = tid / 32;           // global warp id
+    const int lane = tid & (32-1);          // local thread id within warp
+    const int icol = warp_id / num_cols_r;  // lhs column that this warp computes
+    const int kcol = warp_id % num_cols_r;  // rhs column that this warp computes
+
+    // Compute range of nnz elements in this column
+    const int low  = static_cast<int>(indptr_l[icol]);
+    const int high = static_cast<int>(indptr_l[icol+1]);
+
+    // Iterate through the nnz elements in this column
+    for (int j = low+lane; j < high; j+=32) {
+      const int irow = static_cast<int>(col_idx_l[j]);
+      const DType val = data_l[j]*data_r[icol*num_cols_r+kcol];
+      atomicAdd(static_cast<DType *>(&(out[irow*num_cols_r+kcol])), val);
+    }
+  }
+};
+
+/*!
+ * \brief Thread block kernel of dot(csr.T(), dns1) = dns2
+ * Parallelization by columns: 1 thread block computes one lhs column for all rhs columns
+ */
+template<int req>
+struct DotCsrTransDnsDnsThreadBlockKernel {
+  template<typename DType, typename IType, typename CType>
+  __device__ __forceinline__ static void Map(int tid, DType* out, const DType* data_l, const IType* indptr_l,
+                                             const CType* col_idx_l, const DType* data_r,
+                                             const int num_cols_r) {
+    const int warps_per_block = blockDim.x / 32;  // number of warps in this thread block
+    const int warp_id = tid / 32;                 // global warp id
+    const int lane = tid & (32-1);                // local thread id within warp
+    const int icol = blockIdx.x;                  // lhs column that this thread block computes
+    const int kcol = warp_id % warps_per_block;   // rhs column where warp starts computing (offset)
+
+    // Compute range of nnz elements in this lhs column
+    const int low  = static_cast<int>(indptr_l[icol]);
+    const int high = static_cast<int>(indptr_l[icol+1]);
+
+    // Iterate through the nnz elements in this lhs column
+    for (int j = low+lane; j < high; j+=32) {
+      const int irow = static_cast<int>(col_idx_l[j]);
+      const DType datum_l = data_l[j];
+      // Iterate over rhs columns that this warp computes
+      for (int k = kcol; k < num_cols_r; k+=warps_per_block) {
+        const DType val = datum_l*data_r[icol*num_cols_r+k];
+        atomicAdd(static_cast<DType *>(&(out[irow*num_cols_r+k])), val);
+      }
+    }
+  }
+};
+
+/*!
+ * \brief Warp block kernel of dot(csr.T(), dns1) = dns2
+ * Parallelization by columns: 1 warp computes one lhs column for all rhs columns
+ */
+template<int req>
+struct DotCsrTransDnsDnsWarpBlockKernel {
+  template<typename DType, typename IType, typename CType>
+  __device__ __forceinline__ static void Map(int tid, DType* out, const DType* data_l, const IType* indptr_l,
+                                             const CType* col_idx_l, const DType* data_r,
+                                             const int num_cols_r) {
+    const int warp_id = tid / 32;   // global warp id
+    const int lane = tid & (32-1);  // local thread id within warp
+    const int icol = warp_id;       // lhs column that this warp computes
+
+    // Compute range of nnz elements in this column
+    const int low  = static_cast<int>(indptr_l[icol]);
+    const int high = static_cast<int>(indptr_l[icol+1]);
+
+    // Iterate through the nnz elements in lhs column
+    for (int j = low+lane; j < high; j+=32) {
+      const int irow = static_cast<int>(col_idx_l[j]);
+      const DType datum_l = data_l[j];
+      // Iterate over all rhs columns
+      for (int k = 0; k < num_cols_r; k++) {
+        const DType val = datum_l*data_r[icol*num_cols_r+k];
+        atomicAdd(static_cast<DType *>(&(out[irow*num_cols_r+k])), val);
+      }
+    }
+  }
+};
+
 inline void DotCsrDnsDnsImpl(mshadow::Stream<gpu>* s,
                              const NDArray& lhs,
                              const TBlob& rhs,
@@ -109,22 +244,107 @@ inline void DotCsrDnsDnsImpl(mshadow::Stream<gpu>* s,
   const TBlob& data_r = rhs;
   const TBlob data_out = *ret;
 
-  MSHADOW_TYPE_SWITCH(data_l.type_flag_, DType, {  // data type
+  MSHADOW_SGL_DBL_TYPE_SWITCH(data_l.type_flag_, DType, {  // data type
     MSHADOW_IDX_TYPE_SWITCH(indptr_l.type_flag_, IType, {  // indptr type
       MSHADOW_IDX_TYPE_SWITCH(col_idx_l.type_flag_, CType, {  // col idx type
+        if (kWriteTo == req) {
+          mxnet_op::Kernel<mxnet_op::set_zero, gpu>::Launch(s, data_out.Size(), data_out.dptr<DType>());
+        }
+        int num_threads;
+        const int threads_per_warp = 32;
+        const int threads_per_block = kBaseThreadNum;
+        const int num_rows_l = lhs.shape()[0];
+        const int num_cols_r = rhs.shape_[1];
         if (trans_lhs) {
-          MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
-            mxnet_op::Kernel<DotCsrTransDnsDns<ReqType>, gpu>::Launch(s, data_out.Size(),
-                data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
-                col_idx_l.dptr<CType>(), data_r.dptr<DType>(), lhs.shape()[0],
-                data_out.shape_[1]);
-          });
+          // Different kernel versions are optimized for different matrix instances
+          // TODO: switch between kernel versions depending on input
+          // (1) 'Scalar kernel'       (one thread       computing one output element                )
+          // (2) 'Warp kernel'         (one warp         computing one lhs column for one rhs column )
+          // (3) 'Thread block kernel' (one thread block computing one lhs column for all rhs columns)
+          // (4) 'Warp block kernel'   (one warp         computing one lhs column for all rhs columns)
+          const int kernel_version = 0;
+          switch (kernel_version) {
+            case 1:
+              num_threads = data_out.Size();
+              MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                mxnet_op::Kernel<DotCsrTransDnsDnsScalarKernel<ReqType>, gpu>::Launch(s, num_threads,
+                    data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                    col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_rows_l, num_cols_r);
+              });
+              break;
+            case 2:
+              num_threads = threads_per_warp * num_rows_l * num_cols_r;
+              MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                mxnet_op::Kernel<DotCsrTransDnsDnsWarpKernel<ReqType>, gpu>::Launch(s, num_threads,
+                    data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                    col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+              });
+              break;
+            case 3:
+              num_threads = threads_per_block * num_rows_l;
+              MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                mxnet_op::Kernel<DotCsrTransDnsDnsThreadBlockKernel<ReqType>, gpu>::Launch(s, num_threads,
+                    data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                    col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+              });
+              break;
+            case 4:
+              num_threads = threads_per_warp * num_rows_l;
+              MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                mxnet_op::Kernel<DotCsrTransDnsDnsWarpBlockKernel<ReqType>, gpu>::Launch(s, num_threads,
+                    data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                    col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+              });
+              break;
+            default:
+              num_threads = threads_per_warp * num_rows_l * num_cols_r;
+              MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                mxnet_op::Kernel<DotCsrTransDnsDnsWarpKernel<ReqType>, gpu>::Launch(s, num_threads,
+                    data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                    col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+              });
+              break;
+          }
         } else {
-          MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
-            mxnet_op::Kernel<DotCsrDnsDns<ReqType>, gpu>::Launch(s, data_out.Size(),
-                data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
-                col_idx_l.dptr<CType>(), data_r.dptr<DType>(), rhs.shape_[1]);
-          });
+          // Different kernel versions are optimized for different matrix instances
+          // (1) 'Scalar kernel' (one thread computing one output element)
+          // (2) 'Vector kernel' (one warp   computing one output element)
+          const int kernel_version = 0;
+          switch (kernel_version) {
+            case 1:
+              num_threads = data_out.Size();
+              MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                mxnet_op::Kernel<DotCsrDnsDnsScalarKernel<ReqType>, gpu>::Launch(s, num_threads,
+                    data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                    col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+              });
+              break;
+            case 2:
+              num_threads = threads_per_warp * num_rows_l * num_cols_r;
+              MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                mxnet_op::Kernel<DotCsrDnsDnsVectorKernel<ReqType>, gpu>::Launch(s, num_threads,
+                    data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                    col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+              });
+              break;
+            default:
+              if (num_cols_r > 4) {
+                num_threads = data_out.Size();
+                MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                  mxnet_op::Kernel<DotCsrDnsDnsScalarKernel<ReqType>, gpu>::Launch(s, num_threads,
+                      data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                      col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+                });
+              } else {
+                num_threads = threads_per_warp * num_rows_l * num_cols_r;
+                MXNET_ASSIGN_REQ_SWITCH(req, ReqType, {
+                  mxnet_op::Kernel<DotCsrDnsDnsVectorKernel<ReqType>, gpu>::Launch(s, num_threads,
+                      data_out.dptr<DType>(), data_l.dptr<DType>(), indptr_l.dptr<IType>(),
+                      col_idx_l.dptr<CType>(), data_r.dptr<DType>(), num_cols_r);
+                });
+              }
+              break;
+          }
         }
       });
     });

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -187,7 +187,8 @@ inline bool DotForwardInferStorageType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(out_attrs->size(), 1U);
   const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
   // csr has many zero columns, so the result of dot(csr.T, matrix) should be rsp
-  if (param.transpose_a && kCSRStorage == (*in_attrs)[0]) {
+  // dot(csr.T,dns)=rsp not yet implemented on gpu
+  if (param.transpose_a && kCSRStorage == (*in_attrs)[0] && ctx.dev_type != Context::kGPU) {
     STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 0, kRowSparseStorage);
   } else {
     STORAGE_TYPE_ASSIGN_CHECK(*out_attrs, 0, kDefaultStorage);

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.join(curr_path, '../unittest'))
 from test_operator import *
 from test_optimizer import *
 from test_random import *
+from test_sparse_operator import test_sparse_dot
 import mxnet as mx
 import numpy as np
 from mxnet.test_utils import check_consistency, set_default_context

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -103,12 +103,12 @@ def test_cast_storage_ex():
 
 def test_sparse_dot():
     def test_dot_csr(lhs_shape, rhs_shape, rhs_stype, trans_lhs, density=1):
-        lhs_dns = rand_ndarray(lhs_shape, 'default')
-        lhs_nd = mx.nd.cast_storage(lhs_dns, storage_type='csr')
+        lhs_nd = rand_ndarray(lhs_shape, 'csr', 1)
+        lhs_dns = lhs_nd.todense()
         rhs_nd = rand_ndarray(rhs_shape, rhs_stype, density=density)
         rhs_dns = rhs_nd if rhs_stype == 'default' else rhs_nd.todense()
         out = mx.nd.dot(lhs_nd, rhs_dns, transpose_a=trans_lhs)
-        if trans_lhs:
+        if trans_lhs and default_context().device_type is 'cpu':
             assert out.storage_type == 'row_sparse'
         else:
             assert out.storage_type == 'default'
@@ -131,6 +131,8 @@ def test_sparse_dot():
                                 rtol=1e-3, atol=1e-4)
 
     lhs_shape = rand_shape_2d(50, 200)
+    test_dot_csr(lhs_shape, (lhs_shape[1], 1), 'default', False)
+    test_dot_csr(lhs_shape, (lhs_shape[0], 1), 'default', True)
     test_dot_csr(lhs_shape, (lhs_shape[1], rnd.randint(1, 10)), 'default', False)
     test_dot_csr(lhs_shape, (lhs_shape[0], rnd.randint(1, 10)), 'default', True)
     test_dot_csr(lhs_shape, (lhs_shape[1], rnd.randint(1, 10)), 'row_sparse', False)


### PR DESCRIPTION
Implementation of optimized GPU kernels for `dot(csr,dns)=dns` and `dot(csr.T,dns)=dns`. Different kernel versions are included for both cases which can be switched depending on the input attributes for best performance - for example, the `dot(csr,dns)` vector kernel performs better than the scalar kernel in most cases for SpMV or when dense matrix is tall and skinny (see e.g. [SpMV paper](http://wnbell.com/media/2008-12-NVR-SpMV/nvr-2008-004.pdf) for more details and terminology). The old kernels are so-called scalar kernels (1); the new kernels are numbered (2)-(4).
Benchmark results for SpMV and SpMM and the transpose case with uniformly distributed non-zeros in the CSR matrix are shown below for Kernels (1) and (2) of each case. Benchmark conducted on K-80 (p2.xlarge) with compile flags `USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDNN=1`.
Highlights (for this particular benchmark):
- Performance of SpMV/SpMM [dot(csr,dns)] improved by up to ~40.
- Performance of SpMV/SpMM tranpose [dot(csr.T,dns)] improved by up to ~500.

@piiswrong @madjam @reminisce @eric-haibin-lin @bhavinthaker

Benchmark Table for `dot(csr,dns)=dns` with `m x k * k x n = m x n`:

| density(%) | n  | m   | k     | (1) Scalar Kernel:  | t_dense/t_sparse | t_dense | t_sparse | (2) Vector Kernel:  | t_dense/t_sparse | t_dense | t_sparse |
|------------|----|-----|-------|---|------------------|---------|----------|---|------------------|---------|----------|
| 20         | 1  | 512 | 50000 |   | 0.096            | 0.0037  | 0.0384   |   | 3.638            | 0.0037  | 0.0010   |
| 10         | 1  | 512 | 50000 |   | 0.153            | 0.0033  | 0.0214   |   | 4.991            | 0.0033  | 0.0007   |
| 5          | 1  | 512 | 50000 |   | 0.298            | 0.0029  | 0.0099   |   | 7.423            | 0.0033  | 0.0004   |
| 2          | 1  | 512 | 50000 |   | 0.717            | 0.0027  | 0.0038   |   | 12.352           | 0.0033  | 0.0003   |
| 1          | 1  | 512 | 50000 |   | 1.391            | 0.0027  | 0.0020   |   | 18.655           | 0.0033  | 0.0002   |
| 0.5        | 1  | 512 | 50000 |   | 2.625            | 0.0027  | 0.0010   |   | 26.777           | 0.0033  | 0.0001   |
| 0.1        | 1  | 512 | 50000 |   | 10.734           | 0.0027  | 0.0003   |   | 43.958           | 0.0033  | 0.0001   |
|            |    |     |       |   |                  |         |          |   |                  |         |          |
| 20         | 4  | 512 | 50000 |   | 0.187            | 0.0031  | 0.0165   |   | 0.567            | 0.0037  | 0.0065   |
| 10         | 4  | 512 | 50000 |   | 0.316            | 0.0024  | 0.0077   |   | 0.844            | 0.0033  | 0.0039   |
| 5          | 4  | 512 | 50000 |   | 0.624            | 0.0024  | 0.0039   |   | 1.467            | 0.0033  | 0.0023   |
| 2          | 4  | 512 | 50000 |   | 1.449            | 0.0024  | 0.0017   |   | 3.318            | 0.0033  | 0.0010   |
| 1          | 4  | 512 | 50000 |   | 2.762            | 0.0024  | 0.0009   |   | 6.133            | 0.0033  | 0.0005   |
| 0.5        | 4  | 512 | 50000 |   | 4.883            | 0.0024  | 0.0005   |   | 10.515           | 0.0033  | 0.0003   |
| 0.1        | 4  | 512 | 50000 |   | 17.888           | 0.0024  | 0.0001   |   | 27.302           | 0.0033  | 0.0001   |
|            |    |     |       |   |                  |         |          |   |                  |         |          |
| 20         | 64 | 512 | 50000 |   | 0.301            | 0.0085  | 0.0283   |   | 0.068            | 0.0085  | 0.1263   |
| 10         | 64 | 512 | 50000 |   | 0.609            | 0.0075  | 0.0123   |   | 0.126            | 0.0081  | 0.0649   |
| 5          | 64 | 512 | 50000 |   | 1.148            | 0.0068  | 0.0059   |   | 0.218            | 0.0058  | 0.0265   |
| 2          | 64 | 512 | 50000 |   | 2.716            | 0.0061  | 0.0023   |   | 0.568            | 0.0056  | 0.0099   |
| 1          | 64 | 512 | 50000 |   | 5.085            | 0.0061  | 0.0012   |   | 1.120            | 0.0056  | 0.0050   |
| 0.5        | 64 | 512 | 50000 |   | 9.270            | 0.0061  | 0.0007   |   | 2.149            | 0.0056  | 0.0026   |
| 0.1        | 64 | 512 | 50000 |   | 31.551           | 0.0061  | 0.0002   |   | 8.268            | 0.0056  | 0.0007   |

Benchmark Table for `dot(csr.T,dns)=dns` with `k x m * m x n = k x n`:

| density(%) | n  | m   | k     |  (1) Scalar Kernel: | t_dense/t_sparse | t_dense | t_sparse | (2): Warp Kernel  | t_dense/t_sparse | t_dense | t_sparse |
|------------|----|-----|-------|---|------------------|---------|----------|---|------------------|---------|----------|
| 20         | 1  | 512 | 50000 |   | 0.223            | 0.0031  | 0.0141   |   | 3.027            | 0.0027  | 0.0009   |
| 10         | 1  | 512 | 50000 |   | 0.212            | 0.0028  | 0.0130   |   | 4.681            | 0.0023  | 0.0005   |
| 5          | 1  | 512 | 50000 |   | 0.233            | 0.0028  | 0.0118   |   | 8.081            | 0.0023  | 0.0003   |
| 2          | 1  | 512 | 50000 |   | 0.267            | 0.0028  | 0.0104   |   | 14.382           | 0.0023  | 0.0002   |
| 1          | 1  | 512 | 50000 |   | 0.291            | 0.0028  | 0.0095   |   | 20.981           | 0.0023  | 0.0001   |
| 0.5        | 1  | 512 | 50000 |   | 0.323            | 0.0028  | 0.0086   |   | 29.041           | 0.0023  | 0.0001   |
| 0.1        | 1  | 512 | 50000 |   | 0.421            | 0.0028  | 0.0065   |   | 51.109           | 0.0023  | 0.0000   |
|            |    |     |       |   |                  |         |          |   |                  |         |          |
| 20         | 4  | 512 | 50000 |   | 0.060            | 0.0032  | 0.0525   |   | 0.851            | 0.0039  | 0.0046   |
| 10         | 4  | 512 | 50000 |   | 0.057            | 0.0028  | 0.0485   |   | 1.365            | 0.0035  | 0.0026   |
| 5          | 4  | 512 | 50000 |   | 0.063            | 0.0025  | 0.0402   |   | 2.278            | 0.0035  | 0.0015   |
| 2          | 4  | 512 | 50000 |   | 0.071            | 0.0025  | 0.0353   |   | 5.318            | 0.0035  | 0.0007   |
| 1          | 4  | 512 | 50000 |   | 0.077            | 0.0025  | 0.0323   |   | 9.666            | 0.0035  | 0.0004   |
| 0.5        | 4  | 512 | 50000 |   | 0.085            | 0.0025  | 0.0293   |   | 16.151           | 0.0035  | 0.0002   |
| 0.1        | 4  | 512 | 50000 |   | 0.112            | 0.0025  | 0.0222   |   | 38.063           | 0.0035  | 0.0001   |
|            |    |     |       |   |                  |         |          |   |                  |         |          |
| 20         | 64 | 512 | 50000 |   | 0.006            | 0.0032  | 0.5154   |   | 0.017            | 0.0045  | 0.2645   |
| 10         | 64 | 512 | 50000 |   | 0.005            | 0.0021  | 0.4498   |   | 0.022            | 0.0026  | 0.1183   |
| 5          | 64 | 512 | 50000 |   | 0.005            | 0.0021  | 0.4199   |   | 0.049            | 0.0026  | 0.0537   |
| 2          | 64 | 512 | 50000 |   | 0.006            | 0.0021  | 0.3778   |   | 0.157            | 0.0026  | 0.0167   |
| 1          | 64 | 512 | 50000 |   | 0.006            | 0.0021  | 0.3468   |   | 0.411            | 0.0026  | 0.0064   |
| 0.5        | 64 | 512 | 50000 |   | 0.007            | 0.0021  | 0.3156   |   | 1.055            | 0.0026  | 0.0025   |
| 0.1        | 64 | 512 | 50000 |   | 0.009            | 0.0021  | 0.2414   |   | 5.130            | 0.0026  | 0.0005   |


