### PR TITLE
Fix ndarray aux data issue

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -352,6 +352,18 @@ MXNET_DLL int MXNDArraySyncCopyFromCPU(NDArrayHandle handle,
 MXNET_DLL int MXNDArraySyncCopyToCPU(NDArrayHandle handle,
                                      void *data,
                                      size_t size);
+
+/*!
+ * \brief Perform a syncrhonized copy from an default storage type NDArray to
+ * an NDArray's data() or aux_data(i) depending on the parameter i
+ * \param handle_dst handle of a dst ndarray whose data/aux_data has been allocated
+ * \param handle_src handle of a src ndarray which has default storage type
+ * \param i if i = -1, copy src.data() to dst.data(); if i >= 0, copy src.data() to dst.aux_data(i)
+ */
+MXNET_DLL int MXNDArraySyncCopyFromNDArray(NDArrayHandle handle_dst,
+                                           const NDArrayHandle handle_src,
+                                           const int i);
+
 /*!
  * \brief Wait until all the pending writes with respect NDArray are finished.
  *  Always call this before read data out synchronizely.

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -352,13 +352,12 @@ MXNET_DLL int MXNDArraySyncCopyFromCPU(NDArrayHandle handle,
 MXNET_DLL int MXNDArraySyncCopyToCPU(NDArrayHandle handle,
                                      void *data,
                                      size_t size);
-
 /*!
- * \brief Perform a syncrhonized copy from an default storage type NDArray to
- * an NDArray's data() or aux_data(i) depending on the parameter i
+ * \brief Copy src.data() to dst.data() if i = -1, else dst.aux_data(i) if i >= 0
+ * This function blocks. Do not use it in performance critical code.
  * \param handle_dst handle of a dst ndarray whose data/aux_data has been allocated
  * \param handle_src handle of a src ndarray which has default storage type
- * \param i if i = -1, copy src.data() to dst.data(); if i >= 0, copy src.data() to dst.aux_data(i)
+ * \param i dst data blob indicator
  */
 MXNET_DLL int MXNDArraySyncCopyFromNDArray(NDArrayHandle handle_dst,
                                            const NDArrayHandle handle_src,
@@ -470,12 +469,20 @@ MXNET_DLL int MXNDArrayGetAuxType(NDArrayHandle handle,
                                   mx_uint i,
                                   int *out_type);
 
-// Get the ith aux data blob wrapped in an NDArray
+/*!
+ * \brief Get a deep copy of the ith aux data blob
+ * in the form of an NDArray of default storage type.
+ * This function blocks. Do not use it in performance critical code.
+ */
 MXNET_DLL int MXNDArrayGetAuxNDArray(NDArrayHandle handle,
                                      mx_uint i,
                                      NDArrayHandle *out);
 
-// Get the data blob wrapped in an NDArray
+/*!
+ * \brief Get a deep copy of the data blob
+ * in the form of an NDArray of default storage type.
+ * This function blocks. Do not use it in performance critical code.
+ */
 MXNET_DLL int MXNDArrayGetDataNDArray(NDArrayHandle handle,
                                       NDArrayHandle *out);
 /*!

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -643,6 +643,9 @@ class NDArray {
       // aux_handles always reflect the correct number of aux data
       for (size_t i = 0; i < aux_shapes.size(); i++) {
         CheckAndAllocAuxData(i, aux_shapes[i]);
+        // this line is needed in case when aux_shapes[i].Size() = 0
+        // aux_handles[i] will not be updated and take only default value.
+        aux_handles[i].ctx = ctx;
       }
       if (!delay_alloc) {
         CheckAndAllocData(storage_shape, dtype);

--- a/python/mxnet/ndarray/sparse_ndarray.py
+++ b/python/mxnet/ndarray/sparse_ndarray.py
@@ -309,21 +309,23 @@ class SparseNDArray(NDArray):
     def todense(self):
         return todense(self)
 
-    def _aux_data(self, i, writable=True):
+    def _aux_data(self, i):
         """ Get a deep copy NDArray of the i-th aux data array associated with the SparseNDArray.
+        This function blocks. Do not use it in performance critical code.
         """
         self.wait_to_read()
         hdl = NDArrayHandle()
         check_call(_LIB.MXNDArrayGetAuxNDArray(self.handle, i, ctypes.byref(hdl)))
-        return NDArray(hdl, writable)
+        return NDArray(hdl)
 
-    def _data(self, writable=True):
+    def _data(self):
         """ Get a deep copy NDArray of the value array associated with the SparseNDArray.
+        This function blocks. Do not use it in performance critical code.
         """
         self.wait_to_read()
         hdl = NDArrayHandle()
         check_call(_LIB.MXNDArrayGetDataNDArray(self.handle, ctypes.byref(hdl)))
-        return NDArray(hdl, writable)
+        return NDArray(hdl)
 
 # pylint: disable=abstract-method
 class CSRNDArray(SparseNDArray):

--- a/python/mxnet/ndarray/sparse_ndarray.py
+++ b/python/mxnet/ndarray/sparse_ndarray.py
@@ -329,7 +329,7 @@ class SparseNDArray(NDArray):
 
 # pylint: disable=abstract-method
 class CSRNDArray(SparseNDArray):
-    """A CSRNDArray represents a NDArray as three separate arrays: `values`,
+    """A CSRNDArray represents a NDArray as three separate arrays: `data`,
     `indptr` and `indices`. It uses the standard CSR representation where the column indices for
     row i are stored in indices[indptr[i]:indptr[i+1]] and their corresponding values are stored
     in values[indptr[i]:indptr[i+1]].

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -230,6 +230,25 @@ int MXNDArraySyncCopyToCPU(NDArrayHandle handle,
   API_END();
 }
 
+/*!
+ * \brief
+ * \param handle_dst handle of a dst ndarray whose data/aux_data has been allocated
+ * \param handle_src handle of a src ndarray which has default storage type
+ * \param i if i = -1, copy src.data() to dst.data(); if i >= 0, copy src.data() to dst.aux_data(i)
+ */
+int MXNDArraySyncCopyFromNDArray(NDArrayHandle handle_dst,
+                                 const NDArrayHandle handle_src,
+                                 const int i) {
+  API_BEGIN();
+  NDArray* dst = static_cast<NDArray*>(handle_dst);
+  NDArray* src = static_cast<NDArray*>(handle_src);
+  dst->WaitToRead();
+  NDArray ret((i >= 0? dst->aux_data(i) : dst->data()), dst->ctx().dev_id);
+  CopyFromTo(*src, &ret);
+  ret.WaitToRead();
+  API_END();
+}
+
 int MXNDArrayWaitToRead(NDArrayHandle handle) {
   API_BEGIN();
   static_cast<NDArray*>(handle)->WaitToRead();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -231,10 +231,11 @@ int MXNDArraySyncCopyToCPU(NDArrayHandle handle,
 }
 
 /*!
- * \brief
+ * \brief Copy src.data() to dst.data() if i = -1, else dst.aux_data(i) if i >= 0
+ * This function blocks. Do not use it in performance critical code.
  * \param handle_dst handle of a dst ndarray whose data/aux_data has been allocated
  * \param handle_src handle of a src ndarray which has default storage type
- * \param i if i = -1, copy src.data() to dst.data(); if i >= 0, copy src.data() to dst.aux_data(i)
+ * \param i dst data blob indicator
  */
 int MXNDArraySyncCopyFromNDArray(NDArrayHandle handle_dst,
                                  const NDArrayHandle handle_src,
@@ -242,10 +243,7 @@ int MXNDArraySyncCopyFromNDArray(NDArrayHandle handle_dst,
   API_BEGIN();
   NDArray* dst = static_cast<NDArray*>(handle_dst);
   NDArray* src = static_cast<NDArray*>(handle_src);
-  dst->WaitToRead();
-  NDArray ret((i >= 0? dst->aux_data(i) : dst->data()), dst->ctx().dev_id);
-  CopyFromTo(*src, &ret);
-  ret.WaitToRead();
+  dst->SyncCopyFromNDArray(*src, -1, i);
   API_END();
 }
 
@@ -455,6 +453,11 @@ int MXNDArrayGetAuxType(NDArrayHandle handle,
   API_END();
 }
 
+/*!
+ * \brief Get a deep copy of the ith aux data blob
+ * in the form of an NDArray of default storage type.
+ * This function blocks. Do not use it in performance critical code.
+ */
 int MXNDArrayGetAuxNDArray(NDArrayHandle handle,
                            mx_uint i,
                            NDArrayHandle *out) {
@@ -464,6 +467,11 @@ int MXNDArrayGetAuxNDArray(NDArrayHandle handle,
   API_END();
 }
 
+/*!
+ * \brief Get a deep copy of the data blob
+ * in the form of an NDArray of default storage type.
+ * This function blocks. Do not use it in performance critical code.
+ */
 int MXNDArrayGetDataNDArray(NDArrayHandle handle,
                             NDArrayHandle *out) {
   API_BEGIN();

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -106,6 +106,24 @@ NDArray NDArray::At(index_t idx) const {
   }
 }
 
+NDArray NDArray::aux_ndarray(size_t i) const {
+  CHECK_NE(storage_type(), kDefaultStorage);
+  CHECK(i < ptr_->aux_shapes.size());
+  WaitToRead();
+  NDArray ret(aux_shape(i), ctx(), false, aux_type(i));
+  CopyFromTo(NDArray(aux_data(i), ctx().dev_id), &ret);
+  ret.WaitToRead();
+  return ret;
+}
+
+NDArray NDArray::data_ndarray() const {
+  CHECK_NE(storage_type(), kDefaultStorage);
+  WaitToRead();
+  NDArray ret(storage_shape(), ctx(), false, dtype_);
+  CopyFromTo(NDArray(data(), ctx().dev_id), &ret);
+  ret.WaitToRead();
+  return ret;
+}
 
 bool NDArray::fresh_out_grad() const {
   if (entry_.ag_node != nullptr) return entry_.ag_node->fresh_out_grad;

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1052,7 +1052,7 @@ void NDArray::SyncCopyFromNDArray(const NDArray& src, int i, int j) {
   if (i >= 0) {
     CHECK_NE(src.storage_type(), kDefaultStorage);
   } else {
-    CHECK(!src.is_none()) << "src dense ndarray must have been iniatilized";
+    CHECK(!src.is_none()) << "src dense ndarray must have been initialized";
   }
   if (j >= 0) {
     CHECK_NE(storage_type(), kDefaultStorage);
@@ -1129,6 +1129,8 @@ void NDArray::SyncCopyFromNDArray(const NDArray& src, int i, int j) {
     LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif
   }
+  // The copy operation was pushed to engine to execute.
+  // Need to wait here for it being completed.
   WaitToRead();
 }
 

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1131,6 +1131,12 @@ void NDArray::SyncCopyFromNDArray(const NDArray& src, int i, int j) {
   }
   // The copy operation was pushed to engine to execute.
   // Need to wait here for it being completed.
+  // The reason for pushing the copy operation to engine
+  // is because when copying data from a sparse tensor
+  // to the current one, that sparse ndarray's storage_shape/aux_shape
+  // may not be ready or changed and we need to ensure
+  // thread safty for reading the correct shape info to allocate
+  // memory for the current ndarray.
   WaitToRead();
 }
 

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -6,6 +6,7 @@ from test_operator import *
 from test_optimizer import *
 from test_random import *
 from test_sparse_operator import test_sparse_nd_zeros, test_sparse_dot
+from test_sparse_ndarray import test_create_csr, test_create_row_sparse
 import mxnet as mx
 import numpy as np
 from mxnet.test_utils import check_consistency, set_default_context

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -378,6 +378,38 @@ def test_sparse_ndarray_save_load():
     os.remove(fname)
 
 
+def test_create_csr():
+    dim0 = 50
+    dim1 = 50
+    densities = [0, 0.01, 0.1, 0.2, 0.5]
+    for density in densities:
+        shape = rand_shape_2d(dim0, dim1)
+        matrix = rand_ndarray(shape, 'csr', density)
+        data = matrix.data
+        indptr = matrix.indptr
+        indices = matrix.indices
+        csr_created = mx.nd.csr(data=data, indptr=indptr, indices=indices, shape=shape)
+        assert csr_created.stype == 'csr'
+        assert same(csr_created.data.asnumpy(), data.asnumpy())
+        assert same(csr_created.indptr.asnumpy(), indptr.asnumpy())
+        assert same(csr_created.indices.asnumpy(), indices.asnumpy())
+
+
+def test_create_row_sparse():
+    dim0 = 50
+    dim1 = 50
+    densities = [0, 0.01, 0.1, 0.2, 0.5]
+    for density in densities:
+        shape = rand_shape_2d(dim0, dim1)
+        matrix = rand_ndarray(shape, 'row_sparse', density)
+        data = matrix.data
+        indices = matrix.indices
+        rsp_created = mx.nd.row_sparse(data=data, indices=indices, shape=shape)
+        assert rsp_created.stype == 'row_sparse'
+        assert same(rsp_created.data.asnumpy(), data.asnumpy())
+        assert same(rsp_created.indices.asnumpy(), indices.asnumpy())
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
1. Returns a sparse tensor's data/aux_data in form of an NDArray, which is a deep copy of the original data blob. This behavior is same as scipy's csr_matrix.
2. Changed functions csr and row_sparse for generating sparse tensors accordingly and added unit tests.
@piiswrong @eric-haibin-lin @madjam @stefanhenneking @bhavinthaker 