### PR TITLE
Improve sparse ndarray error message

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -38,6 +38,21 @@ class MXNetError(Exception):
     """Error that will be throwed by all mxnet functions."""
     pass
 
+class NotSupportedForSparseNDArray(MXNetError):
+    def __init__(self, function, alias, *args):
+        super(NotSupportedForSparseNDArray, self).__init__()
+        self.function = function.__name__
+        self.alias = alias
+        self.args = [str(type(a)) for a in args]
+    def __str__(self):
+        msg = 'Function {}'.format(self.function)
+        if self.alias:
+            msg += ' (namely operator "{}")'.format(self.alias)
+        if self.args:
+            msg += ' with arguments ({})'.format(', '.join(self.args))
+        msg += ' is not supported for SparseNDArray and only available in NDArray.'
+        return msg
+
 def _load_lib():
     """Load libary by searching possible path."""
     lib_path = libinfo.find_lib_path()

--- a/python/mxnet/ndarray/sparse_ndarray.py
+++ b/python/mxnet/ndarray/sparse_ndarray.py
@@ -15,6 +15,7 @@ import sys as _sys
 
 # import operator
 import numpy as np
+from ..base import NotSupportedForSparseNDArray
 from ..base import _LIB, numeric_types
 from ..base import c_array, mx_real_t
 from ..base import mx_uint, NDArrayHandle, check_call
@@ -179,9 +180,9 @@ class SparseNDArray(NDArray):
         """
         stype = self.stype
         if stype != 'csr':
-            raise Exception("__getitem__ for " + str(stype) + " not implemented yet")
+            raise Exception("__getitem__ for " + str(stype) + " is not implemented yet")
         if isinstance(key, int):
-            raise Exception("Not implemented yet")
+            raise Exception("__getitem__ with int key is not implemented yet")
         if isinstance(key, py_slice):
             if key.step is not None:
                 raise ValueError('NDArray only supports continuous slicing on axis 0')
@@ -198,13 +199,13 @@ class SparseNDArray(NDArray):
         raise Exception('Not implemented for SparseND yet!')
 
     def _at(self, idx):
-        raise Exception('at operator for SparseND is not supported.')
+        raise NotSupportedForSparseNDArray(self._at, '[idx]', idx)
+
+    def _slice(self, start, stop):
+        raise NotSupportedForSparseNDArray(self._slice, None, start, stop)
 
     def reshape(self, shape):
-        raise Exception('Not implemented for SparseND yet!')
-
-    def broadcast_to(self, shape):
-        raise Exception('Not implemented for SparseND yet!')
+        raise NotSupportedForSparseNDArray(self.reshape, None, shape)
 
     def _aux_type(self, i):
         """Data-type of the array’s ith aux data.
@@ -235,11 +236,6 @@ class SparseNDArray(NDArray):
         ''' The number of aux data used to help store the sparse ndarray.
         '''
         return len(_STORAGE_AUX_TYPES[self.stype])
-
-    @property
-    # pylint: disable= invalid-name, undefined-variable
-    def T(self):
-        raise Exception('Transpose is not supported for SparseNDArray.')
 
     @property
     def _aux_types(self):

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -321,6 +321,38 @@ def test_sparse_nd_negate():
         # we compute (-arr)
         assert_almost_equal(npy, arr.asnumpy())
 
+def test_sparse_nd_broadcast():
+    sample_num = 1000
+    def test_broadcast_to(stype):
+        for i in range(sample_num):
+            ndim = 2
+            target_shape = np.random.randint(1, 11, size=ndim)
+            shape = target_shape.copy()
+            axis_flags = np.random.randint(0, 2, size=ndim)
+            axes = []
+            for (axis, flag) in enumerate(axis_flags):
+                if flag:
+                    shape[axis] = 1
+            dat = np.random.rand(*shape) - 0.5
+            numpy_ret = dat
+            ndarray = mx.nd.cast_storage(mx.nd.array(dat), stype=stype)
+            ndarray_ret = ndarray.broadcast_to(shape=target_shape)
+            if type(ndarray_ret) is mx.ndarray.NDArray:
+                ndarray_ret = ndarray_ret.asnumpy()
+            assert (ndarray_ret.shape == target_shape).all()
+            err = np.square(ndarray_ret - numpy_ret).mean()
+            assert err < 1E-8
+    stypes = ['csr', 'row_sparse']
+    for stype in stypes:
+        test_broadcast_to(stype)
+
+
+def test_sparse_nd_transpose():
+    npy = np.random.uniform(-10, 10, rand_shape_2d())
+    stypes = ['csr', 'row_sparse']
+    for stype in stypes:
+        nd = mx.nd.cast_storage(mx.nd.array(npy), stype=stype)
+        assert_almost_equal(npy.T, (nd.T).asnumpy())
 
 def test_sparse_nd_output_fallback():
     shape = (10, 10)
@@ -337,7 +369,7 @@ def test_sparse_nd_astype():
         assert(y.dtype == np.int32), y.dtype
 
 
-def test_sparse_ndarray_pickle():
+def test_sparse_nd_pickle():
     np.random.seed(0)
     repeat = 10
     dim0 = 40
@@ -357,7 +389,7 @@ def test_sparse_ndarray_pickle():
                 assert same(a.asnumpy(), b.asnumpy())
 
 
-def test_sparse_ndarray_save_load():
+def test_sparse_nd_save_load():
     np.random.seed(0)
     repeat = 1
     stypes = ['default', 'row_sparse', 'csr']
@@ -389,6 +421,18 @@ def test_sparse_ndarray_save_load():
             assert same(x.asnumpy(), y.asnumpy())
     os.remove(fname)
 
+def test_sparse_nd_unsupported():
+    nd = mx.nd.zeros((2,2), stype='row_sparse')
+    fn_slice = lambda x: x._slice(None, None)
+    fn_at = lambda x: x._at(None)
+    fn_reshape = lambda x: x.reshape(None)
+    fns = [fn_slice, fn_at, fn_reshape]
+    for fn in fns:
+        try:
+            fn(nd)
+            assert(False)
+        except:
+            pass
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -323,6 +323,7 @@ def test_sparse_nd_negate():
 
 def test_sparse_nd_broadcast():
     sample_num = 1000
+    # TODO(haibin) test with more than 2 dimensions
     def test_broadcast_to(stype):
         for i in range(sample_num):
             ndim = 2


### PR DESCRIPTION
- improve sparse ndarray error message
- throw exception on shared_memory functions (_at, _slice, reshape) inherited from NDArray
- add test for transpose and broadcast_to

@reminisce @cjolivier01 @stefanhenneking @piiswrong 