### PR TITLE
pretty-print structure of gluon layers

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -7,6 +7,7 @@ from ..symbol import Symbol
 from ..ndarray import NDArray
 from .. import name as _name
 from .parameter import Parameter, ParameterDict, DeferredInitializationError
+from .utils import _indent
 
 
 class _BlockScope(object):
@@ -144,6 +145,14 @@ class Block(object):
 
     def _alias(self):
         return self.__class__.__name__.lower()
+
+    def __repr__(self):
+        s = '{name}(\n{modstr}\n)'
+        modstr = '\n'.join(['  ({key}): {block}'.format(key=key,
+                                                        block=_indent(block.__repr__(), 2))
+                            for key, block in self.__dict__.items() if isinstance(block, Block)])
+        return s.format(name=self.__class__.__name__,
+                        modstr=modstr)
 
     @property
     def params(self):

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -111,6 +111,26 @@ class _Conv(HybridBlock):
             act = self.act(act)
         return act
 
+    def __repr__(self):
+        s = '{name}({mapping}, kernel_size={kernel}, stride={stride}'
+        len_kernel_size = len(self._kwargs['kernel'])
+        if self._kwargs['pad'] != (0,) * len_kernel_size:
+            s += ', padding={pad}'
+        if self._kwargs['dilate'] != (1,) * len_kernel_size:
+            s += ', dilation={dilate}'
+        if hasattr(self, 'out_pad') and self.out_pad != (0,) * len_kernel_size:
+            s += ', output_padding={out_pad}'.format(out_pad=self.out_pad)
+        if self._kwargs['num_group'] != 1:
+            s += ', groups={num_group}'
+        if self.bias is None:
+            s += ', bias=False'
+        s += ')'
+        return s.format(name=self.__class__.__name__,
+                        mapping=self._channels if not self._in_channels
+                        else '{0} -> {1}'.format(self._in_channels,
+                                                 self._channels),
+                        **self._kwargs)
+
 
 class Conv1D(_Conv):
     """1D convolution layer (e.g. temporal convolution).
@@ -430,6 +450,7 @@ class Conv1DTranspose(_Conv):
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer,
             bias_initializer, op_name='Deconvolution', adj=output_padding, **kwargs)
+        self.outpad = output_padding
 
 
 class Conv2DTranspose(_Conv):
@@ -515,6 +536,7 @@ class Conv2DTranspose(_Conv):
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer,
             bias_initializer, op_name='Deconvolution', adj=output_padding, **kwargs)
+        self.outpad = output_padding
 
 
 class Conv3DTranspose(_Conv):
@@ -600,6 +622,7 @@ class Conv3DTranspose(_Conv):
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer, bias_initializer,
             op_name='Deconvolution', adj=output_padding, **kwargs)
+        self.outpad = output_padding
 
 
 class _Pooling(HybridBlock):
@@ -620,6 +643,12 @@ class _Pooling(HybridBlock):
 
     def hybrid_forward(self, F, x):
         return F.Pooling(x, **self._kwargs)
+
+    def __repr__(self):
+        s = '{name}(size={kernel}, stride={stride}, padding={pad}, ceil_mode={ceil_mode})'
+        return s.format(name=self.__class__.__name__,
+                        ceil_mode=self._kwargs['pooling_convention'] == 'full',
+                        **self._kwargs)
 
 
 class MaxPool1D(_Pooling):

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -9,6 +9,7 @@ from ..base import mx_real_t, MXNetError
 from .. import symbol, ndarray, initializer, context
 from ..context import Context
 from .. import autograd
+from .utils import _indent
 
 # pylint: disable= invalid-name
 tensor_types = (symbol.Symbol, ndarray.NDArray)
@@ -75,6 +76,10 @@ class Parameter(object):
         self._data = None
         self._grad = None
         self._defered_init = ()
+
+    def __repr__(self):
+        s = 'Parameter {name} (shape={shape}, dtype={dtype})'
+        return s.format(**self.__dict__)
 
     def initialize(self, init=None, ctx=None, default_init=initializer.Uniform()):
         """Initializes parameter and gradient arrays. Only used for `NDArray` API.
@@ -321,6 +326,13 @@ class ParameterDict(object):
 
     def __getitem__(self, key):
         return self._params[key]
+
+    def __repr__(self):
+        s = '{name}(\n{content}\n)'
+        name = self._prefix+' ' if self._prefix else ''
+        return s.format(name=name,
+                        content='\n'.join([_indent('  {0}'.format(v), 2)
+                                           for v in self.values()]))
 
     def items(self):
         return self._params.items()

--- a/python/mxnet/gluon/rnn/rnn_layer.py
+++ b/python/mxnet/gluon/rnn/rnn_layer.py
@@ -62,6 +62,21 @@ class _RNNLayer(Block):
 
         self._unfused = self._unfuse()
 
