### PR TITLE
Add python-pip for GPU installation steps too

### DIFF
--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -458,10 +458,10 @@ $ make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/
 
 **Install the MXNet Python binding**
 
-**Step 1** Install prerequisites - python setup tools and numpy.
+**Step 1** Install prerequisites - python, setup-tools, python-pip and numpy.
 
 ```bash
-$ sudo apt-get install -y python-dev python-setuptools python-numpy
+$ sudo apt-get install -y python-dev python-setuptools python-numpy python-pip
 ```
 
 **Step 2** Install the MXNet Python binding.


### PR DESCRIPTION
This is related to #6989 . Missed adding python-pip to installation prereqs for GPU. Adding it now.
<img width="784" alt="screen shot 2017-07-12 at 6 04 04 pm" src="https://user-images.githubusercontent.com/1522319/28146279-65a4b176-672d-11e7-9511-e7f9d951b79c.png">
