### PR TITLE
Fix broken amalgamation by include missing symbol definition in the expansion list

### DIFF
--- a/amalgamation/amalgamation.py
+++ b/amalgamation/amalgamation.py
@@ -8,7 +8,8 @@ blacklist = [
     'kvstore_dist.h', 'mach/clock.h', 'mach/mach.h',
     'malloc.h', 'mkl.h', 'mkl_cblas.h', 'mkl_vsl.h', 'mkl_vsl_functions.h',
     'nvml.h', 'opencv2/opencv.hpp', 'sys/stat.h', 'sys/types.h', 'cuda.h', 'cuda_fp16.h',
-    'omp.h', 'execinfo.h', 'packet/sse-inl.h', 'emmintrin.h', 'thrust/device_vector.h'
+    'omp.h', 'execinfo.h', 'packet/sse-inl.h', 'emmintrin.h', 'thrust/device_vector.h', 
+    'cusolverDn.h'
     ]
 
 minimum = int(sys.argv[6]) if len(sys.argv) > 5 else 0

--- a/amalgamation/mxnet_predict0.cc
+++ b/amalgamation/mxnet_predict0.cc
@@ -26,6 +26,7 @@
 
 
 #include "src/ndarray/ndarray_function.cc"
+#include "src/ndarray/autograd.cc"
 #include "src/ndarray/ndarray.cc"
 
 #include "src/engine/engine.cc"


### PR DESCRIPTION
Fix for issue #7180 

Recent updates to the ndarray module introduced the autograd runtime whose declarations were expanded by the python amalgamation script, but left out the definition.  The result was an undefined symbol error when loading the shared library.

The fix for now is to include the definition file in the expansion list.