### PR TITLE
remove untested gpu operators

### DIFF
--- a/src/operator/tensor/elemwise_binary_op_basic.cu
+++ b/src/operator/tensor/elemwise_binary_op_basic.cu
@@ -9,8 +9,7 @@
 namespace mxnet {
 namespace op {
 NNVM_REGISTER_OP(elemwise_add)
-.set_attr<FCompute>("FCompute<gpu>", BinaryComputeWithHalf2<gpu, mshadow::op::plus>)
-.set_attr<FComputeEx>("FComputeEx<gpu>", BinaryComputeEx<gpu, mshadow::op::plus>);
+.set_attr<FCompute>("FCompute<gpu>", BinaryComputeWithHalf2<gpu, mshadow::op::plus>);
 
 NNVM_REGISTER_OP(_grad_add)
 .set_attr<FCompute>("FCompute<gpu>", BinaryComputeWithHalf2<gpu, mshadow::op::plus>);
@@ -18,9 +17,7 @@ NNVM_REGISTER_OP(_grad_add)
 NNVM_REGISTER_OP(_backward_add)
 .set_attr<FCompute>("FCompute<gpu>",
                     BinaryBackwardUseNoneWithHalf2<gpu,
-                    mshadow_op::identity, mshadow_op::identity>)
-.set_attr<FComputeEx>("FComputeEx<gpu>",
-                      BinaryBackwardUseNoneEx<gpu, mshadow_op::identity, mshadow_op::identity>);
+                    mshadow_op::identity, mshadow_op::identity>);
 
 NNVM_REGISTER_OP(_sub)
 .set_attr<FCompute>("FCompute<gpu>", BinaryComputeWithHalf2<gpu, mshadow::op::minus>);

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -26,12 +26,6 @@ NNVM_REGISTER_OP(batch_take)
 NNVM_REGISTER_OP(one_hot)
 .set_attr<FCompute>("FCompute<gpu>", OneHotOpForward<gpu>);
 
-NNVM_REGISTER_OP(sparse_retain)
-.set_attr<FComputeEx>("FComputeEx<gpu>", SparseRetainOpForwardEx<gpu>);
-
-NNVM_REGISTER_OP(_backward_sparse_retain)
-.set_attr<FComputeEx>("FComputeEx<gpu>", SparseRetainOpBackwardEx<gpu>);
-
 }  // namespace op
 }  // namespace mxnet
 

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.join(curr_path, '../unittest'))
 from test_operator import *
 from test_optimizer import *
 from test_random import *
-from test_sparse_operator import test_sparse_dot
+from test_sparse_operator import test_sparse_nd_zeros, test_sparse_dot
 import mxnet as mx
 import numpy as np
 from mxnet.test_utils import check_consistency, set_default_context

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -60,18 +60,6 @@ def test_sparse_nd_elementwise_fallback():
         check_sparse_nd_elemwise_binary(shape, ['row_sparse', 'row_sparse'], op, g)
 
 
-def test_sparse_nd_zeros():
-    def check_sparse_nd_zeros(stype, shape):
-        zero = mx.nd.zeros(shape)
-        sparse_zero = mx.nd.zeros(shape=shape, stype=stype)
-        assert_almost_equal(sparse_zero.asnumpy(), zero.asnumpy())
-
-    shape = rand_shape_2d()
-    check_sparse_nd_zeros('row_sparse', shape)
-    check_sparse_nd_zeros('csr', shape)
-    check_sparse_nd_zeros('default', shape)
-
-
 def test_sparse_nd_copy():
     def check_sparse_nd_copy(from_stype, to_stype):
         shape = rand_shape_2d()

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -139,7 +139,9 @@ def test_sparse_dot():
     test_dot_csr(lhs_shape, (lhs_shape[1], rnd.randint(1, 10)), 'row_sparse', False)
     test_dot_csr(lhs_shape, (lhs_shape[0], rnd.randint(1, 10)), 'row_sparse', True)
     test_dot_csr(lhs_shape, (lhs_shape[1], rnd.randint(1, 10)), 'row_sparse', False, 0.05)
-    test_dot_csr(lhs_shape, (lhs_shape[0], rnd.randint(1, 10)), 'row_sparse', True, 0.05)
+    # TODO(haibin/jun/stefan) test dot(csr.T, row_sparse) = dns gpu version
+    if Context.default_ctx == mx.cpu():
+        test_dot_csr(lhs_shape, (lhs_shape[0], rnd.randint(1, 10)), 'row_sparse', True, 0.05)
 
 
 def test_sparse_slice():
@@ -178,6 +180,18 @@ def test_sparse_retain():
         idx = mx.symbol.Variable('indices')
         sym = mx.sym.sparse_retain(data=data, indices=idx)
         check_numeric_gradient(sym, [rsp, indices], grad_nodes=['data'], grad_stype_dict={'data': 'row_sparse'})
+
+def test_sparse_nd_zeros():
+    def check_sparse_nd_zeros(stype, shape):
+        zero = mx.nd.zeros(shape)
+        sparse_zero = mx.nd.zeros(shape=shape, stype=stype)
+        assert_almost_equal(sparse_zero.asnumpy(), zero.asnumpy())
+
+    shape = rand_shape_2d()
+    check_sparse_nd_zeros('row_sparse', shape)
+    check_sparse_nd_zeros('csr', shape)
+    check_sparse_nd_zeros('default', shape)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
Removed a few gpu-registered operators since they're not tested on gpu due to lack of cast_storage(dns->rsp) implementation
@reminisce @stefanhenneking 