### PR TITLE
Support K-dimensional row-sparse tensor

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -683,7 +683,6 @@ class NDArray {
       if (kRowSparseStorage == storage_type) {
         // For row sparse, aux_shape indicates the number of rows to allocate
         auto aux_shape = aux_shapes[rowsparse::kIdx];
-        CHECK_EQ(shape.ndim(), 2) << "High dim RowSparse not yet implemented";
         CheckAndAllocAuxData(rowsparse::kIdx, aux_shape);
         TShape storage_shape(shape);
         storage_shape[0] = aux_shape[0];

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -80,10 +80,6 @@ def rand_sparse_ndarray(shape, stype, density=None):
     """Generate a random sparse ndarray. Returns the ndarray, value(np) and indices(np) """
     density = rnd.rand() if density is None else density
     if stype == 'row_sparse':
-        # TODO(haibin) support high dim sparse ndarray
-        assert(len(shape) < 3)
-        prod = np.prod(shape)
-        num_cols = int(prod / shape[0])
         # sample index
         idx_sample = rnd.rand(shape[0])
         indices = np.argwhere(idx_sample < density).flatten()
@@ -91,7 +87,7 @@ def rand_sparse_ndarray(shape, stype, density=None):
             result = mx.nd.zeros(shape, stype='row_sparse')
             return result, (np.array([], dtype='int64'), np.array([], dtype='int64'))
         # generate random values
-        val = rnd.rand(indices.shape[0], num_cols)
+        val = rnd.rand(indices.shape[0], *shape[1:])
         arr = mx.nd.row_sparse(val, indices, shape, indices_type=np.int64)
         return arr, (val, indices)
     elif stype == 'csr':
@@ -114,6 +110,8 @@ def rand_ndarray(shape, stype, density=None):
 def rand_shape_2d(dim0=10, dim1=10):
     return rnd.randint(1, dim0), rnd.randint(1, dim1)
 
+def rand_shape_3d(dim0=10, dim1=10, dim2=10):
+    return rnd.randint(1, dim0), rnd.randint(1, dim1), rnd.randint(1, dim2)
 
 def np_reduce(dat, axis, keepdims, numpy_reduce_func):
     """Compatible reduce for old version of NumPy.

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -108,10 +108,10 @@ def rand_ndarray(shape, stype, density=None):
 
 
 def rand_shape_2d(dim0=10, dim1=10):
-    return rnd.randint(1, dim0), rnd.randint(1, dim1)
+    return rnd.randint(1, dim0 + 1), rnd.randint(1, dim1 + 1)
 
 def rand_shape_3d(dim0=10, dim1=10, dim2=10):
-    return rnd.randint(1, dim0), rnd.randint(1, dim1), rnd.randint(1, dim2)
+    return rnd.randint(1, dim0 + 1), rnd.randint(1, dim1 + 1), rnd.randint(1, dim2 + 1)
 
 def np_reduce(dat, axis, keepdims, numpy_reduce_func):
     """Compatible reduce for old version of NumPy.

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -131,10 +131,10 @@ inline void SGDUpdateDnsRspImpl(const SGDParam& param,
   MSHADOW_REAL_TYPE_SWITCH(weight.type_flag_, DType, {
     MSHADOW_IDX_TYPE_SWITCH(grad.aux_type(rowsparse::kIdx), IType, {
       MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
-        auto weight_data = weight.dptr<DType>();
-        auto grad_idx = grad.aux_data(rowsparse::kIdx).dptr<IType>();
-        auto grad_val = grad.data().dptr<DType>();
-        auto num_rows = grad.aux_shape(rowsparse::kIdx)[0];
+        DType* weight_data = weight.dptr<DType>();
+        IType* grad_idx = grad.aux_data(rowsparse::kIdx).dptr<IType>();
+        DType* grad_val = grad.data().dptr<DType>();
+        index_t num_rows = grad.aux_shape(rowsparse::kIdx)[0];
         auto row_length = weight.shape_.ProdShape(1, weight.ndim());
         Kernel<SGDDnsRspKernel<req_type>, xpu>::Launch(s, num_rows, row_length,
           out->dptr<DType>(), weight_data, grad_idx, grad_val,
@@ -195,9 +195,9 @@ inline void SGDUpdateRspDnsImpl(const SGDParam& param,
   Stream<xpu>* s = ctx.get_stream<xpu>();
   MSHADOW_REAL_TYPE_SWITCH(weight.dtype(), DType, {
     MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
-      auto weight_data = weight.data().dptr<DType>();
-      auto grad_data = grad.dptr<DType>();
-      auto num_rows = weight.aux_shape(kIdx)[0];
+      DType* weight_data = weight.data().dptr<DType>();
+      DType* grad_data = grad.dptr<DType>();
+      index_t num_rows = weight.aux_shape(kIdx)[0];
       auto num_cols = weight.shape().ProdShape(1, weight.shape().ndim());
       Kernel<SGDRspDnsKernel<req_type>, xpu>::Launch(s, num_rows, num_cols,
         out->data().dptr<DType>(), weight_data, grad_data,
@@ -366,12 +366,12 @@ inline void SGDMomUpdateDnsRspDnsImpl(const SGDMomParam& param,
   MSHADOW_REAL_TYPE_SWITCH(weight.type_flag_, DType, {
     MSHADOW_IDX_TYPE_SWITCH(grad.aux_type(kIdx), IType, {
       MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
-        auto weight_data = weight.dptr<DType>();
-        auto grad_idx = grad.aux_data(kIdx).dptr<IType>();
-        auto grad_val = grad.data().dptr<DType>();
-        auto mom_data = mom.dptr<DType>();
-        auto out_data = out->dptr<DType>();
-        auto num_rows = grad.aux_shape(kIdx)[0];
+        DType* weight_data = weight.dptr<DType>();
+        IType* grad_idx = grad.aux_data(kIdx).dptr<IType>();
+        DType* grad_val = grad.data().dptr<DType>();
+        DType* mom_data = mom.dptr<DType>();
+        DType* out_data = out->dptr<DType>();
+        index_t num_rows = grad.aux_shape(kIdx)[0];
         auto row_length = weight.shape_.ProdShape(1, weight.ndim());
         Kernel<SGDMomDnsRspDnsKernel<req_type>, xpu>::Launch(s, num_rows, row_length,
           out_data, mom_data, weight_data, grad_idx, grad_val,
@@ -443,10 +443,10 @@ inline void SGDMomUpdateRspDnsImpl(const SGDMomParam& param,
   if (out_req == kWriteTo) out_req = kWriteInplace;
   MSHADOW_REAL_TYPE_SWITCH(weight.dtype(), DType, {
     MXNET_ASSIGN_REQ_SWITCH(out_req, req_type, {
-      auto weight_data = weight.data().dptr<DType>();
-      auto grad_data = grad.dptr<DType>();
-      auto mom_data = mom.data().dptr<DType>();
-      auto num_rows = weight.aux_shape(kIdx)[0];
+      DType* weight_data = weight.data().dptr<DType>();
+      DType* grad_data = grad.dptr<DType>();
+      DType* mom_data = mom.data().dptr<DType>();
+      index_t num_rows = weight.aux_shape(kIdx)[0];
       auto num_cols = weight.shape().ProdShape(1, weight.shape().ndim());
       Kernel<SGDMomRspDnsKernel<req_type>, xpu>::Launch(s, num_rows, num_cols,
         out->data().dptr<DType>(), mom_data, weight_data, grad_data,

--- a/src/operator/tensor/cast_storage-inl.h
+++ b/src/operator/tensor/cast_storage-inl.h
@@ -111,8 +111,8 @@ void CastStorageRspDnsImpl(mshadow::Stream<xpu>* s, const NDArray& rsp, TBlob* d
       if (rsp.storage_initialized()) {
         // copy over row by row
         auto in_idx = rsp.aux_data(rowsparse::kIdx).FlatTo1D<xpu, IType>(s).dptr_;
-        auto in_data = rsp.data().FlatTo2D<xpu, DType>(s).dptr_;
-        auto out_data = dns->FlatTo2D<xpu, DType>(s).dptr_;
+        auto in_data = rsp.data().dptr<DType>();
+        auto out_data = dns->dptr<DType>();
         auto num_rows = rsp.aux_shape(rowsparse::kIdx).Size();
         const auto shape = rsp.shape();
         auto row_length = shape.ProdShape(1, shape.ndim());

--- a/src/operator/tensor/cast_storage-inl.h
+++ b/src/operator/tensor/cast_storage-inl.h
@@ -47,33 +47,34 @@ struct MarkRspRowIdx {
  * CPU implementation of casting a dns tensor to rsp type.
  */
 inline void CastStorageDnsRspImpl(mshadow::Stream<cpu>* s, const TBlob& dns, NDArray* rsp) {
+  using namespace rowsparse;
+  using namespace mshadow;
   CHECK(rsp != nullptr);
   CHECK_EQ(rsp->storage_type(), kRowSparseStorage);
   CHECK_EQ(dns.shape_, rsp->shape());
   MSHADOW_TYPE_SWITCH(dns.type_flag_, DType, {  // data type
-    MSHADOW_IDX_TYPE_SWITCH(rsp->aux_type(rowsparse::kIdx), RType, {  // row idx type
+    MSHADOW_IDX_TYPE_SWITCH(rsp->aux_type(kIdx), RType, {  // row idx type
       const index_t num_rows = dns.shape_[0];
       const index_t row_length = dns.shape_.ProdShape(1, dns.shape_.ndim());
-      rsp->CheckAndAllocAuxData(rowsparse::kIdx, mshadow::Shape1(num_rows));
-      TBlob row_idx_blob = rsp->aux_data(rowsparse::kIdx);
+      rsp->CheckAndAllocAuxData(kIdx, Shape1(num_rows));
+      TBlob row_idx_blob = rsp->aux_data(kIdx);
       RType* row_idx = row_idx_blob.dptr<RType>();
       mxnet_op::Kernel<MarkRspRowIdx, cpu>::Launch(s, num_rows, row_idx,
           dns.dptr<DType>(), row_length);
       index_t nnr = 0;
       nnr = common::ParallelAccumulate(row_idx, num_rows, nnr);
-      rsp->set_aux_shape(rowsparse::kIdx, mshadow::Shape1(nnr));
+      rsp->set_aux_shape(kIdx, Shape1(nnr));
       if (0 == nnr) return;
       auto storage_shape = dns.shape_;
       storage_shape[0] = nnr;
       rsp->CheckAndAllocData(storage_shape);
-      TShape shape_2d = mshadow::Shape2(num_rows, row_length);
-      auto dns_data = dns.reshape(shape_2d).FlatTo2D<cpu, DType>(s);
-      auto rsp_data = rsp->data().reshape(shape_2d).FlatTo2D<cpu, DType>(s);
+      auto dns_data = dns.reshape(Shape2(num_rows, row_length)).FlatTo2D<cpu, DType>(s);
+      auto rsp_data = rsp->data().reshape(Shape2(nnr, row_length)).FlatTo2D<cpu, DType>(s);
       size_t idx = 0;
       for (index_t i = 0; i < num_rows; ++i) {
         if (row_idx[i] > 0) {
           row_idx[idx] = i;
-          mshadow::Copy(rsp_data[idx], dns_data[i], s);
+          Copy(rsp_data[idx], dns_data[i], s);
           ++idx;
         }
       }

--- a/src/operator/tensor/cast_storage-inl.h
+++ b/src/operator/tensor/cast_storage-inl.h
@@ -68,8 +68,8 @@ inline void CastStorageDnsRspImpl(mshadow::Stream<cpu>* s, const TBlob& dns, NDA
       auto storage_shape = dns.shape_;
       storage_shape[0] = nnr;
       rsp->CheckAndAllocData(storage_shape);
-      auto dns_data = dns.reshape(Shape2(num_rows, row_length)).FlatTo2D<cpu, DType>(s);
-      auto rsp_data = rsp->data().reshape(Shape2(nnr, row_length)).FlatTo2D<cpu, DType>(s);
+      auto dns_data = dns.get_with_shape<cpu, 2, DType>(Shape2(num_rows, row_length), s);
+      auto rsp_data = rsp->data().get_with_shape<cpu, 2, DType>(Shape2(nnr, row_length), s);
       size_t idx = 0;
       for (index_t i = 0; i < num_rows; ++i) {
         if (row_idx[i] > 0) {

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -709,7 +709,9 @@ void DotForwardEx(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(outputs.size(), 1U);
   CHECK_EQ(req.size(), 1U);
   const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
-  CHECK(!param.transpose_b) << "tranposing rhs of the op dot is not supported";
+  CHECK(!param.transpose_b) << "transposing rhs of the op dot is not supported";
+  CHECK_EQ(inputs[0].shape().ndim(), 2) << "dot only supports 2 dimensional lhs";
+  CHECK_EQ(inputs[1].shape().ndim(), 2) << "dot only supports 2 dimensional rhs";
   auto lhs_stype = inputs[0].storage_type();
   auto rhs_stype = inputs[1].storage_type();
   auto out_stype = outputs[0].storage_type();
@@ -749,6 +751,8 @@ void DotBackwardEx(const nnvm::NodeAttrs& attrs,
 
   const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
   CHECK(!param.transpose_b) << "sparse dot only supports dot(A, X) and dot(A.T(), X)";
+  CHECK_EQ(inputs[0].shape().ndim(), 2) << "sparse dot only supports 2 dimensional lhs";
+  CHECK_EQ(inputs[1].shape().ndim(), 2) << "sparse dot only supports 2 dimensional rhs";
   const auto ograd_stype = inputs[0].storage_type();
   const auto lhs_stype = inputs[1].storage_type();
   const auto rhs_stype = inputs[2].storage_type();

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -502,7 +502,6 @@ inline void DotCsrDnsRspImpl(mshadow::Stream<cpu>* s,
             index_t nnr = 0;
             nnr = mxnet::common::ParallelAccumulate(row_idx, ret->shape()[0], nnr);
             ret->set_aux_shape(rowsparse::kIdx, mshadow::Shape1(nnr));
-            ret->set_storage_shape(mshadow::Shape2(nnr, ret->shape()[1]));
             if (0 == nnr) return;
             mshadow::Tensor<cpu, 2, DType> rsp_data = data_out.FlatTo2D<cpu, DType>(s);
             size_t idx = 0;
@@ -636,7 +635,6 @@ inline void DotCsrRspRspImpl(mshadow::Stream<cpu>* s,
             index_t nnr = 0;
             nnr = mxnet::common::ParallelAccumulate(row_idx, ret->shape()[0], nnr);
             ret->set_aux_shape(rowsparse::kIdx, mshadow::Shape1(nnr));
-            ret->set_storage_shape(mshadow::Shape2(nnr, ret->shape()[1]));
             if (0 == nnr) return;
             mshadow::Tensor<cpu, 2, DType> rsp_data = data_out.FlatTo2D<cpu, DType>(s);
             size_t idx = 0;

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -707,9 +707,9 @@ void DotForwardEx(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(outputs.size(), 1U);
   CHECK_EQ(req.size(), 1U);
   const DotParam& param = nnvm::get<DotParam>(attrs.parsed);
-  CHECK(!param.transpose_b) << "transposing rhs of the op dot is not supported";
-  CHECK_EQ(inputs[0].shape().ndim(), 2) << "dot only supports 2 dimensional lhs";
-  CHECK_EQ(inputs[1].shape().ndim(), 2) << "dot only supports 2 dimensional rhs";
+  CHECK(!param.transpose_b) << "transposing rhs of the sparse dot op is not supported";
+  CHECK_EQ(inputs[0].shape().ndim(), 2) << "sparse dot only supports 2 dimensional lhs";
+  CHECK_EQ(inputs[1].shape().ndim(), 2) << "sparse dot only supports 2 dimensional rhs";
   auto lhs_stype = inputs[0].storage_type();
   auto rhs_stype = inputs[1].storage_type();
   auto out_stype = outputs[0].storage_type();

--- a/src/operator/tensor/elemwise_binary_op.h
+++ b/src/operator/tensor/elemwise_binary_op.h
@@ -14,6 +14,7 @@
 #include "../mxnet_op.h"
 #include "../mshadow_op.h"
 #include "../elemwise_op_common.h"
+#include "./init_op.h"
 #include "../../common/utils.h"
 
 namespace mxnet {
@@ -125,38 +126,47 @@ void BinaryBackwardUseNone_(const nnvm::NodeAttrs& attrs,
 }
 
 // TODO(haibin) This is a single-thread inefficient implementation
-// Binary Compute between two row-sparse ndarray
 // This implementation only works on CPU
 template<typename xpu, typename OP>
-void BinaryComputeRspRsp(const nnvm::NodeAttrs& attrs,
-                         const OpContext& ctx,
-                         const std::vector<NDArray>& inputs,
-                         const std::vector<OpReqType>& req,
-                         const std::vector<NDArray>& outputs) {
+void BinaryComputeRspRspImpl(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const std::vector<NDArray>& inputs,
+                             const std::vector<OpReqType>& req,
+                             const std::vector<NDArray>& outputs) {
+  CHECK(req[0] == kWriteTo) << "only kWriteTo is supported for rowsparse elemwise_add";
+  using namespace rowsparse;
+  using namespace mshadow;
   auto &lhs = inputs[0];
   auto &rhs = inputs[1];
   auto &output = outputs[0];
 
   bool init_l = lhs.storage_initialized();
   bool init_r = rhs.storage_initialized();
+  Stream<xpu> *s = ctx.get_stream<xpu>();
   // both inputs are zeros
-  if (!init_l && !init_r) return;
+  if (!init_l && !init_r) {
+    NDArray out = output;
+    FillZerosRspImpl(s, &out);
+    return;
+  }
   // Memory Estimation: This is (roughly) the number of result rows. We still
   // need to subtract the number of common rows
-  unsigned int num_rows_l = lhs.aux_shape(rowsparse::kIdx).Size();
-  unsigned int num_rows_r = rhs.aux_shape(rowsparse::kIdx).Size();
-  output.CheckAndAlloc({mshadow::Shape1(num_rows_l + num_rows_r)});
-  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  unsigned int num_rows_l = lhs.aux_shape(kIdx)[0];
+  unsigned int num_rows_r = rhs.aux_shape(kIdx)[0];
+  unsigned int num_rows_total = num_rows_l + num_rows_r;
+  auto row_len = output.shape().ProdShape(1, output.shape().ndim());
+  output.CheckAndAlloc({Shape1(num_rows_total)});
+  CHECK_GT(row_len, 0);
   MSHADOW_TYPE_SWITCH(output.dtype(), DType, {
-    MSHADOW_TYPE_SWITCH(lhs.aux_type(rowsparse::kIdx), IType, {
+    MSHADOW_TYPE_SWITCH(lhs.aux_type(kIdx), IType, {
       // Indices
-      auto indices_l = lhs.aux_data(rowsparse::kIdx).FlatTo1D<xpu, IType>(s);
-      auto indices_r = rhs.aux_data(rowsparse::kIdx).FlatTo1D<xpu, IType>(s);
-      auto indices_out = output.aux_data(rowsparse::kIdx).FlatTo1D<xpu, IType>(s);
+      auto indices_l = lhs.aux_data(kIdx).dptr<IType>();
+      auto indices_r = rhs.aux_data(kIdx).dptr<IType>();
+      auto indices_out = output.aux_data(kIdx).dptr<IType>();
       // Data
-      auto data_l = lhs.data().FlatTo2D<xpu, DType>(s);
-      auto data_r = rhs.data().FlatTo2D<xpu, DType>(s);
-      auto out = output.data().FlatTo2D<xpu, DType>(s);
+      auto data_l = lhs.data().reshape(Shape2(num_rows_l, row_len)).FlatTo2D<xpu, DType>(s);
+      auto data_r = rhs.data().reshape(Shape2(num_rows_r, row_len)).FlatTo2D<xpu, DType>(s);
+      auto out = output.data().reshape(Shape2(num_rows_total, row_len)).FlatTo2D<xpu, DType>(s);
 
       // TODO(haibin) A more appropriate way: Copy to output, then apply ops
       size_t iter_l = 0;
@@ -169,32 +179,32 @@ void BinaryComputeRspRsp(const nnvm::NodeAttrs& attrs,
         if (idx_l == idx_r) {
           // Same row
           indices_out[iter_out] = idx_l;
-          mshadow::Copy(out[iter_out], data_l[iter_l++], s);
+          Copy(out[iter_out], data_l[iter_l++], s);
           out[iter_out] += data_r[iter_r++];
           num_common_rows++;
         } else if (idx_l < idx_r) {
           // Left only
           indices_out[iter_out] = idx_l;
-          mshadow::Copy(out[iter_out], data_l[iter_l++], s);
+          Copy(out[iter_out], data_l[iter_l++], s);
         } else {
           // Right only
           indices_out[iter_out] = idx_r;
-          mshadow::Copy(out[iter_out], data_r[iter_r++], s);
+          Copy(out[iter_out], data_r[iter_r++], s);
         }
         iter_out++;
       }
       // Copying over the rest of the rows
       while (iter_l < num_rows_l) {
         indices_out[iter_out] = indices_l[iter_l];
-        mshadow::Copy(out[iter_out++], data_l[iter_l++], s);
+        Copy(out[iter_out++], data_l[iter_l++], s);
       }
       while (iter_r < num_rows_r) {
         indices_out[iter_out] = indices_r[iter_r];
-        mshadow::Copy(out[iter_out++], data_r[iter_r++], s);
+        Copy(out[iter_out++], data_r[iter_r++], s);
       }
-      auto new_shape = output.aux_shape(rowsparse::kIdx);
-      new_shape[0] -= num_common_rows;
-      output.set_aux_shape(rowsparse::kIdx, new_shape);
+      auto new_ashape = output.aux_shape(rowsparse::kIdx);
+      new_ashape[0] -= num_common_rows;
+      output.set_aux_shape(rowsparse::kIdx, new_ashape);
     });
   });
 }
@@ -213,14 +223,14 @@ void BinaryComputeEx(const nnvm::NodeAttrs& attrs,
   if (typeid(OP) == typeid(mshadow::op::plus)) {
     // If any input is dense, fallback to FCompute
     // TODO(haibin) implement dns + rsp in a separate kernel
-    if (mxnet::common::ContainsDefaultStorage(inputs)) {
+    if (common::ContainsDefaultStorage(inputs)) {
       FCompExFallback<xpu>(attrs, ctx, inputs, req, outputs,
                            BinaryCompute<xpu, OP>, "BinaryCompute");
       return;
     }
     CHECK_EQ(inputs[0].storage_type(), kRowSparseStorage) << "Sparse type not supported yet";
     CHECK_EQ(inputs[1].storage_type(), kRowSparseStorage) << "Sparse type not supported yet";
-    BinaryComputeRspRsp<xpu, OP>(attrs, ctx, inputs, req, outputs);
+    BinaryComputeRspRspImpl<xpu, OP>(attrs, ctx, inputs, req, outputs);
     return;
   } else {
     LOG(FATAL) << "Not implemented";

--- a/src/operator/tensor/elemwise_binary_op.h
+++ b/src/operator/tensor/elemwise_binary_op.h
@@ -164,9 +164,9 @@ void BinaryComputeRspRspImpl(const nnvm::NodeAttrs& attrs,
       auto indices_r = rhs.aux_data(kIdx).dptr<IType>();
       auto indices_out = output.aux_data(kIdx).dptr<IType>();
       // Data
-      auto data_l = lhs.data().reshape(Shape2(num_rows_l, row_len)).FlatTo2D<xpu, DType>(s);
-      auto data_r = rhs.data().reshape(Shape2(num_rows_r, row_len)).FlatTo2D<xpu, DType>(s);
-      auto out = output.data().reshape(Shape2(num_rows_total, row_len)).FlatTo2D<xpu, DType>(s);
+      auto data_l = lhs.data().get_with_shape<cpu, 2, DType>(Shape2(num_rows_l, row_len), s);
+      auto data_r = rhs.data().get_with_shape<cpu, 2, DType>(Shape2(num_rows_r, row_len), s);
+      auto out = output.data().get_with_shape<cpu, 2, DType>(Shape2(num_rows_total, row_len), s);
 
       // TODO(haibin) A more appropriate way: Copy to output, then apply ops
       size_t iter_l = 0;
@@ -203,6 +203,7 @@ void BinaryComputeRspRspImpl(const nnvm::NodeAttrs& attrs,
         Copy(out[iter_out++], data_r[iter_r++], s);
       }
       auto new_ashape = output.aux_shape(rowsparse::kIdx);
+      CHECK_GT(new_ashape[0], num_common_rows);
       new_ashape[0] -= num_common_rows;
       output.set_aux_shape(rowsparse::kIdx, new_ashape);
     });

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -157,7 +157,6 @@ void FillZerosRspImpl(mshadow::Stream<xpu> *s, NDArray *dst) {
   auto storage_shape = dst->storage_shape();
   storage_shape[0] = 0;
   dst->set_aux_shape(rowsparse::kIdx, TShape(mshadow::Shape1(0)));
-  dst->set_storage_shape(storage_shape);
 }
 
 // Fill a CSR NDArray with zeros by updating the aux shape.
@@ -168,7 +167,6 @@ void FillZerosCsrImpl(mshadow::Stream<xpu> *s, NDArray *dst) {
   TShape new_shape(mshadow::Shape1(0));
   dst->set_aux_shape(csr::kIndPtr, new_shape);
   dst->set_aux_shape(csr::kIdx, new_shape);
-  dst->set_storage_shape(new_shape);
 }
 
 // This operator never needs to fall back, since there's no input NDArray

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -174,10 +174,10 @@ void FillZerosCsrImpl(mshadow::Stream<xpu> *s, NDArray *dst) {
 // This operator never needs to fall back, since there's no input NDArray
 template<typename xpu>
 void FillComputeZerosEx(const nnvm::NodeAttrs& attrs,
-                 const OpContext& ctx,
-                 const std::vector<NDArray>& inputs,
-                 const std::vector<OpReqType>& req,
-                 const std::vector<NDArray>& outputs) {
+                        const OpContext& ctx,
+                        const std::vector<NDArray>& inputs,
+                        const std::vector<OpReqType>& req,
+                        const std::vector<NDArray>& outputs) {
   using namespace mshadow;
   using namespace mshadow::expr;
   Stream<xpu> *s = ctx.get_stream<xpu>();

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -61,8 +61,7 @@ def test_sparse_nd_elementwise_fallback():
 
 
 def test_sparse_nd_copy():
-    def check_sparse_nd_copy(from_stype, to_stype):
-        shape = rand_shape_2d()
+    def check_sparse_nd_copy(from_stype, to_stype, shape):
         from_nd = rand_ndarray(shape, from_stype)
         # copy to ctx
         to_ctx = from_nd.copyto(default_context())
@@ -72,21 +71,14 @@ def test_sparse_nd_copy():
         assert np.sum(np.abs(from_nd.asnumpy() != to_ctx.asnumpy())) == 0.0
         assert np.sum(np.abs(from_nd.asnumpy() != to_nd.asnumpy())) == 0.0
 
-    check_sparse_nd_copy('row_sparse', 'row_sparse')
-    check_sparse_nd_copy('row_sparse', 'default')
-    check_sparse_nd_copy('default', 'row_sparse')
-    check_sparse_nd_copy('default', 'csr')
-
-
-def check_sparse_nd_prop_rsp():
-    storage_type = 'row_sparse'
     shape = rand_shape_2d()
-    nd, (v, idx) = rand_sparse_ndarray(shape, storage_type)
-    assert(nd._num_aux == 1)
-    assert(nd.indices.dtype == np.int64)
-    assert(nd.stype == 'row_sparse')
-    assert_almost_equal(nd.indices.asnumpy(), idx)
-
+    shape_3d = rand_shape_3d()
+    check_sparse_nd_copy('row_sparse', 'row_sparse', shape)
+    check_sparse_nd_copy('row_sparse', 'default', shape)
+    check_sparse_nd_copy('default', 'row_sparse', shape)
+    check_sparse_nd_copy('default', 'csr', shape)
+    check_sparse_nd_copy('row_sparse', 'row_sparse', shape_3d)
+    check_sparse_nd_copy('default', 'row_sparse', shape_3d)
 
 def test_sparse_nd_basic():
     def check_rsp_creation(values, indices, shape):
@@ -103,6 +95,16 @@ def test_sparse_nd_basic():
         assert_almost_equal(csr.indices.asnumpy(), indices)
         assert_almost_equal(csr.data.asnumpy(), values)
 
+    def check_sparse_nd_rsp_aux():
+        storage_type = 'row_sparse'
+        shape = rand_shape_2d()
+        nd, (v, idx) = rand_sparse_ndarray(shape, storage_type)
+        assert(nd._num_aux == 1)
+        assert(nd.indices.dtype == np.int64)
+        assert(nd.stype == 'row_sparse')
+        assert_almost_equal(nd.indices.asnumpy(), idx)
+        assert_almost_equal(nd.data.asnumpy(), v)
+
     shape = (4,2)
     values = np.random.rand(2,2)
     indices = np.array([1,3], dtype='int64')
@@ -117,7 +119,7 @@ def test_sparse_nd_basic():
     check_rsp_creation(values, indices, shape)
 
     check_csr_creation(shape)
-    check_sparse_nd_prop_rsp()
+    check_sparse_nd_rsp_aux()
 
 
 def test_sparse_nd_setitem():

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -24,12 +24,13 @@ def check_elemwise_add_ex(lhs_stype, rhs_stype, shape, lhs_grad_stype=None, rhs_
 
 
 def test_elemwise_add_ex():
-    shape = rand_shape_2d()
-    check_elemwise_add_ex('default', 'default', shape)
-    check_elemwise_add_ex('default', 'row_sparse', shape)
-    check_elemwise_add_ex('row_sparse', 'default', shape)
-    check_elemwise_add_ex('row_sparse', 'row_sparse', shape,
-                          lhs_grad_stype='row_sparse', rhs_grad_stype='row_sparse')
+    shapes = [rand_shape_2d(), rand_shape_3d()]
+    for shape in shapes:
+        check_elemwise_add_ex('default', 'default', shape)
+        check_elemwise_add_ex('default', 'row_sparse', shape)
+        check_elemwise_add_ex('row_sparse', 'default', shape)
+        check_elemwise_add_ex('row_sparse', 'row_sparse', shape,
+                              lhs_grad_stype='row_sparse', rhs_grad_stype='row_sparse')
 
 
 # TODO(haibin) randomize this test

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -160,8 +160,7 @@ def test_sparse_slice():
 
 
 def test_sparse_retain():
-    for _ in range(10):
-        shape = rand_shape_2d()
+    def check_sparse_retain(shape):
         num_rows = shape[0]
         rsp, _ = rand_sparse_ndarray(shape=shape, stype='row_sparse', density=0.5)
         length = np.random.randint(1, num_rows + 1)
@@ -180,6 +179,10 @@ def test_sparse_retain():
         idx = mx.symbol.Variable('indices')
         sym = mx.sym.sparse_retain(data=data, indices=idx)
         check_numeric_gradient(sym, [rsp, indices], grad_nodes=['data'], grad_stype_dict={'data': 'row_sparse'})
+    shape = rand_shape_2d()
+    shape_3d = rand_shape_3d()
+    check_sparse_retain(shape)
+    check_sparse_retain(shape_3d)
 
 def test_sparse_nd_zeros():
     def check_sparse_nd_zeros(stype, shape):


### PR DESCRIPTION
- overhauled existing sparse operators with rowsparse tensor. Added checks for the ones doesn't support kdim rowsparse tensor. Modified `elemwise_add`, `sparse_retain` and `cast_storage` to support dim rowsparse tensor.
- removed `set_storage_shape` interface from NDArray. It is now set automatically every time aux_shape(kIdx) is set. 
@stefanhenneking @reminisce @cjolivier01 @piiswrong 