+    def __repr__(self):
+        s = '{name}({mapping}, {_layout}'
+        if self._num_layers != 1:
+            s += ', num_layers={_num_layers}'
+        if self._dropout != 0:
+            s += ', dropout={_dropout}'
+        if self._dir == 2:
+            s += ', bidirectional'
+        s += ')'
+        mapping = ('{_input_size} -> {_hidden_size}'.format(**self.__dict__) if self._input_size
+                   else self._hidden_size)
+        return s.format(name=self.__class__.__name__,
+                        mapping=mapping,
+                        **self.__dict__)
+
     def state_info(self, batch_size=0):
         raise NotImplementedError
 

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -97,3 +97,15 @@ def clip_global_norm(arrays, max_norm):
         for arr in arrays:
             arr *= scale
     return total_norm
+
+
+def _indent(s_, numSpaces):
+    """Indent string
+    """
+    s = s_.split('\n')
+    if len(s) == 1:
+        return s_
+    first = s.pop(0)
+    s = [first] + [(numSpaces * ' ') + line for line in s]
+    s = '\n'.join(s)
+    return s


### PR DESCRIPTION
@piiswrong @mli 
example:
```
In [1]: import mxnet as mx

In [2]: a = mx.gluon.rnn.BidirectionalCell(mx.gluon.rnn.GRUCell(10), mx.gluon.rnn.LSTMCell(20))

In [3]: b = mx.gluon.rnn.ZoneoutCell(mx.gluon.rnn.GRUCell(10), 0.1, 0.2)

In [4]: c = mx.gluon.rnn.SequentialRNNCell()

In [5]: c.add(a)

In [6]: c.add(b)

In [7]: a
Out[7]: BidirectionalCell(forward=GRUCell(10), backward=LSTMCell(20))

In [8]: b
Out[8]: ZoneoutCell(p_out=0.1, p_state=0.2, GRUCell(10))

In [9]: c
Out[9]:
SequentialRNNCell(
(0): BidirectionalCell(forward=GRUCell(10), backward=LSTMCell(20))
(1): ZoneoutCell(p_out=0.1, p_state=0.2, GRUCell(10))
)

In [10]: d = mx.gluon.rnn.SequentialRNNCell()

In [11]: d.add(c)

In [12]: d
Out[12]:
SequentialRNNCell(
(0): SequentialRNNCell(
  (0): BidirectionalCell(forward=GRUCell(10), backward=LSTMCell(20))
  (1): ZoneoutCell(p_out=0.1, p_state=0.2, GRUCell(10))
  )
)

In [13]: a.collect_params()
Out[13]:
(
  Parameter lstm0_i2h_weight (shape=(80, 0), dtype=<type 'numpy.float32'>)
  Parameter gru0_i2h_bias (shape=(30,), dtype=<type 'numpy.float32'>)
  Parameter lstm0_h2h_weight (shape=(80, 20), dtype=<type 'numpy.float32'>)
  Parameter lstm0_h2h_bias (shape=(80,), dtype=<type 'numpy.float32'>)
  Parameter lstm0_i2h_bias (shape=(80,), dtype=<type 'numpy.float32'>)
  Parameter gru0_i2h_weight (shape=(30, 0), dtype=<type 'numpy.float32'>)
  Parameter gru0_h2h_bias (shape=(30,), dtype=<type 'numpy.float32'>)
  Parameter gru0_h2h_weight (shape=(30, 10), dtype=<type 'numpy.float32'>)
)
```
and a VGG example
```
VGG(
  (features): HybridSequential(
    (0): Conv2D(64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (1): Activation(relu)
    (2): MaxPool2D(size=(2, 2), stride=(2, 2), padding=(0, 0), ceil_mode=False)
    (3): Conv2D(128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (4): Activation(relu)
    (5): MaxPool2D(size=(2, 2), stride=(2, 2), padding=(0, 0), ceil_mode=False)
    (6): Conv2D(256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (7): Activation(relu)
    (8): Conv2D(256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (9): Activation(relu)
    (10): MaxPool2D(size=(2, 2), stride=(2, 2), padding=(0, 0), ceil_mode=False)
    (11): Conv2D(512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (12): Activation(relu)
    (13): Conv2D(512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (14): Activation(relu)
    (15): MaxPool2D(size=(2, 2), stride=(2, 2), padding=(0, 0), ceil_mode=False)
    (16): Conv2D(512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (17): Activation(relu)
    (18): Conv2D(512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (19): Activation(relu)
    (20): MaxPool2D(size=(2, 2), stride=(2, 2), padding=(0, 0), ceil_mode=False)
  )
  (classifier): HybridSequential(
    (0): Dense(4096, Activation(relu))
    (1): Dropout(p = 0.5)
    (2): Dense(4096, Activation(relu))
    (3): Dropout(p = 0.5)
    (4): Dense(1000, linear)
  )
)
```