### PR TITLE
avoid runtime crash caused by error context of gradient storage when using context group

### DIFF
--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/ModelParallelSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/ModelParallelSuite.scala
@@ -23,8 +23,11 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 class ModelParallelSuite extends FunSuite with BeforeAndAfterAll {
   test("chain") {
     val n = 2
+    val ctx1 = Context.cpu(0)
+    val ctx2 = Context.cpu(1)
     val data1 = Symbol.Variable("data1")
     val data2 = Symbol.Variable("data2")
+    val data3 = Symbol.Variable("data3")
 
     var net: Symbol = null
     new AttrScope(Map("ctx_group" -> "dev1")).withScope {
@@ -32,31 +35,28 @@ class ModelParallelSuite extends FunSuite with BeforeAndAfterAll {
     }
 
     new AttrScope(Map("ctx_group" -> "dev2")).withScope {
-      net = net + data1
+      net = net + data3
     }
 
     val shape = Shape(4, 5)
-    val (arr, arrGrad) =
-      new Context(Context.cpu(0)).withScope {
-        val arr = (0 until n).map(_ => NDArray.empty(shape))
-        val arrGrad = (0 until n).map(_ => NDArray.empty(shape))
-        (arr, arrGrad)
-      }
+    val arr = (0 until n + 1).map(_ => NDArray.empty(shape, ctx1))
+    val arrGrad = (0 until n).map(_ => NDArray.empty(shape, ctx1)) :+ NDArray.empty(shape, ctx2)
 
-    val exec1 = net.bind(Context.cpu(),
+    val exec1 = net.bind(ctx1,
       args = arr,
       argsGrad = arrGrad,
       gradReq = "write",
       auxStates = Nil,
-      group2ctx = Map("dev1" -> Context.cpu(0), "dev2" -> Context.cpu(1)),
+      group2ctx = Map("dev1" -> ctx1, "dev2" -> ctx2),
       sharedExec = null)
 
     arr(0).set(1f)
     arr(1).set(2f)
+    arr(2).set(3f)
 
-    val arr2 = arr.map(_.copyTo(Context.cpu()))
-    val arrGrad2 = arrGrad.map(_.copyTo(Context.cpu()))
-    val exec2 = net.bind(Context.cpu(), args = arr2, argsGrad = arrGrad2)
+    val arr2 = arr.map(_.copyTo(ctx1))
+    val arrGrad2 = arrGrad.map(_.copyTo(ctx1))
+    val exec2 = net.bind(ctx1, args = arr2, argsGrad = arrGrad2)
 
     // Show the execution plan that involves copynode
     // scalastyle:off println
@@ -65,14 +65,14 @@ class ModelParallelSuite extends FunSuite with BeforeAndAfterAll {
 
     exec1.forward()
     exec2.forward()
-    assert(reldiff(exec1.outputs(0).copyTo(Context.cpu()),
-        exec2.outputs(0).copyTo(Context.cpu())) < 1e-6f)
+    assert(reldiff(exec1.outputs(0).copyTo(ctx1),
+        exec2.outputs(0).copyTo(ctx1)) < 1e-6f)
 
-    val outGrad = NDArray.ones(shape, Context.cpu(1))
+    val outGrad = NDArray.ones(shape, ctx2)
     exec1.backward(Array(outGrad))
-    exec2.backward(Array(outGrad.copyTo(Context.cpu())))
+    exec2.backward(Array(outGrad.copyTo(ctx1)))
     (arrGrad zip arrGrad2) foreach { case (a, b) =>
-      assert(reldiff(a, b) < 1e-6f)
+      assert(reldiff(a.copyTo(ctx1), b) < 1e-6f)
     }
   }
 }

--- a/tests/python/unittest/test_model_parallel.py
+++ b/tests/python/unittest/test_model_parallel.py
@@ -10,42 +10,52 @@ def reldiff(a, b):
     return reldiff
 
 def test_chain():
+    ctx1 = mx.cpu(0)
+    ctx2 = mx.cpu(1)
     n = 2
     data1 = mx.sym.Variable('data1')
     data2 = mx.sym.Variable('data2')
+    data3 = mx.sym.Variable('data3')
     with mx.AttrScope(ctx_group='dev1'):
         net = data1 + data2
         net = net * 3
 
     with mx.AttrScope(ctx_group='dev2'):
-        net = net + data1
+        net = net + data3
 
-    with mx.Context(mx.cpu(0)):
-        shape = (4, 5)
-        arr = [mx.nd.empty(shape) for i in range(n)]
-        arr_grad = [mx.nd.empty(shape) for i in range(n)]
+    arr = []
+    arr_grad = []
+    shape = (4, 5)
+    with mx.Context(ctx1):
+        for i in range(n):
+            arr.append(mx.nd.empty(shape))
+            arr_grad.append(mx.nd.empty(shape))
+    with mx.Context(ctx2):
+        arr.append(mx.nd.empty(shape))
+        arr_grad.append(mx.nd.empty(shape))
 
-    exec1 = net.bind(mx.cpu(),
+    exec1 = net.bind(ctx1,
                      args=arr,
                      args_grad=arr_grad,
-                     group2ctx={'dev1': mx.cpu(0), 'dev2': mx.cpu(1)})
+                     group2ctx={'dev1': ctx1, 'dev2': ctx2})
     arr[0][:] = 1.0
     arr[1][:] = 2.0
-    arr2 = [a.copyto(mx.cpu()) for a in arr]
-    arr_grad2 = [a.copyto(mx.cpu()) for a in arr_grad]
-    exec2 = net.bind(mx.cpu(),
+    arr[2][:] = 3.0
+    arr2 = [a.copyto(ctx1) for a in arr]
+    arr_grad2 = [a.copyto(ctx1) for a in arr_grad]
+    exec2 = net.bind(ctx1,
                      args=arr2,
                      args_grad=arr_grad2)
 
     # Show the execution plan that involves copynode
     print(exec1.debug_str())
-    exec1.forward()
-    exec2.forward()
+    exec1.forward(is_train=True)
+    exec2.forward(is_train=True)
     assert reldiff(exec1.outputs[0].asnumpy(), exec2.outputs[0].asnumpy()) < 1e-6
-    out_grad = mx.nd.empty(shape, mx.cpu(1))
+    out_grad = mx.nd.empty(shape, ctx1)
     out_grad[:] = 1.0
     exec1.backward([out_grad])
-    exec2.backward([out_grad.copyto(mx.cpu())])
+    exec2.backward([out_grad.copyto(ctx1)])
     for a, b in zip(arr_grad, arr_grad2):
         assert reldiff(a.asnumpy(), b.asnumpy()) < 1e-6
 


### PR DESCRIPTION
Consider following code:
```python
import mxnet as mx
a = mx.sym.Variable('a')
b = mx.sym.Variable('b')
c = mx.sym.Variable('c')
with mx.AttrScope(ctx_group='dev1'):
    net = a * b
with mx.AttrScope(ctx_group='dev2'):
    net = net * c
args_dict = {'a': mx.nd.array([2]), 'b': mx.nd.array([5]), 'c': mx.nd.array([7])}
args_grad = {'a': mx.nd.zeros((1,1)), 'b': mx.nd.zeros((1,1)), 'c': mx.nd.zeros((1,1))}
ctx_map = {'dev1': mx.cpu(), 'dev2': mx.gpu()}
net = mx.sym.MakeLoss(net)
exe = net.bind(mx.cpu(), args_dict, args_grad=args_grad, group2ctx=ctx_map)
print exe.forward(is_train=True)[0].asnumpy()
exe.backward()
print args_grad['a'].asnumpy()
print args_grad['b'].asnumpy()
```
which would cause a CUDA runtime error because of memory access violation.

In `test_model_parallel.py`, if we modify the `mx.cpu(1)` context to `mx.gpu()`, this test would also crash. The reason is that after `AssignContext` we should check again if the gradient storage is on the same device of backward operator.