### PR TITLE
Add python-pip to the "build from source" install prerequisites

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -235,10 +235,10 @@ $ make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
 
 **Build the MXNet Python binding**
 
-**Step 1** Install prerequisites - python setup tools and numpy.
+**Step 1** Install prerequisites - python, setup-tools, python-pip and numpy.
 
 ```bash
-$ sudo apt-get install -y python-dev python-setuptools python-numpy
+$ sudo apt-get install -y python-dev python-setuptools python-numpy python-pip
 ```
 
 **Step 2** Install the MXNet Python binding.


### PR DESCRIPTION
This also fixes the failing jenkins tests for the installation guide
![install_doc_changes](https://user-images.githubusercontent.com/1522319/28046616-c72f6502-6599-11e7-91ae-0cf1c1a38077.png)
