### PR TITLE
Fix linear regression tutorial

### DIFF
--- a/docs/tutorials/python/linear-regression.md
+++ b/docs/tutorials/python/linear-regression.md
@@ -157,7 +157,7 @@ parameters of the model to fit the training data. This is accomplished using the
 model.fit(train_iter, eval_iter,
             optimizer_params={'learning_rate':0.005, 'momentum': 0.9},
             num_epoch=50,
-	    eval_metric='mse',
+            eval_metric='mse',
             batch_end_callback = mx.callback.Speedometer(batch_size, 2))
 ```
 

--- a/docs/tutorials/python/linear-regression.md
+++ b/docs/tutorials/python/linear-regression.md
@@ -21,6 +21,9 @@ To begin, the following code imports the necessary packages we'll need for this 
 ```python
 import mxnet as mx
 import numpy as np
+
+import logging
+logging.getLogger().setLevel(logging.DEBUG)
 ```
 
 ## Preparing the Data
@@ -153,7 +156,8 @@ parameters of the model to fit the training data. This is accomplished using the
 ```python
 model.fit(train_iter, eval_iter,
             optimizer_params={'learning_rate':0.005, 'momentum': 0.9},
-            num_epoch=1000,
+            num_epoch=50,
+	    eval_metric='mse',
             batch_end_callback = mx.callback.Speedometer(batch_size, 2))
 ```
 


### PR DESCRIPTION
- Print training logs in notebook.
- Switch from accuracy to mse for validation metrics. Accuracy doesn't make much sense for regression.
- Lower the number of epochs to 50. Number of epochs in unnecessarily huge (1000) consuming too much time. Training converges in around 30 epochs.