### PR TITLE
remove sparse embedding

### DIFF
--- a/python/mxnet/ndarray/sparse_ndarray.py
+++ b/python/mxnet/ndarray/sparse_ndarray.py
@@ -387,7 +387,7 @@ class RowSparseNDArray(SparseNDArray):
     ``dense[rsp.indices[i], :, :, :, ...] = rsp.values[i, :, :, :, ...]``
 
     RowSparseNDArray is used principally in the definition of gradients for operations
-    that have sparse gradients (e.g. SparseEmbedding).
+    that have sparse gradients (e.g. dot with sparse inputs).
 
     Examples
     --------

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -86,49 +86,6 @@ NNVM_REGISTER_OP(_backward_Embedding)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
 .set_attr<FCompute>("FCompute<cpu>", EmbeddingOpBackward<cpu>);
 
-NNVM_REGISTER_OP(SparseEmbedding)
-.describe(R"doc(Represents words or other sparse inputs by dense continuous vectors.
-It assumes that the input is in one-hot form. E.g., for a vocabulary size of 10,000,
- each input vector is expected to have dimension 10,000.
-The index of the non-zero entry is the index of the word or item it represents.
-
-The corresponding embedding vectors are stored as rows of a matrix.
-Hence, mapping an input word to its embedding is implemented as a matrix product.
-
-The gradient of an embedding matrix has the form of gradient vectors that are only
- non-zero for words seen in a minibatch.
-)doc" ADD_FILELINE)
-.set_num_inputs(2)
-.set_num_outputs(1)
-.set_attr_parser(ParamParser<EmbeddingParam>)
-.set_attr<nnvm::FListInputNames>("FListInputNames",
-  [](const NodeAttrs& attrs) {
-    return std::vector<std::string>{"data", "weight"};
-  })
-.set_attr<nnvm::FInferShape>("FInferShape", SparseEmbeddingShape)
-.set_attr<nnvm::FInferType>("FInferType", EmbeddingOpType)
-.set_attr<FInferStorageType>("FInferStorageType", SparseEmbeddingForwardStorageType)
-.set_attr<FResourceRequest>("FResourceRequest",
-  [](const NodeAttrs& attrs) {
-    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-  })
-.set_attr<FComputeEx>("FComputeEx<cpu>", SparseEmbeddingForwardEx<cpu>)
-.set_attr<nnvm::FGradient>("FGradient",
-  [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    return MakeNonlossGradNode("_backward_SparseEmbedding", n, ograds,
-                               {n->inputs[0]}, n->attrs.dict);
-  })
-.add_argument("data", "NDArray-or-Symbol",
-              "The input array to the sparse embedding operator.")
-.add_argument("weight", "NDArray-or-Symbol", "The embedding weight matrix.")
-.add_arguments(EmbeddingParam::__FIELDS__());
-
-NNVM_REGISTER_OP(_backward_SparseEmbedding)
-.set_num_inputs(2)
-.set_num_outputs(2)
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<FComputeEx>("FComputeEx<cpu>", SparseEmbeddingBackwardEx<cpu>);
-
 NNVM_REGISTER_OP(take)
 .describe(R"code(Takes elements from an input array along the given axis.
 

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -142,36 +142,6 @@ def test_sparse_dot():
     test_dot_csr(lhs_shape, (lhs_shape[0], rnd.randint(1, 10)), 'row_sparse', True, 0.05)
 
 
-def test_sparse_embedding():
-    in_dim = 10
-    out_dim = 4
-    batch = 24
-
-    data = mx.sym.Variable("data", stype='csr')
-    embed = mx.sym.SparseEmbedding(data=data, input_dim=in_dim, output_dim=out_dim, name="embed")
-    exe_test = embed.simple_bind(default_context(), grad_req={'data': 'null', 'embed_weight': 'write'},
-                                 data=(batch, in_dim))
-
-    arg_map = dict(zip(embed.list_arguments(), exe_test.arg_arrays))
-    grad_map = dict(zip(embed.list_arguments(), exe_test.grad_arrays))
-    np_data = np.random.randint(low=0, high=in_dim, size=batch)
-    np_weight = np.random.uniform(-0.01, 0.01, arg_map["embed_weight"].shape)
-    np_onehot = np.zeros((batch, in_dim))
-    np_onehot[np.arange(batch), np_data] = 1.0
-    nd_onehot = mx.nd.array(np_onehot)._to_csr()
-    # forward
-    arg_map["data"][:] = nd_onehot
-    arg_map["embed_weight"][:] = np_weight
-    exe_test.forward(is_train=True)
-    assert_almost_equal(exe_test.outputs[0].asnumpy(), np.dot(np_onehot, np_weight))
-    # backward
-    np_grad = np.random.uniform(-1, 1, exe_test.outputs[0].shape)
-    grad = mx.nd.zeros(np_grad.shape)
-    grad[:] = np_grad
-    exe_test.backward([grad])
-    assert_almost_equal(grad_map["embed_weight"].asnumpy(), np.dot(np_onehot.T, np_grad), atol=1e-5)
-
-
 def test_sparse_slice():
     def check_csr_slice(shape, slice_input):
         storage_type = 'csr'


### PR DESCRIPTION
Remove sparse embedding op since its definition is confusing compared to the existing embedding op. User will simply use dot operator instead. e.g.
```
v1 = mx.sym.var('input', stype='csr')
weight = mx.sym.var('weight', stype='row_sparse', shape=(feature_dimension, target_dimension))
embed = mx.sym.dot(v1, weight)
```

@mli  @piiswrong  @nikrao @reminisce @stefanhenneking 