### PR TITLE
add set_ctx to gluon parameter/parameter dict

### DIFF
--- a/tests/python/unittest/test_nn.py
+++ b/tests/python/unittest/test_nn.py
@@ -12,6 +12,9 @@ def test_parameter():
     assert p.data(mx.cpu(1)).context == mx.cpu(1)
     assert p.data(mx.cpu(0)).shape == (10, 10)
     assert p.var().name == 'weight'
+    p.set_ctx(ctx=mx.cpu(0))
+    assert len(p.list_ctx()) == 1
+    assert mx.cpu(1) not in p.list_ctx()
 
 
 def test_paramdict():


### PR DESCRIPTION
this is for allowing moving the parameter data around contexts without loading from checkpoints or re-initializing. I found it useful in finetuning models when using part of the weights from a pretrained model.