### PR TITLE
Optimized sequence reverse operator

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1277,7 +1277,6 @@ def test_residual_fused():
     expected_outputs = np.ones((10, 2, 50))+5
     assert np.array_equal(outputs[0].asnumpy(), expected_outputs)
 
-
 def check_rnn_layer(layer):
     layer.collect_params().initialize(ctx=[mx.cpu(0), mx.gpu(0)])
     with mx.gpu(0):
@@ -1302,6 +1301,10 @@ def test_rnn_layer():
     check_rnn_layer(gluon.rnn.GRU(100, num_layers=3))
 
     check_rnn_layer(gluon.rnn.LSTM(100, num_layers=3, bidirectional=True))
+
+
+def test_sequence_reverse():
+    check_sequence_reverse(mx.gpu(0))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@piiswrong @mli @szha This implementation provides some degree of parallelism on the GPU. The version it replaces would do 1 kernel launch per DType instance (int, float) to be copied, which would make perf really bad on the GPU (kernel launch latency and no parallelism). In Sockeye, this would take up 20% of the timeline. With this change, the time consumed went down to less than 0.5%. I also added tests, since this operator didn't have either CPU or GPU tests.